### PR TITLE
Fix android.mk for external commit helper

### DIFF
--- a/wrappers/jni/Android.mk
+++ b/wrappers/jni/Android.mk
@@ -22,7 +22,7 @@ LOCAL_SRC_FILES += src/object-store/src/shared_realm.cpp
 LOCAL_SRC_FILES += src/object-store/src/impl/realm_coordinator.cpp
 LOCAL_SRC_FILES += src/object-store/src/impl/async_query.cpp
 LOCAL_SRC_FILES += src/object-store/src/impl/transact_log_handler.cpp
-LOCAL_SRC_FILES += src/object-store/src/impl/generic/external_commit_helper.cpp
+LOCAL_SRC_FILES += src/object-store/src/impl/android/external_commit_helper.cpp
 
 LOCAL_SRC_FILES += src/error_handling.cpp
 LOCAL_SRC_FILES += src/linklist_cs.cpp


### PR DESCRIPTION
#426 introduced a build error. This fixes it.
