### PR TITLE
Add `.gitmodules` file to fix errors when checking out

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "external/pegtl"]
+	path = wrappers/src/object-store/external/pegtl
+	url = https://github.com/ColinH/PEGTL
+[submodule "external/catch"]
+	path = wrappers/src/object-store/external/catch
+	url = https://github.com/philsquared/Catch


### PR DESCRIPTION
Add `.gitmodules` file to fix errors reported by SourceTree when checking out releases. Somehow these definitions came across in a recent objectstore merge but the relative paths were wrong for our nested structure.

Opinions from @fealebenpae appreciated too
