### PR TITLE
Rename attributes

### DIFF
--- a/RealmNet.Shared/Attributes.cs
+++ b/RealmNet.Shared/Attributes.cs
@@ -14,7 +14,7 @@ namespace RealmNet
     {
     }
 
-    public class IgnoreAttribute : Attribute
+    public class IgnoredAttribute : Attribute
     {
     }
 

--- a/RealmNet.Shared/Realm.cs
+++ b/RealmNet.Shared/Realm.cs
@@ -70,7 +70,7 @@ namespace RealmNet
             var propertiesToMap = objectClass.GetProperties(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.NonPublic | BindingFlags.Public)
                 .Where(p =>
                 {
-                    return p.GetCustomAttributes(false).All(a => a.GetType() != typeof (IgnoreAttribute));
+                    return p.GetCustomAttributes(false).All(a => a.GetType() != typeof (IgnoredAttribute));
                 });
 
             foreach (var p in propertiesToMap)

--- a/Tests/IntegrationTests.Shared/Person.cs
+++ b/Tests/IntegrationTests.Shared/Person.cs
@@ -17,11 +17,11 @@ namespace IntegrationTests
         public double Longitude { get; set; }
 
         // Property that's not persisted in Realm
-        [Ignore]
+        [Ignored]
         public bool IsOnline { get; set; }
 
         // Composite property
-        [Ignore]
+        [Ignored]
         public string FullName
         {
             get { return FirstName + " " + LastName; }
@@ -39,7 +39,7 @@ namespace IntegrationTests
         private string Email_ { get; set; }
 
         // Wrapped version of previous property
-        [Ignore]
+        [Ignored]
         public string Email
         {
             get { return Email_; }

--- a/Tests/Playground.Win32/Person.cs
+++ b/Tests/Playground.Win32/Person.cs
@@ -14,11 +14,11 @@ namespace Playground.Win32
         public string LastName { get; set; }
 
         // Property that's not persisted in Realm
-        [Ignore]
+        [Ignored]
         public bool IsOnline { get; set; }
 
         // Composite property
-        [Ignore]
+        [Ignored]
         public string FullName
         {
             get { return FirstName + " " + LastName; }
@@ -36,7 +36,7 @@ namespace Playground.Win32
         private string Email_ { get; set; }
 
         // Wrapped version of previous property
-        [Ignore]
+        [Ignored]
         public string Email
         {
             get { return Email_; }

--- a/Tests/WeaverTests/AssemblyToProcess/Person.cs
+++ b/Tests/WeaverTests/AssemblyToProcess/Person.cs
@@ -20,11 +20,11 @@ namespace AssemblyToProcess
         public string LastName { get; set; }
 
         // Ignored property
-        [Ignore]
+        [Ignored]
         public bool IsOnline { get; set; }
 
         // Composite property
-        [Ignore]
+        [Ignored]
         public string FullName
         {
             get { return FirstName + " " + LastName; }
@@ -42,7 +42,7 @@ namespace AssemblyToProcess
         private string Email_ { get; set; }
         
         // Wrapped version of previous property
-        [Ignore]
+        [Ignored]
         public string Email 
         { 
             get { return Email_; } 
@@ -53,7 +53,7 @@ namespace AssemblyToProcess
         }
 
         // Manually implemented property
-        [Ignore]
+        [Ignored]
         public string Address
         {
             get { return GetValue<string>("Address"); }


### PR DESCRIPTION
This renames the following attributes:
- PrimaryKey -> Identifier
- Ignore -> Ignored

Indexed was already named so, which is in line with what the Java team is headed for, so that one remains unchanged.
