### PR TITLE
#401 Fix Nuget Android relative lib paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Still requires installation from private copy of NuGet download.
 
 ### Minor Fixes
 * Finish `RealmList.CopyTo` so you can apply `ToList` to related lists (issue #299)
+* NuGet now inserts `libwrappers.so` for Android targets using `$(SolutionDir)packages` so it copes with the different relative paths in cross-platform (Xamarin Forms) app templates vs pure Android templates.  
 
 0.73.0 Privat Beta (2016-02-26)
 -------------------

--- a/NuGet/NuGet.Library/Realm.targets
+++ b/NuGet/NuGet.Library/Realm.targets
@@ -1,26 +1,26 @@
 <?xml version="1.0"  encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <AndroidNativeLibrary Include="../packages/Realm.0.73.0/lib/MonoAndroid44/armeabi/libwrappers.so">
-            <Link>../packages/Realm.0.73.0/lib/MonoAndroid44/armeabi/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/armeabi/libwrappers.so">
+            <Link>$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/armeabi/libwrappers.so</Link>
         </AndroidNativeLibrary>
-        <AndroidNativeLibrary Include="../packages/Realm.0.73.0/lib/MonoAndroid44/armeabi-v7a/libwrappers.so">
-            <Link>../packages/Realm.0.73.0/lib/MonoAndroid44/armeabi-v7a/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/armeabi-v7a/libwrappers.so">
+            <Link>$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/armeabi-v7a/libwrappers.so</Link>
         </AndroidNativeLibrary>
-        <AndroidNativeLibrary Include="../packages/Realm.0.73.0/lib/MonoAndroid44/x86/libwrappers.so">
-            <Link>../packages/Realm.0.73.0/lib/MonoAndroid44/x86/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/x86/libwrappers.so">
+            <Link>$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/x86/libwrappers.so</Link>
         </AndroidNativeLibrary>
 <!-- disabled until clarify need and Xamarin support
-        <AndroidNativeLibrary Include="../packages/Realm.0.73.0/lib/MonoAndroid44/mips/libwrappers.so">
-            <Link>../packages/Realm.0.73.0/lib/MonoAndroid44/mips/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/mips/libwrappers.so">
+            <Link>$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/mips/libwrappers.so</Link>
         </AndroidNativeLibrary>
 -->        
 <!-- 64bit -->
-        <AndroidNativeLibrary Include="../packages/Realm.0.73.0/lib/MonoAndroid44/arm64-v8a/libwrappers.so">
-            <Link>../packages/Realm.0.73.0/lib/MonoAndroid44/arm64-v8a/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/arm64-v8a/libwrappers.so">
+            <Link>$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/arm64-v8a/libwrappers.so</Link>
         </AndroidNativeLibrary>
-        <AndroidNativeLibrary Include="../packages/Realm.0.73.0/lib/MonoAndroid44/x86_64/libwrappers.so">
-            <Link>../packages/Realm.0.73.0/lib/MonoAndroid44/x86_64/libwrappers.so</Link>
+        <AndroidNativeLibrary Include="$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/x86_64/libwrappers.so">
+            <Link>$(SolutionDir)packages/Realm.0.73.1/lib/MonoAndroid44/x86_64/libwrappers.so</Link>
         </AndroidNativeLibrary>
     </ItemGroup>
 </Project>

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1675,3 +1675,10 @@ RealmList.cs
 - CopyTo implemented stubbed method
  
  
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#401 Fix Nuget Android relative lib paths
+
+realm.targets
+- instead of ../packages use $(SolutionDir)packages
+  because need it to be solution-relative in MSBuild terms (not at NuGet time)
+  


### PR DESCRIPTION
This fixes #401

realm.targets
- instead of ../packages use $(SolutionDir)packages
  because need it to be solution-relative in MSBuild terms (not at NuGet time)
