### PR TITLE
Bump to v0.71.1 just removing redundant iPhoneSimulator build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+0.71.1 Private Beta
+-------------------
+### Minor Fixes
+
+Building IOS apps targeting the simulator sometimes got an error like:
+
+    Error MT5209: Native linking error...building for iOS simulator, 
+    but linking in object file built for OSX, for architecture i386 (MT5209) 
+
+This was fixed by removing a redundant simulator library included in NuGet
+
 0.71.0 Private Beta
 -------------------
 Still requires installation from private copy of NuGet download.

--- a/NuGet/NuGet.Library/Realm.nuspec
+++ b/NuGet/NuGet.Library/Realm.nuspec
@@ -21,7 +21,6 @@
   </metadata>
   <files>
 <!-- IOS files -->
-    <file src="../../Realm.XamarinIOS/bin/iPhoneSimulator/Release/RealmSimulator.dll" target="lib\Xamarin.iOS10" /> 
     <file src="../../Realm.XamarinIOS/bin/iPhone/Release/Realm.dll" target="lib\Xamarin.iOS10" />
 <!-- Android files -->
     <file src="Realm.targets" target="build\MonoAndroid44" />

--- a/NuGet/NuGet.Library/Realm.targets
+++ b/NuGet/NuGet.Library/Realm.targets
@@ -1,14 +1,14 @@
 <?xml version="1.0"  encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <AndroidNativeLibrary Include="../packages/Realm.0.71.0/lib/MonoAndroid44/armeabi/libwrappers.so">
-            <Link>../packages/Realm.0.71.0/lib/MonoAndroid44/armeabi/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="../packages/Realm.0.71.1/lib/MonoAndroid44/armeabi/libwrappers.so">
+            <Link>../packages/Realm.0.71.1/lib/MonoAndroid44/armeabi/libwrappers.so</Link>
         </AndroidNativeLibrary>
-        <AndroidNativeLibrary Include="../packages/Realm.0.71.0/lib/MonoAndroid44/armeabi-v7a/libwrappers.so">
-            <Link>../packages/Realm.0.71.0/lib/MonoAndroid44/armeabi-v7a/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="../packages/Realm.0.71.1/lib/MonoAndroid44/armeabi-v7a/libwrappers.so">
+            <Link>../packages/Realm.0.71.1/lib/MonoAndroid44/armeabi-v7a/libwrappers.so</Link>
         </AndroidNativeLibrary>
-        <AndroidNativeLibrary Include="../packages/Realm.0.71.0/lib/MonoAndroid44/x86/libwrappers.so">
-            <Link>../packages/Realm.0.71.0/lib/MonoAndroid44/x86/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="../packages/Realm.0.71.1/lib/MonoAndroid44/x86/libwrappers.so">
+            <Link>../packages/Realm.0.71.1/lib/MonoAndroid44/x86/libwrappers.so</Link>
         </AndroidNativeLibrary>
     </ItemGroup>
 </Project>

--- a/internals/RealmDotnetNugetBuild.md
+++ b/internals/RealmDotnetNugetBuild.md
@@ -18,20 +18,17 @@ Building the DLLS
 * In Xamarin Studio, open`Realm.sln`
 * select Release ARM
 * select Realm.XamarinAndroid project and Rebuild
-* select Release iPhoneSimulator
-* select Realm.XamarinIOS project and Rebuild
-* rename `/Users/andydent/dev/Realm/realm-dotnet/Realm.XamarinIOS/bin/iPhoneSimulator/Release/Realm.dll` to `RealmSimulator.dll` so you have a uniquely named DLL for the simulator
 * select Release iPhone with a device attached
 * select Realm.XamarinIOS project and Rebuild
 
-
-
-Once you have your DLLS,
+Once you have your DLLS, follow these next steps to set version numbers and build NuGet.
 
 
 Setting Version Numbers
 -----------------------
 Edit `NuGet/NuGet.Library/Realm.targets` and update version numbers in the paths.
+
+You will also have to change the version number you use in the `nuget` command line.
 
 If the Fody Weaver version number is also changing, edit it in `NuGet/NuGet.Weaver/RealmWeaver.Fody.nuspec`
 
@@ -59,14 +56,13 @@ The above assumes that the NuGet.exe tool was unpacked into `C:\tools` and you a
 
 Done correctly, this creates a package `/Users/andydent/dev/Realm/realm-dotnet/NuGet/NuGet.Library/Realm.0.71.0.nupkg` which you should copy to your **local test folder**.
 
-
 ### Binaries on OS X
 If you are copying binaries from an OS X machine to a separate Windows tree, you will need to get:
 
 * `Realm.XamarinAndroid/bin/Release`
 * `Realm.XamarinIOS/bin/iPhone/Release`
-* `Realm.XamarinIOS/bin/iPhoneSimulator/Release`
 * `wrappers/build/Release-*` multiple directories
+
 Testing the packages
 --------------------
 Set your Xamarin or Visual Studio to use your **local test folder** as a NuGet source.


### PR DESCRIPTION
NuGet change only after a rebuild.
