### PR TITLE
#404 Add way to specify encryption key

### DIFF
--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -94,7 +94,7 @@ namespace Realms
                 srPtr = NativeSharedRealm.open(schemaHandle, 
                     databasePath, (IntPtr)databasePath.Length, 
                     readOnly, durability, 
-                    "", IntPtr.Zero,
+                    config.EncryptionKey,
                     config.SchemaVersion);
             } catch (RealmMigrationNeededException) {
                 if (config.ShouldDeleteIfMigrationNeeded)
@@ -111,7 +111,7 @@ namespace Realms
                 srPtr = NativeSharedRealm.open(schemaHandle, 
                     databasePath, (IntPtr)databasePath.Length, 
                     readOnly, durability, 
-                    "", IntPtr.Zero,
+                    config.EncryptionKey,
                     config.SchemaVersion);
             }
 

--- a/Realm.Shared/RealmConfiguration.cs
+++ b/Realm.Shared/RealmConfiguration.cs
@@ -4,6 +4,8 @@
  
 using System;
 using System.IO;
+using System.Linq;
+using System.Collections.Generic;
 
 // see internals/RealmConfigurations.md for a detailed diagram of how this interacts with the ObjectStore configuration
 
@@ -64,6 +66,23 @@ namespace Realms
         /// </summary>
         /// <value>0-based value initially set to indicate user is not versioning.</value>
         public UInt64 SchemaVersion { get; set;} = RealmConfiguration.NotVersioned;
+
+
+        private byte[] _EncryptionKey;
+
+        /// <summary>
+        /// Specify the key used to encrypt the entire Realm. Once set, must be specified each time file is used.
+        /// </summary>
+        /// <value>Full 64byte (512bit) key for AES-256 encryption.</value>
+        public byte[] EncryptionKey { 
+            get { return _EncryptionKey; }
+            set 
+            {
+                if (value != null && value.Length != 64)
+                    throw new FormatException("EncryptionKey must be 64 bytes");
+                _EncryptionKey = value;
+            }
+        }
 
         /// <summary>
         /// Configuration you can override which is used when you create a new Realm without specifying a configuration.
@@ -132,7 +151,8 @@ namespace Realms
             if (GC.ReferenceEquals(this, rhs))
                 return true;
             return ShouldDeleteIfMigrationNeeded == rhs.ShouldDeleteIfMigrationNeeded &&
-                DatabasePath == rhs.DatabasePath;
+                DatabasePath == rhs.DatabasePath && 
+                ( (EncryptionKey == null && rhs.EncryptionKey == null) || EncryptionKey.SequenceEqual(rhs.EncryptionKey));
         }
 
 

--- a/Realm.Shared/native/NativeSharedRealm.cs
+++ b/Realm.Shared/native/NativeSharedRealm.cs
@@ -11,7 +11,7 @@ namespace Realms
     {
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_open", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr open(SchemaHandle schemaHandle, [MarshalAs(UnmanagedType.LPWStr)]string path, IntPtr pathLength, IntPtr readOnly,
-            IntPtr durability, [MarshalAs(UnmanagedType.LPWStr)]string encryptionKey, IntPtr encryptionKeyLength, UInt64 schemaVersion);
+            IntPtr durability, byte[] encryptionKey, UInt64 schemaVersion);
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_destroy", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr destroy(IntPtr sharedRealm);

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1626,3 +1626,28 @@ RealmQueryVisitor.cs
 
 RealmQueryProvider.cs
 - rename RealmQueryProvider to RealmResultsProvider
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#404 Add way to specify encryption key
+
+RealmConfiguration.cs
+- add EncryptionKey property
+- Equals(RealmConfiguration rhs) enhanced to check EncryptionKey
+
+
+wrappers/shared_realm_cs.cpp
+shared_realm_open
+- change signature to take just byte array of fixed length, dropping the 
+  encryption_key_len param
+
+Realm.GetInstance
+- pass EncryptionKey to NaiveSharedRealm.open
+
+ConfigurationTests.cs
+- EncryptionKeyMustBe64Bytes added
+- ValidEncryptionKeyAcceoted added
+- UnableToOpenWithNoKey added
+- UnableToOpenWithKeyIfNotEncrypted added
+- UnableToOpenWithDifferentKey added
+- AbleToReopenEncryptedWithSameKey added

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -16,19 +16,21 @@ using namespace realm::binding;
 extern "C" {
 
 REALM_EXPORT SharedRealm* shared_realm_open(Schema* schema, uint16_t* path, size_t path_len, bool read_only, SharedGroup::DurabilityLevel durability,
-                        uint16_t* encryption_key, size_t encryption_key_len, uint64_t schemaVersion)
+                        uint8_t* encryption_key, uint64_t schemaVersion)
 {
     return handle_errors([&]() {
         Utf16StringAccessor pathStr(path, path_len);
-        Utf16StringAccessor encryptionStr(encryption_key, encryption_key_len);
-
 
         Realm::Config config;
         config.path = pathStr.to_string();
         config.read_only = read_only;
         config.in_memory = durability != SharedGroup::durability_Full;
 
-        config.encryption_key = std::vector<char>(&encryptionStr.data()[0], &encryptionStr.data()[encryptionStr.size()]);
+        // by definition the key is only allowwed to be 64 bytes long, enforced by C# code
+        if (encryption_key == nullptr)
+          config.encryption_key = std::vector<char>();
+        else
+          config.encryption_key = std::vector<char>(encryption_key, encryption_key+64);
 
         config.schema.reset(schema);
         config.schema_version = schemaVersion;


### PR DESCRIPTION
RealmConfiguration.cs
- add EncryptionKey property
- Equals(RealmConfiguration rhs) enhanced to check EncryptionKey

wrappers/shared_realm_cs.cpp
shared_realm_open
- change signature to take just byte array of fixed length, dropping the
  encryption_key_len param

Realm.GetInstance
- pass EncryptionKey to NaiveSharedRealm.open

ConfigurationTests.cs
- EncryptionKeyMustBe64Bytes added
- ValidEncryptionKeyAcceoted added
- UnableToOpenWithNoKey added
- UnableToOpenWithKeyIfNotEncrypted added
- UnableToOpenWithDifferentKey added
- AbleToReopenEncryptedWithSameKey added
