### PR TITLE
fixed sharedgroup unit test that did not use using. For now, You have to...

### DIFF
--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -23,9 +23,11 @@
 
 //using System.IO;
 
+using System;
 using NUnitLite.Runner;
 //using NUnit.Framework.Internal;
 using TightDbCSharp;
+using TightDbCSharpTest;
 
 namespace NUnitLite.Tests
 {
@@ -93,16 +95,72 @@ namespace NUnitLite.Tests
         ///             over all includes
         /// 
         /// </param>
+        /// 
+
+        public static void TdbTester(Action test)
+        {
+            try
+            {
+                Console.WriteLine("TDB Tester running "+test.Method.ToString());
+                test();
+            }
+            finally
+            {                
+            }
+        }
+
         public static void Main(string[] args)
         {
-            if (args!=null && args.Length != 0)
+            if (args != null && args.Length != 0)
             {
                 new TextUI().Execute(args);
             }
             else
-            {       
+            {
+                /*
                 Table.ShowVersionTest();
-                new TextUI().Execute(new [] {"-labels","-full","-wait"/* "-out:C:\\Files\\UnitTestDumpCS.txt"*/});
+                TdbTester(TableTests1.SubTableNoFields);
+                TdbTester(TableTests1.TableAddColumn);
+                TdbTester(TableTests1.TableAddColumnAndSpecTest);
+                TdbTester(TableTests1.TableAddColumnAndSpecTestSimple);
+                TdbTester(TableTests1.TableAddColumnTypeParameter);
+                TdbTester(TableTests1.TableAddColumnTypeParameterPath);
+                TdbTester(TableTests1.TableAddColumnTypes);
+                TdbTester(TableTests1.TableAddColumnWithData);
+                TdbTester(TableTests1.TableAddIntArray);
+                TdbTester(TableTests1.TableAddSubTableAsNull);
+                TdbTester(TableTests1.TableAddSubTableEmptyArray);
+                TdbTester(TableTests1.TableAddSubTableHugeTable);
+                TdbTester(TableTests1.TableAddSubTablePlausiblePathExample);
+                TdbTester(TableTests1.TableAddSubTableStringArray);
+                TdbTester(TableTests1.TableAddSubTableUsingParameters);
+                TdbTester(TableTests1.TableAddSubTableUsingPath);
+                TdbTester(TableTests1.TableAggregate);
+                TdbTester(TableTests1.TableClearSubTable);
+                TdbTester(TableTests1.TableCloneLostFieldNameTest);
+                TdbTester(TableTests1.TableCloneTest);
+                TdbTester(TableTests1.TableCloneTest2);
+                TdbTester(TableTests1.TableCloneTest3);
+                TdbTester(TableTests1.TableCloneTest4);
+                TdbTester(TableTests1.TableCollectionInitializer);
+                TdbTester(TableTests1.TableDistinct);
+                TdbTester(TableTests1.TableDistinctBadType);
+                TdbTester(TableTests1.TableDistinctNoIndex);
+                TdbTester(TableTests1.TableFindAllBinaryBadType);
+                TdbTester(TableTests1.TableFindAllBinaryBadType2);
+                TdbTester(TableTests1.TableFindAllBinarySuccessful);
+                TdbTester(TableTests1.TableFindAllBoolBadType);
+                TdbTester(TableTests1.TableFindAllBoolBadType2);
+                TdbTester(TableTests1.TableFindAllBoolSuccessful);
+                TdbTester(TableTests1.TableFindAllDateBadType);
+                TdbTester(TableTests1.TableFindAllDateBadTypeString);
+                TdbTester(TableTests1.TableFindAllDateSuccessful);
+                TdbTester(TableTests1.TableFindAllDoubleBadType);
+                TdbTester(TableTests1.TableFindAllDoubleBadType2);
+                TdbTester(TableTests1.TableFindAllDoubleSuccessful);
+                TdbTester(TableTests1.TableFindAllFloatBadType);
+*/
+                new TextUI().Execute(new[] {/* "-test:TableFindAllFloatBadType", "-test:TableTests1.TableFindAllFloatBadType",*/ "-labels", "-full", "-wait"/* "-out:C:\\Files\\UnitTestDumpCS.txt"*/});
             }
             //Console.WriteLine("Tests finished, any key to close the application");
             //Console.ReadKey();

--- a/TightDbCSharp/Group.cs
+++ b/TightDbCSharp/Group.cs
@@ -127,7 +127,7 @@ namespace TightDbCSharp
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                //Console.WriteLine(e.Message);
                 Dispose();
                 throw;
             }

--- a/TightDbCSharp/Handled.cs
+++ b/TightDbCSharp/Handled.cs
@@ -43,8 +43,12 @@ namespace TightDbCSharp
             {
                 if (NotifyCppWhenDisposing)
                 {
-                    //   Console.WriteLine("Handle being released by calling cpp :{0}", ObjectIdentification());
+                    //string myId = ObjectIdentification();
+                  //  Console.WriteLine("Handle being released by calling cpp :{0}", myId);
                     ReleaseHandle();
+                  //  Console.WriteLine("Handle released successfully :{0}", myId);
+                    //Console.ReadKey();
+                  //  Console.WriteLine("Continuing...");
                 }
                 //                else
                 // {
@@ -71,7 +75,7 @@ namespace TightDbCSharp
         //store the pointer to the c++ class, and do neccessary housekeeping
         internal void SetHandle(IntPtr newHandle, bool shouldBeDisposed)
         {            
-//            Console.WriteLine("Handle being set to newhandle:{0}h shouldBeDisposed:{1} ",newHandle.ToString("X"),shouldBeDisposed);
+            //Console.WriteLine("Handle being set to newhandle:{0}h shouldBeDisposed:{1} ",newHandle.ToString("X"),shouldBeDisposed);
             if (HandleInUse)
             {
                 

--- a/TightDbCSharp/Table.cs
+++ b/TightDbCSharp/Table.cs
@@ -496,7 +496,10 @@ namespace TightDbCSharp
         /// </summary>
         protected override void ReleaseHandle()
         {
-            UnsafeNativeMethods.TableUnbind(this);            
+            //string tableid = ObjectIdentification();
+//            Console.WriteLine("unbinding: {0}",tableid);
+            UnsafeNativeMethods.TableUnbind(this);
+//            Console.WriteLine("Done unbinding: {0}", tableid);
         }
 
         internal override Spec GetSpec()
@@ -528,8 +531,8 @@ namespace TightDbCSharp
 
         internal override string ObjectIdentification()
         {
-            ValidateIsValid();
-            return string.Format(CultureInfo.InvariantCulture,"Table:" + Handle);
+            //ValidateIsValid(); OI could be called on an invalid (detached) table but that is okay as we don't call c++ in OI
+            return string.Format(CultureInfo.InvariantCulture,"Table:" + Handle.ToString("X"));
         }
 
         internal override DataType GetMixedTypeNoCheck(long columnIndex, long rowIndex)

--- a/TightDbCSharp/TableView.cs
+++ b/TightDbCSharp/TableView.cs
@@ -500,7 +500,7 @@ namespace TightDbCSharp
 
         internal override string ObjectIdentification()
         {
-            ValidateIsValid();
+           // ValidateIsValid();
             return String.Format(CultureInfo.InvariantCulture,"TableView:{0}", Handle);
         }
 

--- a/TightDbCSharpTest/TableTests.cs
+++ b/TightDbCSharpTest/TableTests.cs
@@ -903,16 +903,39 @@ Table Name  : column name is 123 then two non-ascii unicode chars then 678
         [Test]
         public static void TableFindAllFloatBadType()
         {
+                using (var t = new Table("Field".Float(), "IntField".Int()))
+                {
+                    const float match = 42;
+                    t.Add(match, 1);
+                    using (var tv = t.FindAllFloat(1, match)) //should throw
+                    {
+                        Assert.AreEqual(1, tv[0].GetLong(1));
+                    }
+                }
+            
+        }
+
+
+        /// <summary>
+        /// Test bad field specification, wrong type
+        /// </summary>
+        [ExpectedException("System.ArgumentException")]
+        [Test]
+        public static void TableFindAllFloatBadType2Error()
+        {
             using (var t = new Table("Field".Float(), "IntField".Int()))
             {
                 const float match = 42;
                 t.Add(match, 1);
-                using (var tv = t.FindAllFloat(1, match))//should throw
+                using (var tv = t.FindAllFloat("IntField", match))//should throw
                 {
-                    Assert.AreEqual(1, tv[0].GetLong(1));
+                    long myLong = tv[0].GetLong(1);
+                    
+                    Assert.AreEqual(1, myLong);
                 }
             }
         }
+
 
 
         /// <summary>
@@ -922,6 +945,8 @@ Table Name  : column name is 123 then two non-ascii unicode chars then 678
         [Test]
         public static void TableFindAllFloatBadType2()
         {
+          
+          
             using (var t = new Table("Field".Float(), "IntField".Int()))
             {
                 const float match = 42;
@@ -984,6 +1009,7 @@ Table Name  : column name is 123 then two non-ascii unicode chars then 678
         [Test]
         public static void TableFindAllDoubleBadType()
         {
+//            Console.ReadKey();
             using (var t = new Table("Field".Double(), "IntField".Int()))
             {
                 const double match = 42;
@@ -993,6 +1019,7 @@ Table Name  : column name is 123 then two non-ascii unicode chars then 678
                     Assert.AreEqual(1, tv[0].GetDouble(1));
                 }
             }
+//            Console.ReadKey();
         }
 
 
@@ -5307,6 +5334,7 @@ root:[ //1 rows   { //Start row 0
             //string actualres3;
             //string actualres4;
             //string actualres5;
+//            Console.ReadKey();
             string actualres;
 
             using (var t = new Table(
@@ -5391,6 +5419,7 @@ root:[ //1 rows   { //Start row 0
 ------------------------------------------------------
 ";
             TestHelper.Cmp(expectedres, actualres);
+//            Console.ReadKey();
         }
 
 


### PR DESCRIPTION
... use using, or else your wrapper object might get concurrently GC'ed and that might lead to fatal errors as neither C# binding or core supports multiple threads running in the same object. (for instance operations on a table could be ongoing while the GC concurrently deletes a subtable taken out from that table earlier). Also removed validatetable from ObjectIdentification as OI does not call core, and is used in situations where the table is in fact not attached.
