### PR TITLE
#444 Fix Analytics to match Cocoa

### DIFF
--- a/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -82,7 +82,7 @@
   </ItemGroup>
   <Import Project="..\IntegrationTests.Shared\IntegrationTests.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
+  <Import Project="..\..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
   <ItemGroup>
     <ProjectReference Include="..\..\Realm.XamarinIOS\Realm.XamarinIOS.csproj">
       <Project>{A55BD773-5A29-4B2A-9DB7-1AB1DD38B537}</Project>

--- a/Tests/IntegrationTests.XamarinIOS/packages.config
+++ b/Tests/IntegrationTests.XamarinIOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="1.29.3" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Fody" version="1.29.4" targetFramework="xamarinios10" developmentDependency="true" />
 </packages>

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1921,4 +1921,17 @@ shared_realm_cs.cpp
 InstanceTests.cs
 - GetUniqueInstancesDifferentThreads made explicit until fixed
   to separate effect of its failure from running other tests.
-  
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#444 Fix Analytics to match Cocoa
+
+RealmWeaver/Analytics.cs
+- TargetOS changed case and content to match 
+- Analytics.JsonTemplate
+  - Binding changed to "dotnet"
+  - "Langauge" : "c#" added
+- ComputeHostOSNameAndVersion 
+  - report standard lowercase ids
+  - report windows instead of Generic .net
+- TargetOS      
+  - report standard lowercase ids


### PR DESCRIPTION
RealmWeaver/Analytics.cs
- TargetOS changed case and content to match
- Analytics.JsonTemplate
  - Binding changed to "dotnet"
  - "Langauge" : "c#" added
- ComputeHostOSNameAndVersion
  - report standard lowercase ids
  - report windows instead of Generic .net
- TargetOS
  - report standard lowercase ids
