### PR TITLE
#286 Fix Makefile to build iosdbg

### DIFF
--- a/Tests/IntegrationTests.Shared/RelationshipTests.cs
+++ b/Tests/IntegrationTests.Shared/RelationshipTests.cs
@@ -22,8 +22,6 @@ namespace IntegrationTests.Shared
             public string Name { get; set; }
             public string Color { get; set; } = "Brown";
             public bool Vaccinated { get; set; } = true;
-            // here to create Fody error feedback until we support in https://github.com/realm/realm-dotnet/issues/36
-            // public DateTime born { get; set; }
             //Owner Owner { get; set; }  will uncomment when verifying that we have back-links from ToMany relationships
         }
 

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1168,4 +1168,11 @@ Realm.cs
 - Close added
 - Dispose filled out to invoke Close
 
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#286 Fix Makefile
+Makefile
+- revert changes that built using the core-debug target as that doesn't work
+  this means the iosdbg works but is not using a debug version of core
   
+RelationshipTests.cs
+- delete a couple of commented out lines in sample that no longer apply

--- a/wrappers/Makefile
+++ b/wrappers/Makefile
@@ -48,6 +48,9 @@ build/Release-iphoneos/libwrappers.a: core $(SRCS)
 build/Release-iphonesimulator/libwrappers.a: core $(SRCS)
 	xcodebuild -sdk iphonesimulator -configuration Release -target "wrappers"
 
+build:
+	mkdir build
+
 build/Release-ios-universal: | build
 	mkdir -p build/Release-ios-universal
 
@@ -55,16 +58,16 @@ build/Release-ios-universal/libwrappers.a: build/Release-iphoneos/libwrappers.a 
 	lipo -create -output "build/Release-ios-universal/libwrappers.a" "build/Release-iphoneos/libwrappers.a" "build/Release-iphonesimulator/libwrappers.a"
 
 build/Debug-iphoneos/libwrappers.a: core $(SRCS)
-	xcodebuild -sdk iphoneos -configuration Debug -target "wrappers-core-debug"
+	xcodebuild -sdk iphoneos -configuration Debug -target "wrappers"
 
 build/Debug-iphonesimulator/libwrappers.a: core $(SRCS)
-	xcodebuild -sdk iphonesimulator -configuration Debug -target "wrappers-core-debug"
+	xcodebuild -sdk iphonesimulator -configuration Debug -target "wrappers"
 
 build/Debug-ios-universal: | build
 	mkdir -p build/Debug-ios-universal
 
 build/Debug-ios-universal/libwrappers.a: build/Debug-iphoneos/libwrappers.a build/Debug-iphonesimulator/libwrappers.a | build/Debug-ios-universal
-	lipo -create -output "build/Debug-ios-universal/libwrappers.a" "build/Debug-iphoneos/libwrappers-core-debug.a" "build/Debug-iphonesimulator/libwrappers-core-debug.a"
+	lipo -create -output "build/Debug-ios-universal/libwrappers.a" "build/Debug-iphoneos/libwrappers.a" "build/Debug-iphonesimulator/libwrappers.a"
 
 .PHONY: osx ios iosdbg
 


### PR DESCRIPTION
Makefile
- revert changes that built using the core-debug target as that doesn't work
  this means the iosdbg works but is not using a debug version of core

RelationshipTests.cs
- delete a couple of commented out lines in sample that no longer apply
