### PR TITLE
Make sure all the realms the tests open are properly closed

### DIFF
--- a/Tests/IntegrationTests.Shared/InstanceTests.cs
+++ b/Tests/IntegrationTests.Shared/InstanceTests.cs
@@ -24,7 +24,7 @@ namespace IntegrationTests
         public void GetInstanceTest()
         {
             // Arrange, act and "assert" that no exception is thrown, using default location
-            Realm.GetInstance();
+            Realm.GetInstance().Close();
         }
 
         // This is a test of the Exception throwing mechanism but is included in the Instance tests
@@ -32,33 +32,37 @@ namespace IntegrationTests
         [Test]
         public void FakeExceptionThrowTest()
         {
-            Realm.GetInstance();
-            Assert.Throws<RealmPermissionDeniedException>(() => NativeCommon.fake_a_native_exception((IntPtr)RealmExceptionCodes.RealmPermissionDenied));
+            using (Realm.GetInstance())
+            {
+                Assert.Throws<RealmPermissionDeniedException>(() => NativeCommon.fake_a_native_exception((IntPtr)RealmExceptionCodes.RealmPermissionDenied));
+            }
 
         }
 
         [Test]
         public void FakeExceptionThrowLoopingTest()
         {
-            Realm.GetInstance();
-            for (int i = 0; i < 10000; ++i)
+            using (Realm.GetInstance())
             {
+                for (int i = 0; i < 10000; ++i)
+                {
 #if DEBUG
-                bool caughtIt = false;
-                // Assert.Throws doesn't work with the VS debugger which thinks the exception is uncaught
-                try
-                {
-                    NativeCommon.fake_a_native_exception((IntPtr)RealmExceptionCodes.RealmPermissionDenied);
-                }
-                catch (RealmPermissionDeniedException)
-                {
-                    caughtIt = true;
-                }
-                Assert.That(caughtIt, "Should have caught the expected exception");
+                    bool caughtIt = false;
+                    // Assert.Throws doesn't work with the VS debugger which thinks the exception is uncaught
+                    try
+                    {
+                        NativeCommon.fake_a_native_exception((IntPtr)RealmExceptionCodes.RealmPermissionDenied);
+                    }
+                    catch (RealmPermissionDeniedException)
+                    {
+                        caughtIt = true;
+                    }
+                    Assert.That(caughtIt, "Should have caught the expected exception");
 #else
                 Assert.Throws<RealmPermissionDeniedException>(
                     () => NativeCommon.fake_a_native_exception((IntPtr) RealmExceptionCodes.RealmPermissionDenied));
 #endif
+                }
             }
 
         }
@@ -77,7 +81,7 @@ namespace IntegrationTests
         public void GetInstanceWithJustFilenameTest()
         {
             // Arrange, act and "assert" that no exception is thrown, using default location
-            Realm.GetInstance("EnterTheMagic.realm");
+            Realm.GetInstance("EnterTheMagic.realm").Close();
         }
 
         [Test]
@@ -115,6 +119,9 @@ namespace IntegrationTests
             Assert.False(GC.ReferenceEquals(realm1, realm2));
             Assert.False(realm1.IsSameInstance(realm2));
             Assert.That(realm1, Is.EqualTo(realm2));  // equal and same Realm but not same instance
+
+            realm1.Close();
+            realm2.Close();
         }
 
 
@@ -122,14 +129,15 @@ namespace IntegrationTests
         public void GetCachedInstancesSameThread()
         {
             // Arrange
-            var realm1 = Realm.GetInstance("EnterTheMagic.realm");
-            var realm2 = Realm.GetInstance("EnterTheMagic.realm");
-
-            // Assert
-            Assert.False(GC.ReferenceEquals(realm1, realm2));
-            Assert.That(realm1, Is.EqualTo(realm1));  // check equality with self
-            Assert.That(realm1.IsSameInstance(realm2));
-            Assert.That(realm1, Is.EqualTo(realm2));
+            using (var realm1 = Realm.GetInstance("EnterTheMagic.realm"))
+            using (var realm2 = Realm.GetInstance("EnterTheMagic.realm"))
+            {
+                // Assert
+                Assert.False(GC.ReferenceEquals(realm1, realm2));
+                Assert.That(realm1, Is.EqualTo(realm1));  // check equality with self
+                Assert.That(realm1.IsSameInstance(realm2));
+                Assert.That(realm1, Is.EqualTo(realm2));
+            }
         }
 
 
@@ -137,13 +145,14 @@ namespace IntegrationTests
         public void InstancesHaveDifferentHashes()
         {
             // Arrange
-            var realm1 = Realm.GetInstance("EnterTheMagic.realm");
-            var realm2 = Realm.GetInstance("EnterTheMagic.realm");
-
-            // Assert
-            Assert.False(GC.ReferenceEquals(realm1, realm2));
-            Assert.That(realm1.GetHashCode(), Is.Not.EqualTo(0));  
-            Assert.That(realm1.GetHashCode(), Is.Not.EqualTo(realm2.GetHashCode())); 
+            using (var realm1 = Realm.GetInstance("EnterTheMagic.realm"))
+            using (var realm2 = Realm.GetInstance("EnterTheMagic.realm"))
+            {
+                // Assert
+                Assert.False(GC.ReferenceEquals(realm1, realm2));
+                Assert.That(realm1.GetHashCode(), Is.Not.EqualTo(0));  
+                Assert.That(realm1.GetHashCode(), Is.Not.EqualTo(realm2.GetHashCode())); 
+            }
         }
 
 

--- a/Tests/IntegrationTests.Shared/ObjectIntegrationTests.cs
+++ b/Tests/IntegrationTests.Shared/ObjectIntegrationTests.cs
@@ -287,6 +287,7 @@ namespace IntegrationTests
             // Assert
             Assert.DoesNotThrow( () => realm2 = Realm.GetInstance(config2) ); // same path, different version, should auto-migrate quietly
             Assert.That(realm2.Config.SchemaVersion, Is.EqualTo(99));
+            realm2.Close();
 
         }
 

--- a/Tests/IntegrationTests.Shared/PeopleTestsBase.cs
+++ b/Tests/IntegrationTests.Shared/PeopleTestsBase.cs
@@ -14,15 +14,17 @@ namespace IntegrationTests
         protected string _databasePath;
         protected Realm _realm;
 
+        // Override this method in your test class instead of adding another <code>[SetUp]</code> because then NUnit will invoke both.
         [SetUp]
-        public void Setup()
+        public virtual void Setup()
         {
             _databasePath = Path.GetTempFileName();
             _realm = Realm.GetInstance(_databasePath);
         }
 
+        // Override this method in your test class instead of adding another <code>[TearDown]</code> because then NUnit will invoke both.
         [TearDown]
-        public void TearDown()
+        public virtual void TearDown()
         {
             _realm.Close();
             Realm.DeleteRealm(_realm.Config);

--- a/Tests/IntegrationTests.Shared/PerformanceTests.cs
+++ b/Tests/IntegrationTests.Shared/PerformanceTests.cs
@@ -26,6 +26,13 @@ namespace IntegrationTests
             _realm = Realm.GetInstance(_databasePath);
         }
 
+        [TearDown]
+        public void TearDown() 
+        {
+            _realm.Close();
+            Realm.DeleteRealm(_realm.Config);
+        }
+
         [TestCase(1000000), Explicit]
         public void BindingPerformanceTest(int count)
         {

--- a/Tests/IntegrationTests.Shared/RelationshipTests.cs
+++ b/Tests/IntegrationTests.Shared/RelationshipTests.cs
@@ -97,6 +97,12 @@ namespace IntegrationTests.Shared
             }
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            realm.Close();
+            Realm.DeleteRealm(realm.Config);
+        }
 
         [Test]
         public void TimHasATopDog()

--- a/Tests/IntegrationTests.Shared/SimpleLINQtests.cs
+++ b/Tests/IntegrationTests.Shared/SimpleLINQtests.cs
@@ -13,10 +13,8 @@ namespace IntegrationTests
 {
     class SimpleLINQtests : PeopleTestsBase
     {
-
-
-        [SetUp]
-        public new void Setup()
+        // see comment on base method why this isn't decorated with [SetUp]
+        public override void Setup()
         {
             base.Setup();
             MakeThreePeople();


### PR DESCRIPTION
It seems that on Android having open Realms between test runs introduces side-effects that randomly break tests. I've tried to hunt down every hanging realm instance and close it and add teardowns where necessary.
