### PR TITLE
Ad/feature/linq/single and first/#351

### DIFF
--- a/Realm.Shared/linq/RealmQuery.cs
+++ b/Realm.Shared/linq/RealmQuery.cs
@@ -41,7 +41,8 @@ namespace Realms
         /// <returns>An IEnumerator which will iterate through found Realm persistent objects.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            return new RealmQueryEnumerator<T>(_provider._realm, _provider.MakeVisitor<T>(), Expression);
+            var retType = typeof(T);
+            return new RealmQueryEnumerator<T>(_provider._realm, _provider.MakeVisitor(retType), Expression);
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Realm.Shared/linq/RealmQueryEnumerator.cs
+++ b/Realm.Shared/linq/RealmQueryEnumerator.cs
@@ -13,10 +13,11 @@ namespace Realms
     internal class RealmQueryEnumerator<T> : IEnumerator<T> 
     {
         private long _rowIndex = 0;
-        private RealmQueryVisitor<T> _enumerating;
+        private RealmQueryVisitor _enumerating;
         private Realm _realm;
+        private Type _retType = typeof(T);
 
-        internal RealmQueryEnumerator(Realm realm, RealmQueryVisitor<T> qv, Expression expression)
+        internal RealmQueryEnumerator(Realm realm, RealmQueryVisitor qv, Expression expression)
         {
             _realm = realm;
             _enumerating = qv;
@@ -41,8 +42,8 @@ namespace Realms
         /// <returns>True only if can advance.</returns>
         public bool MoveNext()
         {
-            var nextObj = _enumerating.FindNextRowHandle(_rowIndex);
-            Current = nextObj;
+            var nextObj = _enumerating.FindNextObject(ref _rowIndex);
+            Current = (T)((object)nextObj);
             return nextObj != null;
         }
 

--- a/Realm.Shared/linq/RealmQueryProvider.cs
+++ b/Realm.Shared/linq/RealmQueryProvider.cs
@@ -18,9 +18,9 @@ namespace Realms
             _realm = realm;
         }
 
-        internal RealmQueryVisitor<T> MakeVisitor<T>()
+        internal RealmQueryVisitor MakeVisitor(Type retType)
         {
-            return new RealmQueryVisitor<T>(_realm);
+            return new RealmQueryVisitor(_realm, retType);
         }
 
         public IQueryable<T> CreateQuery<T>(Expression expression)
@@ -41,12 +41,13 @@ namespace Realms
             }
         }
 
-        public TRes Execute<TRes>(Expression expression)
+        public T Execute<T>(Expression expression)
         {
-            var v = MakeVisitor<T>();
+            var retType = typeof(T);
+            var v = MakeVisitor(retType);
             Expression visitResult = v.Visit(expression);
             var constExp = visitResult as ConstantExpression;
-            TRes ret = (TRes)constExp?.Value;
+            T ret = (T)constExp?.Value;
             return ret;
         }
 

--- a/Realm.Shared/native/NativeQuery.cs
+++ b/Realm.Shared/native/NativeQuery.cs
@@ -83,7 +83,7 @@ namespace Realms
         internal static extern void double_greater_equal(QueryHandle queryPtr, IntPtr columnIndex, double value);
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_find", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern RowHandle find(QueryHandle queryHandle, IntPtr lastMatch);
+        internal static extern RowHandle find(QueryHandle queryHandle, IntPtr beginAtRow);
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_get_column_index", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr get_column_index(QueryHandle queryPtr,

--- a/Tests/IntegrationTests.Shared/PeopleTestsBase.cs
+++ b/Tests/IntegrationTests.Shared/PeopleTestsBase.cs
@@ -51,7 +51,7 @@ namespace IntegrationTests
                 p2 = _realm.CreateObject<Person>();
                 p2.FullName = "John Doe"; // uses our setter whcih splits and maps to First/Lastname
                 p2.IsInteresting = false;
-                p2.Email = "john@deo.com";
+                p2.Email = "john@doe.com";
                 p2.Score = 100;
                 p2.Latitude = 40.7637286;
                 p2.Longitude = -73.9748113;

--- a/Tests/IntegrationTests.Shared/SimpleLINQtests.cs
+++ b/Tests/IntegrationTests.Shared/SimpleLINQtests.cs
@@ -14,8 +14,9 @@ namespace IntegrationTests
     class SimpleLINQtests : PeopleTestsBase
     {
 
+
         [SetUp]
-        public void Setup()
+        public new void Setup()
         {
             base.Setup();
             MakeThreePeople();
@@ -27,6 +28,18 @@ namespace IntegrationTests
             var s0 = _realm.All<Person>().Where(p => p.Score == 42.42f).ToList();
             Assert.That(s0.Count(), Is.EqualTo(1));
             Assert.That(s0[0].Score, Is.EqualTo(42.42f));
+
+
+            var s1 = _realm.All<Person>().Where(p => p.Longitude < -70.0 && p.Longitude > -90.0).ToList();
+            Assert.That(s1[0].Email, Is.EqualTo("john@doe.com"));
+
+            var s2 = _realm.All<Person>().Where(p => p.Longitude < 0).ToList();
+            Assert.That(s2.Count(), Is.EqualTo(2));
+            Assert.That(s2[0].Email, Is.EqualTo("john@doe.com"));
+            Assert.That(s2[1].Email, Is.EqualTo("peter@jameson.com"));
+
+            var s3 = _realm.All<Person>().Where(p => p.Email != "").ToList();
+            Assert.That(s3.Count(), Is.EqualTo(3));
         }
 
 
@@ -157,7 +170,7 @@ namespace IntegrationTests
         [Test]
         public void SingleFindsTooMany()
         {
-            Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().Single(p => p.Latitude M= 50) );
+            Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().Single(p => p.Latitude == 50) );
             Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().Single(p => p.Score != 100.0f) );
             Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().Single(p => p.FirstName == "John") );
         }
@@ -166,14 +179,37 @@ namespace IntegrationTests
         [Test]
         public void SingleWorks()
         {
-            var s0 = _realm.All<Person>().Single(p => p.Latitude >= 50);
-            Assert.That(s0.FirstName, Is.EqualTo("Peter"));
+            var s0 = _realm.All<Person>().Single(p => p.Longitude < -70.0 && p.Longitude > -90.0);
+            Assert.That(s0.Email, Is.EqualTo("john@doe.com"));
 
             var s1 = _realm.All<Person>().Single(p => p.Score == 100.0f);
-            Assert.That(s1.FirstName, Is.EqualTo("Peter"));
+            Assert.That(s1.Email, Is.EqualTo("john@doe.com"));
 
             var s2 = _realm.All<Person>().Single(p => p.FirstName == "Peter");
             Assert.That(s2.FirstName, Is.EqualTo("Peter"));
+        }
+
+
+        [Test]
+        public void FirstFailsToFind()
+        {
+            Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().First(p => p.Latitude > 100) );
+            Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().First(p => p.Latitude > 100) );
+            Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().First(p => p.Score > 50000) );
+            Assert.Throws<InvalidOperationException>(() => _realm.All<Person>().First(p => p.FirstName == "Samantha") );
+        }
+
+        [Test]
+        public void FirstWorks()
+        {
+            var s0 = _realm.All<Person>().First(p => p.Longitude < -70.0 && p.Longitude > -90.0);
+            Assert.That(s0.Email, Is.EqualTo("john@doe.com"));
+
+            var s1 = _realm.All<Person>().First(p => p.Score == 100.0f);
+            Assert.That(s1.Email, Is.EqualTo("john@doe.com"));
+
+            var s2 = _realm.All<Person>().First(p => p.FirstName == "John");
+            Assert.That(s2.FirstName, Is.EqualTo("John"));
         }
 
     } // SimpleLINQtests

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1497,4 +1497,9 @@ RealmQueryEnumerator.cs
 - _retType removed
 - MoveNext simplified, moved object creation to RealmQueryVisitor
 
+NativeQuery.cs
+- find renamed 2nd param from lastMatch to beginAtRow so name is same as core
 
+NOTE
+- above changes need updating with stuff I just did
+- I think my test structure is wrong - need to delete the realm each time as am Making People over and over in same Realm


### PR DESCRIPTION
Had to do some refactoring as `RealmQueryVisitor` is now responsible for making objects when you use expressions that return a single object. It's getting a bit big so sometime in the near future will refactor into partial classes (a tip I picked up from some of my XMas reading).
