### PR TITLE
Fix Windows wrappers builds for other than x86 Debug and improve reuse

### DIFF
--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -1999,3 +1999,15 @@ NuGet/NuGet.Library/Realm.targets
 
 wrappers/jni/Application.mk
 - conditionally add REALM_DEBUG to APP_CPPFLAGS
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+Fix Windows wrappers builds for other than x86 Debug and improve reuse
+
+Wrappers.vcxproj
+- android\weak_realm_notifier.cpp excluded from all configs and platforms
+- apple\weak_realm_notifier.cpp excluded from all configs and platforms
+- directory path to adjacent core libs changed from
+  $(SolutionDir)..\realm-core
+  to
+  $(ProjectDir)..\..\realm-core
+  

--- a/wrappers/wrappers.vcxproj
+++ b/wrappers/wrappers.vcxproj
@@ -32,6 +32,8 @@
     <ClCompile Include="src\object-store\src\impl\android\weak_realm_notifier.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="src\object-store\src\impl\apple\external_commit_helper.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -42,6 +44,8 @@
     <ClCompile Include="src\object-store\src\impl\apple\weak_realm_notifier.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="src\object-store\src\impl\async_query.cpp" />
     <ClCompile Include="src\object-store\src\impl\generic\external_commit_helper.cpp" />
@@ -177,7 +181,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(SolutionDir)..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture)d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(ProjectDir)..\..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture)d.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(PlatformShortName)-$(ConfigurationName)$(TargetExt)</OutputFile>
     </Link>
   </ItemDefinitionGroup>
@@ -193,7 +197,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(SolutionDir)..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture)d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(ProjectDir)..\..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture)d.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(PlatformShortName)-$(ConfigurationName)$(TargetExt)</OutputFile>
     </Link>
   </ItemDefinitionGroup>
@@ -213,7 +217,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <OutputFile>$(OutDir)$(TargetName)$(PlatformShortName)-$(ConfigurationName)$(TargetExt)</OutputFile>
-      <AdditionalDependencies>$(SolutionDir)..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(ProjectDir)..\..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -232,7 +236,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <OutputFile>$(OutDir)$(TargetName)$(PlatformShortName)-$(ConfigurationName)$(TargetExt)</OutputFile>
-      <AdditionalDependencies>$(SolutionDir)..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(ProjectDir)..\..\realm-core\build\vs2013\lib\realm$(PlatformArchitecture).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Wrappers.vcxproj
- android\weak_realm_notifier.cpp excluded from all configs and platforms
- apple\weak_realm_notifier.cpp excluded from all configs and platforms
- directory path to adjacent core libs changed from
  $(SolutionDir)..\realm-core
  to
  $(ProjectDir)....\realm-core

The latter change makes it possible to drop `wrappers` into another solution.
