### PR TITLE
#328 Update to Core 0.95.6

### DIFF
--- a/wrappers/Makefile
+++ b/wrappers/Makefile
@@ -5,8 +5,8 @@ SRCS=$(wildcard src/*.cpp) $(OS_SRCS) $(ECH_SRCS)
 SDKROOT=$(shell xcrun --sdk iphoneos --show-sdk-path)
 CXX=$(shell xcrun --sdk iphoneos --find clang++)
 FLAGS=-Icore/include -Isrc/object-store -Isrc/object-store/impl -Isrc/object-store/impl/apple -std=c++14 -stdlib=libc++  
-CORE_APPLE_VER=0.95.1
-CORE_ANDROID_VER=0.95.1
+CORE_APPLE_VER=0.95.6
+CORE_ANDROID_VER=0.95.6
 
 help: ## Show this help.
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'

--- a/wrappers/wrappers.xcodeproj/project.pbxproj
+++ b/wrappers/wrappers.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 					"./src/object-store/impl",
 					"./src/object-store/impl/apple",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -450,6 +451,7 @@
 					"./src/object-store/impl",
 					"./src/object-store/impl/apple",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;


### PR DESCRIPTION
reapplied version bump in Makefile

wrappers.xcodeproj
- set deployment to IOS 7.1 to match test projects

Trivial PR just to ensure get OK on the IOS 7.1 deployment prior pulling that across to Master.
