### PR TITLE
Ignore test that relies on manual migrations

### DIFF
--- a/Tests/IntegrationTests.Shared/ObjectIntegrationTests.cs
+++ b/Tests/IntegrationTests.Shared/ObjectIntegrationTests.cs
@@ -291,6 +291,7 @@ namespace IntegrationTests
         }
 
         [Test]
+        [Ignore("this tests for a condition thst's only available under manual migrations, which we lack")]
         public void TriggerMigrationBySchemaEditing()
         {
             


### PR DESCRIPTION
We should revert this if #345 is resolved accordingly.
