### PR TITLE
#67 Adding float and double support

### DIFF
--- a/RealmNet.Shared/RealmObject.cs
+++ b/RealmNet.Shared/RealmObject.cs
@@ -40,19 +40,29 @@ namespace RealmNet
                 } while (MarshalHelpers.StrBufferOverflow(buffer, currentBufferSizeChars, bufferSizeNeededChars));
                 return (T)Convert.ChangeType(MarshalHelpers.StrBufToStr(buffer, (int)bufferSizeNeededChars), typeof(T));
             }
-            else if (typeof(T) == typeof(bool))
+            if (typeof(T) == typeof(bool))
             {
                 var value = MarshalHelpers.IntPtrToBool( NativeTable.get_bool(tableHandle, columnIndex, (IntPtr)rowIndex) );
                 return (T)Convert.ChangeType(value, typeof(T));
             }
-            else if (typeof(T) == typeof(int))  // System.Int32 regardless of bitness
+            if (typeof(T) == typeof(int))  // System.Int32 regardless of bitness
             {
                 var value = NativeTable.get_int64(tableHandle, columnIndex, (IntPtr)rowIndex);
                 return (T)Convert.ChangeType(value, typeof(T));
             }
-            else if (typeof(T) == typeof(Int64)) 
+            if (typeof(T) == typeof(Int64)) 
             {
                 var value = NativeTable.get_int64(tableHandle, columnIndex, (IntPtr)rowIndex);
+                return (T)Convert.ChangeType(value, typeof(T));
+            }
+            if (typeof(T) == typeof(float)) 
+            {
+                var value = NativeTable.get_float(tableHandle, columnIndex, (IntPtr)rowIndex);
+                return (T)Convert.ChangeType(value, typeof(T));
+            }
+            if (typeof(T) == typeof(double)) 
+            {
+                var value = NativeTable.get_double(tableHandle, columnIndex, (IntPtr)rowIndex);
                 return (T)Convert.ChangeType(value, typeof(T));
             }
             else
@@ -90,6 +100,16 @@ namespace RealmNet
             {
                 Int64 marshalledValue = Convert.ToInt64(value);
                 NativeTable.set_int64(tableHandle, columnIndex, (IntPtr)rowIndex, marshalledValue);
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                float marshalledValue = Convert.ToSingle(value);
+                NativeTable.set_float(tableHandle, columnIndex, (IntPtr)rowIndex, marshalledValue);
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                double marshalledValue = Convert.ToDouble(value);
+                NativeTable.set_double(tableHandle, columnIndex, (IntPtr)rowIndex, marshalledValue);
             }
             else
                 throw new Exception ("Unsupported type " + typeof(T).Name);

--- a/Tests/IntegrationTests.Shared/IntegrationTests.cs
+++ b/Tests/IntegrationTests.Shared/IntegrationTests.cs
@@ -61,6 +61,9 @@ namespace IntegrationTests
                 p1.LastName = "Smith";
                 p1.IsInteresting = true;
                 p1.Email = "john@smith.com";
+                p1.Score = -0.9907f;
+                p1.Latitude = 51.508530;
+                p1.Longitude = 0.076132;
                 transaction.Commit();
             }
             Debug.WriteLine("p1 is named " + p1.FullName);
@@ -71,6 +74,9 @@ namespace IntegrationTests
                 p2.FullName = "John Doe";
                 p2.IsInteresting = false;
                 p2.Email = "john@deo.com";
+                p2.Score = 100;
+                p2.Latitude = 40.7637286;
+                p2.Longitude = -73.9748113;
                 transaction.Commit();
             }
             Debug.WriteLine("p2 is named " + p2.FullName);
@@ -81,6 +87,9 @@ namespace IntegrationTests
                 p3.FullName = "Peter Jameson";
                 p3.Email = "peter@jameson.com";
                 p3.IsInteresting = true;
+                p3.Score = 42.42f;
+                p3.Latitude = 37.7798657;
+                p3.Longitude = -122.394179;
                 transaction.Commit();
             }
 
@@ -127,16 +136,23 @@ namespace IntegrationTests
                 // Act
                 p.FirstName = "John";
                 p.IsInteresting = true;
+                p.Score = -0.9907f;
+                p.Latitude = 51.508530;
+                p.Longitude = 0.076132;
                 transaction.Commit();
             }
             var allPeople = _realm.All<Person>().ToList();
             Person p2 = allPeople[0];  // pull it back out of the database otherwise can't tell if just a dumb property
             var receivedFirstName = p2.FirstName;
             var receivedIsInteresting = p2.IsInteresting;
+            var receivedScore = p2.Score;
+            var receivedLatitude = p2.Latitude;
 
             // Assert
             Assert.That(receivedFirstName, Is.EqualTo("John"));
             Assert.That(receivedIsInteresting, Is.True);
+            Assert.That(receivedScore, Is.EqualTo(-0.9907f));
+            Assert.That(receivedLatitude, Is.EqualTo(51.508530));
         }
 
         [Test]

--- a/Tests/IntegrationTests.Shared/Person.cs
+++ b/Tests/IntegrationTests.Shared/Person.cs
@@ -8,6 +8,9 @@ namespace IntegrationTests
         // Automatically implemented (overridden) properties
         public string FirstName { get; set; }
         public string LastName { get; set; }
+        public float Score { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
 
         // Property that's not persisted in Realm
         [Ignore]

--- a/doc/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/doc/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -724,3 +724,34 @@ WindowsDLLWrapperDecls.h
 - renamed realm_export_decls.h
 - REALM_CORE_WRAPPER_API renamed REALM_EXPORT
 
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+Fixed integration tests to actually test if stored and fix IOS test
+
+IntegrationTests.cs
+- SetAndGetPropertyTest get object back from the store
+
+
+IntegrationTests.XamarinIOS.csproj
+- added packages.config
+- added FodyWeavers.xml
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#67 Adding float and double support
+
+IntegrationTests.shared/Person.cs
+- added Score, Latitude and Longitude
+
+IntegrationTests.cs
+- SimpleTest - added setters for Score, Latitude and Longitude
+- SetAndGetPropertyTest added Score and Latitude tests
+
+
+RealmObject.cs
+- SetValue<T>, GetValue<T> - added cases for single and double
+
+NativeTable.cs
+- replaced dummy set/get_float/double with DLL Import calls
+
+table_cs.cpp
+- added table_set_float/double table_get_float/double

--- a/wrappers/table_cs.cpp
+++ b/wrappers/table_cs.cpp
@@ -64,6 +64,20 @@ REALM_EXPORT int64_t table_get_int64(const Table* table_ptr, size_t column_ndx, 
     });
 }
 
+REALM_EXPORT float table_get_float(const Table* table_ptr, size_t column_ndx, size_t row_ndx)
+{
+    return handle_errors([&]() {
+        return table_ptr->get_float(column_ndx, row_ndx);
+    });
+}
+
+REALM_EXPORT double table_get_double(const Table* table_ptr, size_t column_ndx, size_t row_ndx)
+{
+    return handle_errors([&]() {
+        return table_ptr->get_double(column_ndx, row_ndx);
+    });
+}
+
 REALM_EXPORT size_t table_get_string(const Table* table_ptr, size_t column_ndx, size_t row_ndx, uint16_t * datatochsarp, size_t bufsize)
 {
     return handle_errors([&]() {
@@ -83,6 +97,20 @@ REALM_EXPORT void table_set_int64(Table* table_ptr, size_t column_ndx, size_t ro
 {
     return handle_errors([&]() {
         table_ptr->set_int(column_ndx, row_ndx, value);
+    });
+}
+
+REALM_EXPORT void table_set_float(Table* table_ptr, size_t column_ndx, size_t row_ndx, float value)
+{
+    return handle_errors([&]() {
+        table_ptr->set_float(column_ndx, row_ndx, value);
+    });
+}
+
+REALM_EXPORT void table_set_double(Table* table_ptr, size_t column_ndx, size_t row_ndx, double value)
+{
+    return handle_errors([&]() {
+        table_ptr->set_double(column_ndx, row_ndx, value);
     });
 }
 


### PR DESCRIPTION
IntegrationTests.shared/Person.cs
- added Score, Latitude and Longitude

IntegrationTests.cs
- SimpleTest - added setters for Score, Latitude and Longitude
- SetAndGetPropertyTest added Score and Latitude tests

RealmObject.cs
- SetValue<T>, GetValue<T> - added cases for single and double

NativeTable.cs
- replaced dummy set/get_float/double with DLL Import calls

table_cs.cpp
- added table_set_float/double table_get_float/double
