### PR TITLE
#368 Require IList

### DIFF
--- a/Doxygen/mainpage.cs
+++ b/Doxygen/mainpage.cs
@@ -13,12 +13,11 @@ The main classes you will use are:
 
 - @ref Realm
 - @ref RealmObject
-- @ref RealmList
+- @ref Transaction
 
 Helper classes you may use are:
 
 - @ref RealmConfiguration
-- @ref Transaction
 
 */
 }

--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -147,14 +147,15 @@ namespace Realms
                 var indexedAttribute = p.GetCustomAttributes(false).FirstOrDefault(a => a is IndexedAttribute);
                 var isIndexed = indexedAttribute != null;
 
+                // still check RealmList as there may be internal stuff where we declare it, but user code will be IList so check first
                 var isNullable = !(p.PropertyType.IsValueType || 
-                    p.PropertyType.Name == "RealmList`1" ||
                     p.PropertyType.Name == "IList`1") ||
+                    p.PropertyType.Name == "RealmList`1" ||
                     Nullable.GetUnderlyingType(p.PropertyType) != null;
 
                 var objectType = "";
                 if (!p.PropertyType.IsValueType && p.PropertyType.Name!="String") {
-                    if (p.PropertyType.Name == "RealmList`1" || p.PropertyType.Name == "IList`1")
+                    if (p.PropertyType.Name == "IList`1" || p.PropertyType.Name == "RealmList`1")
                         objectType = p.PropertyType.GetGenericArguments()[0].Name;
                     else {
                         if (p.PropertyType.BaseType.Name == "RealmObject")

--- a/Realm.Shared/RealmList.cs
+++ b/Realm.Shared/RealmList.cs
@@ -18,7 +18,7 @@ namespace Realms
     /// </remarks>
     /// 
     /// <typeparam name="T">Type of the RealmObject which is the target of the relationship.</typeparam>
-    public class RealmList<T> : IList<T> where T : RealmObject
+    internal class RealmList<T> : IList<T> where T : RealmObject
     {
         private class RealmListEnumerator : IEnumerator<T> 
         {

--- a/Realm.Shared/RealmObject.cs
+++ b/Realm.Shared/RealmObject.cs
@@ -359,7 +359,7 @@ namespace Realms
             return hasValue ? DateTimeOffsetExtensions.FromUnixTimeSeconds(unixTimeSeconds) : (DateTimeOffset?)null;
         }
 
-        protected RealmList<T> GetListValue<T>(string propertyName) where T : RealmObject
+        internal RealmList<T> GetListValue<T>(string propertyName) where T : RealmObject
         {
             Debug.Assert(_realm != null, "Object is not managed, but managed access was attempted");
 

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1499,3 +1499,16 @@ RealmQueryEnumerator.cs
 
 NativeQuery.cs
 - find renamed 2nd param from lastMatch to beginAtRow so name is same as core
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#368 Require IList
+
+RealmList.cs
+- changed from public to internal
+
+Realm.cs
+- reordered evaluations to check IList ahead of RealmList
+
+RealmObject
+- GetListValue had to become internal, was protected, to match RealmList access level


### PR DESCRIPTION
RealmList.cs
- changed from public to internal

Realm.cs
- reordered evaluations to check IList ahead of RealmList

RealmObject
- GetListValue had to become internal, was protected, to match RealmList access level
