### PR TITLE
Private #50 - Fix Failure to Close

### DIFF
--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -273,9 +273,8 @@ namespace Realms
             RuntimeHelpers.PrepareConstrainedRegions();
             try { /* Close handle in a constrained execution region */ }
             finally {
-                // do explicit native close first rather than relying on destruction
+                // Note we expect this call to also do explicit native close first rather than relying on destruction
                 // in case other handles preserve pointers - they will no longer work but don't stop closing
-                NativeSharedRealm.close(_sharedRealmHandle);
                 _sharedRealmHandle.Close();
             }
         }

--- a/Realm.Shared/native/NativeSharedRealm.cs
+++ b/Realm.Shared/native/NativeSharedRealm.cs
@@ -13,9 +13,6 @@ namespace Realms
         internal static extern IntPtr open(SchemaHandle schemaHandle, [MarshalAs(UnmanagedType.LPWStr)]string path, IntPtr pathLength, IntPtr readOnly,
             IntPtr durability, byte[] encryptionKey, UInt64 schemaVersion);
 
-        [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_close", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void close(SharedRealmHandle sharedRealm);
-
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_bind_to_managed_realm_handle", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void bind_to_managed_realm_handle(SharedRealmHandle sharedRealm, IntPtr managedRealmHandle);
 

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1914,16 +1914,8 @@ Realm.cs
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 Private #50 - Fix Failure to Close
 
-NativeSharedRealm.cs
-- close added invoking shared_realm_close
-
-
-Realm.cs
-- Close call NativeSharedRealm.close() prior to closing handle
-
-
 shared_realm_cs.cpp
-- added shared_realm_close
+- shared_realm_destroy - close the Realm as well as deleting shared handle
 
 
 InstanceTests.cs

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -70,14 +70,6 @@ REALM_EXPORT SharedRealm* shared_realm_open(Schema* schema, uint16_t* path, size
 }
 
 
-REALM_EXPORT void shared_realm_close(SharedRealm* realm)
-{
-    handle_errors([&]() {
-        (*realm)->close();
-    });
-}
-
-
 REALM_EXPORT void shared_realm_bind_to_managed_realm_handle(SharedRealm* realm, void* managed_realm_handle)
 {
     handle_errors([&]() {
@@ -88,6 +80,7 @@ REALM_EXPORT void shared_realm_bind_to_managed_realm_handle(SharedRealm* realm, 
 REALM_EXPORT void shared_realm_destroy(SharedRealm* realm)
 {
     handle_errors([&]() {
+        (*realm)->close();
         delete realm;
     });
 }


### PR DESCRIPTION
NativeSharedRealm.cs
- close added invoking shared_realm_close

Realm.cs
- Close call NativeSharedRealm.close() prior to closing handle

shared_realm_cs.cpp
- added shared_realm_close

InstanceTests.cs
- GetUniqueInstancesDifferentThreads made explicit until fixed
  to separate effect of its failure from running other tests.
