### PR TITLE
Renaming RealmQuery

### DIFF
--- a/Realm.PCL/Realm.PCL.csproj
+++ b/Realm.PCL/Realm.PCL.csproj
@@ -75,10 +75,10 @@
     <Compile Include="..\Realm.Shared\exceptions\RealmPermissionDeniedException.cs">
       <Link>Exceptions\RealmPermissionDeniedException.cs</Link>
     </Compile>
-    <Compile Include="RealmQueryPCL.cs" />
     <Compile Include="..\Realm.Shared\Attributes.cs">
       <Link>Attributes.cs</Link>
     </Compile>
+    <Compile Include="RealmResultsPCL.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Realm.PCL/RealmPCL.cs
+++ b/Realm.PCL/RealmPCL.cs
@@ -205,8 +205,8 @@ namespace Realms
         /// Extract an iterable set of objects for direct use or further query.
         /// </summary>
         /// <typeparam name="T">The Type T must not only be a RealmObject but also have been processd by the Fody weaver, so it has persistent properties.</typeparam>
-        /// <returns>A RealmQuery that without further filtering, allows iterating all objects of class T, in this realm.</returns>
-        public RealmQuery<T> All<T>() where T: RealmObject
+        /// <returns>A RealmResults that without further filtering, allows iterating all objects of class T, in this realm.</returns>
+        public RealmResults<T> All<T>() where T: RealmObject
         {
             RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
             return null;

--- a/Realm.PCL/RealmResultsPCL.cs
+++ b/Realm.PCL/RealmResultsPCL.cs
@@ -17,14 +17,14 @@ namespace Realms
     /// Iterable collection of one kind of RealmObject resulting from Realm.All or from a LINQ query expression.
     /// </summary>
     /// <typeparam name="T">Type of the RealmObject which is being returned.</typeparam>
-    public class RealmQuery<T> : IQueryable<T>
+    public class RealmResults<T> : IQueryable<T>
     {
         public Type ElementType => typeof (T);
         public Expression Expression { get; }
         public IQueryProvider Provider => null;
 
         /// <summary>
-        /// Standard method from interface IEnumerable allows the RealmQuery to be used in a <c>foreach</c>.
+        /// Standard method from interface IEnumerable allows the RealmResults to be used in a <c>foreach</c>.
         /// </summary>
         /// <returns>An IEnumerator which will iterate through found Realm persistent objects.</returns>
         public IEnumerator<T> GetEnumerator()

--- a/Realm.Shared/Realm.Shared.projitems
+++ b/Realm.Shared/Realm.Shared.projitems
@@ -27,9 +27,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)handles\SharedRealmHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)handles\TableHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)linq\ExpressionVisitor.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmQuery.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmQueryProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmQueryVisitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)linq\TypeSystem.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MarshalHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)native\NativeCommon.cs" />
@@ -53,6 +50,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)handles\LinkListHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RealmConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)exceptions\RealmMigrationNeededException.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmQueryEnumerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmResults.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmResultsEnumerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmResultsVisitor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)linq\RealmResultsProvider.cs" />
   </ItemGroup>
 </Project>

--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -403,10 +403,10 @@ namespace Realms
         /// Extract an iterable set of objects for direct use or further query.
         /// </summary>
         /// <typeparam name="T">The Type T must not only be a RealmObject but also have been processd by the Fody weaver, so it has persistent properties.</typeparam>
-        /// <returns>A RealmQuery that without further filtering, allows iterating all objects of class T, in this realm.</returns>
-        public RealmQuery<T> All<T>() where T: RealmObject
+        /// <returns>A RealmResults that without further filtering, allows iterating all objects of class T, in this realm.</returns>
+        public RealmResults<T> All<T>() where T: RealmObject
         {
-            return new RealmQuery<T>(this, true);
+            return new RealmResults<T>(this, true);
         }
 
         /// <summary>

--- a/Realm.Shared/linq/RealmResults.cs
+++ b/Realm.Shared/linq/RealmResults.cs
@@ -15,34 +15,34 @@ namespace Realms
     /// Iterable collection of one kind of RealmObject resulting from Realm.All or from a LINQ query expression.
     /// </summary>
     /// <typeparam name="T">Type of the RealmObject which is being returned.</typeparam>
-    public class RealmQuery<T> : IQueryable<T>
+    public class RealmResults<T> : IQueryable<T>
     {
         public Type ElementType => typeof (T);
         public Expression Expression { get; }
         public IQueryProvider Provider => _provider;
-        private readonly RealmQueryProvider _provider;
+        private readonly RealmResultsProvider _provider;
         private bool _allRecords = false;
 
-        internal RealmQuery(RealmQueryProvider queryProvider, Expression expression) 
+        internal RealmResults(RealmResultsProvider queryProvider, Expression expression) 
         {
             this._provider = queryProvider;
             this.Expression = expression;
         }
 
-        internal RealmQuery(Realm realm, bool createdByAll=false) : this(new RealmQueryProvider(realm), null)
+        internal RealmResults(Realm realm, bool createdByAll=false) : this(new RealmResultsProvider(realm), null)
         {
             _allRecords = createdByAll;
             this.Expression = Expression.Constant(this);
         }
 
         /// <summary>
-        /// Standard method from interface IEnumerable allows the RealmQuery to be used in a <c>foreach</c>.
+        /// Standard method from interface IEnumerable allows the RealmResults to be used in a <c>foreach</c>.
         /// </summary>
         /// <returns>An IEnumerator which will iterate through found Realm persistent objects.</returns>
         public IEnumerator<T> GetEnumerator()
         {
             var retType = typeof(T);
-            return new RealmQueryEnumerator<T>(_provider._realm, _provider.MakeVisitor(retType), Expression);
+            return new RealmResultsEnumerator<T>(_provider._realm, _provider.MakeVisitor(retType), Expression);
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -66,8 +66,8 @@ namespace Realms
                 var tableHandle = _provider._realm._tableHandles[ElementType];
                 return (int)NativeTable.count_all(tableHandle);
             }
-            // we should be in RealmQueryVisitor.VisitMethodCall, not here, ever, seriously!
-            throw new NotImplementedException("Count should not be invoked directly on a RealmQuery unless created by All. LINQ will not invoke this."); 
+            // we should be in RealmQRealmResultsr.VisitMethodCall, not here, ever, seriously!
+            throw new NotImplementedException("Count should not be invoked directly on a RealmQRealmResultss created by All. LINQ will not invoke this."); 
         }    
     }
 }

--- a/Realm.Shared/linq/RealmResultsEnumerator.cs
+++ b/Realm.Shared/linq/RealmResultsEnumerator.cs
@@ -10,14 +10,14 @@ using System.Linq.Expressions;
 
 namespace Realms
 {
-    internal class RealmQueryEnumerator<T> : IEnumerator<T> 
+    internal class RealmResultsEnumerator<T> : IEnumerator<T> 
     {
         private long _rowIndex = 0;
-        private RealmQueryVisitor _enumerating;
+        private RealmResultsVisitor _enumerating;
         private Realm _realm;
         private Type _retType = typeof(T);
 
-        internal RealmQueryEnumerator(Realm realm, RealmQueryVisitor qv, Expression expression)
+        internal RealmResultsEnumerator(Realm realm, RealmResultsVisitor qv, Expression expression)
         {
             _realm = realm;
             _enumerating = qv;

--- a/Realm.Shared/linq/RealmResultsProvider.cs
+++ b/Realm.Shared/linq/RealmResultsProvider.cs
@@ -9,23 +9,23 @@ using System.Reflection;
 
 namespace Realms
 {
-    internal class RealmQueryProvider : IQueryProvider
+    internal class RealmResultsProvider : IQueryProvider
     {
         internal Realm _realm;
 
-        internal RealmQueryProvider(Realm realm)
+        internal RealmResultsProvider(Realm realm)
         {
             _realm = realm;
         }
 
-        internal RealmQueryVisitor MakeVisitor(Type retType)
+        internal RealmResultsVisitor MakeVisitor(Type retType)
         {
-            return new RealmQueryVisitor(_realm, retType);
+            return new RealmResultsVisitor(_realm, retType);
         }
 
         public IQueryable<T> CreateQuery<T>(Expression expression)
         {
-            return new RealmQuery<T>(this, expression);
+            return new RealmResults<T>(this, expression);
         }
 
         public IQueryable CreateQuery(Expression expression)
@@ -33,7 +33,7 @@ namespace Realms
             Type elementType = TypeSystem.GetElementType(expression.Type);
             try
             {
-                return (IQueryable)Activator.CreateInstance(typeof(RealmQuery<>).MakeGenericType(elementType), new object[] { this, expression });
+                return (IQueryable)Activator.CreateInstance(typeof(RealmResults<>).MakeGenericType(elementType), new object[] { this, expression });
             }
             catch (TargetInvocationException tie)
             {

--- a/Realm.Shared/linq/RealmResultsVisitor.cs
+++ b/Realm.Shared/linq/RealmResultsVisitor.cs
@@ -11,14 +11,14 @@ using System.Runtime.CompilerServices;
 
 namespace Realms
 {
-    internal class RealmQueryVisitor : ExpressionVisitor
+    internal class RealmResultsVisitor : ExpressionVisitor
     {
         private Realm _realm;
         private QueryHandle _coreQueryHandle;  // set when recurse down to VisitConstant
         private Type _retType;
 
 
-        internal RealmQueryVisitor(Realm realm, Type retType)
+        internal RealmResultsVisitor(Realm realm, Type retType)
         {
             _realm = realm;
             _retType = retType;
@@ -89,7 +89,7 @@ namespace Realms
                 if (m.Method.Name == "Single")
                 {
                     // unlike Any, has embedded lambda, so treat it more like a Where
-                    // eg: m    {value(Realms.RealmQuery`1[IntegrationTests.Person]).Single(p => (p.Latitude > 100))}
+                    // eg: m    {value(Realms.RealmResults`1[IntegrationTests.Person]).Single(p => (p.Latitude > 100))}
                     this.Visit(m.Arguments[0]);  // creates the query
                     LambdaExpression lambda = (LambdaExpression)StripQuotes(m.Arguments[1]);
                     this.Visit(lambda.Body);

--- a/Realm.XamarinAndroid/Realm.XamarinAndroid.csproj
+++ b/Realm.XamarinAndroid/Realm.XamarinAndroid.csproj
@@ -13,7 +13,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|ARM' ">
     <DebugSymbols>true</DebugSymbols>

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1608,4 +1608,21 @@ IntegrationTests.XamarinAndroid
   set Target Framework to API 22
 - Project Options - Build - Android Application
   set Minimum Android Version to 2.3 (API 10)
-  
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+Renaming RealmQuery
+
+RealmQuery.cs
+- rename RealmQuery to RealmResults
+
+RealmQueryPCL.cs
+- rename RealmQuery to RealmResults
+
+RealmQueryEnumerator.cs
+- rename RealmQueryEnumerator to RealmResultsEnumerator
+
+RealmQueryVisitor.cs
+- rename RealmQueryVisitor to RealmResultsVisitor
+
+RealmQueryProvider.cs
+- rename RealmQueryProvider to RealmResultsProvider

--- a/internals/RealmDotNetArchitecture.md
+++ b/internals/RealmDotNetArchitecture.md
@@ -30,8 +30,8 @@ digraph {
   RealmObject -> ICoreProvider
   
   Realm -> ICoreProvider [label=" owns injected\l platform instance"]
-  Realm -> RealmQuery [label=" create with All"]
-  RealmQuery -> ICoreProvider [label=" querying"]
+  Realm -> RealmResults [label=" create with All"]
+  RealmResults -> ICoreProvider [label=" querying"]
   
   /* subclasses */
   RealmObject -> "User Code" [arrowtail=empty, arrowhead=none, dir=both]
@@ -48,7 +48,7 @@ digraph {
 
   RealmObject -> Realm [label=" Add"]
   
-  {rank=same; Realm; RealmQuery}
+  {rank=same; Realm; RealmResults}
   {rank=same; RealmObject; ICoreProvider}
 }
 @enddot
@@ -69,8 +69,8 @@ digraph {
   RealmObject -> ICoreProvider
   
   Realm -> ICoreProvider [label=" owns injected\l platform instance"]
-  Realm -> RealmQuery [label=" create with All"]
-  RealmQuery -> IQueryCoreProvider [label=" querying"]
+  Realm -> RealmResults [label=" create with All"]
+  RealmResults -> IQueryCoreProvider [label=" querying"]
   
   /* subclasses */
   RealmObject -> "User Code" [arrowtail=empty, arrowhead=none, dir=both]
@@ -99,7 +99,7 @@ digraph {
 
   RealmObject -> Realm [label=" Add"]
   
-  {rank=same; Realm; RealmQuery}
+  {rank=same; Realm; RealmResults}
   {rank=same; RealmObject; ICoreProvider}
 }
 @enddot

--- a/internals/RealmSimpleLinq.md
+++ b/internals/RealmSimpleLinq.md
@@ -24,7 +24,7 @@ We start with a simple search with one clause doing a comparison on a double fie
 
 `var aQuery = _realm.All<Person>().Where(p => p.Latitude < 40);`
 
-The type of `aQuery` is `Realms.RealmQuery<IntegrationTests.Person>` and it requires further evaluation to trigger actually doing the search.
+The type of `aQuery` is `Realms.RealmResults<IntegrationTests.Person>` and it requires further evaluation to trigger actually doing the search.
 
 A common way is to call the standard Linq to Objects call `var newList = aQuery.ToList()` which triggers the search and enumerates the result to copy objects to a list. 
 
@@ -39,27 +39,27 @@ digraph {
     test [label="Test code\nor application code"]
     LinqWhere [label="System.Linq.\nQueryable.Where<Person>"]
     QPCreateQuery [label="QueryProvider.\nCreateQuery<Person>"]
-    RealmQuery [shape=box3d, label="RealmQuery<Person>"]
-    RealmQueryEnumerator [shape=box3d, label="RealmQueryEnumerator<Person>"]
+    RealmResults [shape=box3d, label="RealmResults<Person>"]
+    RealmResultsEnumerator [shape=box3d, label="RealmResultsEnumerator<Person>"]
 
     ToList [label="System.Linq.\nEnumerable.ToList"]
     Listctor[label="System.Collections.Generic.List.ctor"]
-    GetEnum [label="RealmQuery<Person>\n.GetEnumerator"]
-    EnumMove [label="RealmQueryEnumerator.\nMoveNext"]
-    EnumCurrent [label="RealmQueryEnumerator.\nCurrent"]
-    RealmQueryVisitor [shape=box3d]
+    GetEnum [label="RealmResults<Person>\n.GetEnumerator"]
+    EnumMove [label="RealmResultsEnumerator.\nMoveNext"]
+    EnumCurrent [label="RealmResultsEnumerator.\nCurrent"]
+    RealmResultsVisitor [shape=box3d]
     QueryHandle [shape=box3d]
-    QVMethod [label="RealmQueryVisitor.\nVisitMethodCall"]
-    QVBinary [label="RealmQueryVisitor.\nVisitBinary"] 
+    QVMethod [label="RealmResultsVisitor.\nVisitMethodCall"]
+    QVBinary [label="RealmResultsVisitor.\nVisitBinary"] 
     EVVisit [label="ExpressionVisitor.\nVisit"]
     EVVisit2 [label="ExpressionVisitor.\nVisit"]
     EVVisit3 [label="ExpressionVisitor.\nVisit"]
-    QVConstant [label="RealmQueryVisitor.\nVisitConstant"]
-    CreateQuery [label="RealmQueryVisitor.\nCreateQuery"]
-    cqHandle [label="RealmQueryVisitor.\n_coreQueryHandle", shape=none]
+    QVConstant [label="RealmResultsVisitor.\nVisitConstant"]
+    CreateQuery [label="RealmResultsVisitor.\nCreateQuery"]
+    cqHandle [label="RealmResultsVisitor.\n_coreQueryHandle", shape=none]
     TableWhere [label="TableHandle.\nTableWhere"]
     NativeWhereInterface [label="NativeTable.\nwhere"]
-    AddQueryEqual [label="RealmQueryVisitor.\nAddQueryEqual"]
+    AddQueryEqual [label="RealmResultsVisitor.\nAddQueryEqual"]
     getCol [label="NativeQuery.\nget_column_index"]
     queryDoubleEqual [label="NativeQuery.\ndouble_equal"]
     NativeFindInterface [label="NativeQuery.\nfind"]
@@ -76,16 +76,16 @@ digraph {
     
     
     test -> LinqWhere -> QPCreateQuery
-    QPCreateQuery -> RealmQuery [label=" creates as\n IQueryable<Person>"]
+    QPCreateQuery -> RealmResults [label=" creates as\n IQueryable<Person>"]
     test -> ToList
     ToList -> Listctor -> GetEnum
-    GetEnum -> RealmQueryVisitor [label="creates"]
-    GetEnum -> RealmQueryEnumerator [label=" creates"]
+    GetEnum -> RealmResultsVisitor [label="creates"]
+    GetEnum -> RealmResultsEnumerator [label=" creates"]
     Listctor -> EnumMove
     Listctor -> EnumCurrent
-    RealmQueryVisitor -> EVVisit
+    RealmResultsVisitor -> EVVisit
     EVVisit -> QVMethod [label=" Where"]
-    QVMethod -> EVVisit2 [label=" value(RealmQuery`1[Person])"]
+    QVMethod -> EVVisit2 [label=" value(RealmResults`1[Person])"]
     EVVisit2 -> QVConstant
     QVConstant -> CreateQuery -> TableWhere
     CreateQuery -> cqHandle [label=" set"]
@@ -130,19 +130,19 @@ digraph {
     test [label="Test code\nor application code"]
     LinqWhere [label="System.Linq.\nQueryable.Where<Person>"]
     QPCreateQuery [label="QueryProvider.\nCreateQuery<Person>"]
-    RealmQuery [shape=box3d, label="RealmQuery<Person>"]
+    RealmResults [shape=box3d, label="RealmResults<Person>"]
     LinqCount [label="System.Linq.\nQueryable.Count"]
-    RQPEint [label="RealmQueryProvider<int>.\nExecute"]
+    RQPEint [label="RealmResultsProvider<int>.\nExecute"]
     elide2 [label="...", shape=none]
     elide3 [label="...", shape=none]
-    QVMethod0 [label="RealmQueryVisitor.\nVisitMethodCall"]
-    QVMethod [label="RealmQueryVisitor.\nVisitMethodCall"]
-    QVBinary [label="RealmQueryVisitor.\nVisitBinary"] 
+    QVMethod0 [label="RealmResultsVisitor.\nVisitMethodCall"]
+    QVMethod [label="RealmResultsVisitor.\nVisitMethodCall"]
+    QVBinary [label="RealmResultsVisitor.\nVisitBinary"] 
     EVVisit0 [label="ExpressionVisitor.\nVisit"]
     EVVisit [label="ExpressionVisitor.\nVisit"]
     EVVisit2 [label="ExpressionVisitor.\nVisit"]
     EVVisit3 [label="ExpressionVisitor.\nVisit"]
-    QVConstant [label="RealmQueryVisitor.\nVisitConstant"]
+    QVConstant [label="RealmResultsVisitor.\nVisitConstant"]
     NativeCountInterface [label="NativeQuery.\ncount"]
 
     /* c++ */
@@ -152,14 +152,14 @@ digraph {
     
     
     test -> LinqWhere -> QPCreateQuery
-    QPCreateQuery -> RealmQuery [label=" creates as\n IQueryable<Person>"]
+    QPCreateQuery -> RealmResults [label=" creates as\n IQueryable<Person>"]
     test -> LinqCount
     LinqCount -> RQPEint
     RQPEint -> EVVisit0 [label=" Extract count\n from returned\n ConstantExpression"]
     EVVisit0 -> QVMethod0 [label=" Count"]
-    QVMethod0 -> EVVisit [label=" value(RealmQuery`1[Person])\l.Where(p => p.Latitude < 40)"]
+    QVMethod0 -> EVVisit [label=" value(RealmResults`1[Person])\l.Where(p => p.Latitude < 40)"]
     EVVisit -> QVMethod [label=" Where"]
-    QVMethod -> EVVisit2 [label=" value(RealmQuery`1[Person])"]
+    QVMethod -> EVVisit2 [label=" value(RealmResults`1[Person])"]
     EVVisit2 -> QVConstant
     QVConstant -> elide2  [style=dotted]
 


### PR DESCRIPTION
RealmQuery.cs
- rename RealmQuery to RealmResults

RealmQueryPCL.cs
- rename RealmQuery to RealmResults

RealmQueryEnumerator.cs
- rename RealmQueryEnumerator to RealmResultsEnumerator

RealmQueryVisitor.cs
- rename RealmQueryVisitor to RealmResultsVisitor

RealmQueryProvider.cs
- rename RealmQueryProvider to RealmResultsProvider
