### PR TITLE
#238 Removing objects should throw RealmOutsideTransactionExcepton

### DIFF
--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -262,7 +262,7 @@ namespace Realms
         public void Remove(RealmObject obj)
         {
             if (!IsInTransaction)
-                throw new Exception("Cannot remove Realm object outside write transactions");
+                throw new RealmOutsideTransactionException("Cannot remove Realm object outside write transactions");
 
             var tableHandle = _tableHandles[obj.GetType()];
             NativeTable.remove_row(tableHandle, (RowHandle)obj.RowHandle);

--- a/Tests/IntegrationTests.Shared/IntegrationTests.cs
+++ b/Tests/IntegrationTests.Shared/IntegrationTests.cs
@@ -280,7 +280,7 @@ namespace IntegrationTests
 
 
         [Test]
-        public void RemoveTest()
+        public void RemoveSucceedsTest()
         {
             // Arrange
             Person p1, p2, p3;
@@ -308,6 +308,22 @@ namespace IntegrationTests
             var allPeople = _realm.All<Person>().ToList();
 
             Assert.That(allPeople, Is.EquivalentTo(new List<Person> { p1, p3 }));
+        }
+
+
+        [Test]
+        public void RemoveOutsideTransactionShouldFail()
+        {
+            // Arrange
+            Person p;
+            using (var transaction = _realm.BeginWrite())
+            {
+                p = _realm.CreateObject<Person>();
+                transaction.Commit();
+            }
+
+            // Act and assert
+            Assert.Throws<RealmOutsideTransactionException>(() => _realm.Remove(p) );
         }
 
 

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1098,3 +1098,15 @@ All projects with RealmNet in them renamed Realmblah including Fody
 README.md
 - changed repo name back from realm-.net to realm-dotnet
 
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#238 Removing objects should throw RealmOutsideTransactionExcepton
+
+IntegrationTests.cs
+- RemoveTest renamed RemoveSucceedsTest
+- RemoveOutsideTransactionShouldFail added
+
+Realm.cs
+- Remove change to throw RealmOutsideTransactionException
+


### PR DESCRIPTION
IntegrationTests.cs
- RemoveTest renamed RemoveSucceedsTest
- RemoveOutsideTransactionShouldFail added

Realm.cs
- Remove change to throw RealmOutsideTransactionException
