### PR TITLE
ExternalCommitHelper on Apple should throw RealmFileException for EACCES

### DIFF
--- a/wrappers/src/object-store/src/impl/apple/external_commit_helper.cpp
+++ b/wrappers/src/object-store/src/impl/apple/external_commit_helper.cpp
@@ -111,9 +111,15 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
             ret = mkfifo(path.c_str(), 0600);
             err = errno;
         }
-        // the fifo already existing isn't an error
-        if (ret == -1 && err != EEXIST) {
-            throw std::system_error(err, std::system_category());
+
+        if (ret == -1) {
+            if (err == EEXIST) {
+                // the fifo already existing isn't an error
+            } else if (err == EACCES) {
+                throw RealmFileException(RealmFileException::Kind::PermissionDenied, path, "Permission denied opening named pipe");
+            } else {
+                throw std::system_error(err, std::system_category());
+            }
         }
     }
 


### PR DESCRIPTION
Opening a Realm creates a `realm::ExternalCommitHelper`, which wraps the `EACCES` returned by `mkfifo` on Apple platforms when the path is invalid in a `std::system_error`. The dotnet binding expects a `realm::RealmFileException`, though, so it doesn't raise the correct managed exception.
