### PR TITLE
Fix renaming of IntegrationTests.IOS to IntegrationTests.XamarinIOS

### DIFF
--- a/realm/RealmNet.XamarinIOS/Properties/AssemblyInfo.cs
+++ b/realm/RealmNet.XamarinIOS/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using Foundation;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
-[assembly: InternalsVisibleTo("IntegrationTestsIOS")]
+[assembly: InternalsVisibleTo("IntegrationTestsXamarinIOS")]

--- a/realm/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/realm/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>IntegrationTests.XamarinIOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <AssemblyName>IntegrationTestsIOS</AssemblyName>
+    <AssemblyName>IntegrationTestsXamarinIOS</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/realm/doc/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/realm/doc/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -492,3 +492,13 @@ IntegrationTests.IOS
 
 Realm.sln
 - added IntegrationTests.XamarinIOS  
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+Fix renaming of IntegrationTests.IOS to IntegrationTests.XamarinIOS
+
+IntegrationTests.XamarinIOS.csproj
+- change assembly name from IntegrationTestsIOS to IntegrationTestsXamarinIOS
+
+RealmNet.XamarinIOS/Properties/AssemblyInfo.cs
+- change InternalsVisibleTo target to IntegrationTestsXamarinIOS


### PR DESCRIPTION
Very quick fix to the merge to master which was working but had wrong assembly name.

IntegrationTests.XamarinIOS.csproj
- change assembly name from IntegrationTestsIOS to IntegrationTestsXamarinIOS

RealmNet.XamarinIOS/Properties/AssemblyInfo.cs
- change InternalsVisibleTo target to IntegrationTestsXamarinIOS
