### PR TITLE
#462 Ensuring Count uses direct code

### DIFF
--- a/Realm.Shared/linq/RealmResults.cs
+++ b/Realm.Shared/linq/RealmResults.cs
@@ -93,8 +93,13 @@ namespace Realms
                 var tableHandle = _realm.Metadata[ElementType].Table;
                 return (int)NativeTable.count_all(tableHandle);
             }
-            // we should be in RealmQRealmResultsr.VisitMethodCall, not here, ever, seriously!
-            throw new NotImplementedException("Count should not be invoked directly on a RealmResults created by All. LINQ will not invoke this."); 
+
+            // normally we would  be in RealmQRealmResultsr.VisitMethodCall, not here
+            // however, if someone CASTS a RealmResults<blah> variable from a Where call to 
+            // a RealmResults<blah> they change its compile-time type from IQueryable<blah> (which invokes LINQ)
+            // to RealmResults<blah> and thus ends up here.
+            // as in the unit test CountFoundWithCasting
+            return (int)NativeResults.count(ResultsHandle);
         }    
 
     }  // RealmResults

--- a/Realm.Shared/native/NativeResults.cs
+++ b/Realm.Shared/native/NativeResults.cs
@@ -32,6 +32,9 @@ namespace Realms
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_row", CallingConvention = CallingConvention.Cdecl)]
         internal static extern RowHandle get_row(ResultsHandle results, IntPtr index);
 
+        [DllImport (InteropConfig.DLL_NAME, EntryPoint = "results_count", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr count(ResultsHandle results);
+
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_clear", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void clear(ResultsHandle results);
     }

--- a/Tests/IntegrationTests.Shared/SimpleLINQtests.cs
+++ b/Tests/IntegrationTests.Shared/SimpleLINQtests.cs
@@ -79,6 +79,17 @@ namespace IntegrationTests
         }
 
 
+        // added to pick up a nasty side-effect from casting
+        [Test]
+        public void CountFoundWithCasting ()
+        {
+            var r0 = _realm.All<Person> ().Where (p => p.Score == 42.42f);
+            var r1 = r0 as RealmResults<Person>;  // this is its runtime type but r0's Compile Time type is IQueryable<Person>
+            var c0 = r1.Count ();  // invokes RealmResults<T>.Count() shortcut method
+            Assert.That (c0, Is.EqualTo (1));
+        }
+
+
         [Test]
         public void CountFails()
         {

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2050,3 +2050,13 @@ IntegrationTests.XamarinIOS.csproj
 
 SimpleLINQtests.cs
 - CountFoundItems rearranged slightly
+- CountFoundWithCasting added
+
+RealmResults.Count
+- added case for not all records, using Results to get query count
+
+NativeResults.cs
+- count added
+
+results_cs.cpp
+- results_count added

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -91,6 +91,13 @@ REALM_EXPORT void results_clear(Results* results_ptr)
   });
 }
 
+REALM_EXPORT size_t results_count(Results* results_ptr)
+{
+  return handle_errors([&]() {
+      return results_ptr->size();
+  });
+}
+
 REALM_EXPORT SortOrderWrapper* sortorder_create_for_table(Table* table_ptr)
 {
   return handle_errors([&]() {


### PR DESCRIPTION
SimpleLINQtests.cs
- CountFoundItems rearranged slightly

Very minor test change only enough to prove with single-stepping that this **is** working as designed and is **not** creating a `Results` in ObjectStore. If you break at the first part of `CountFoundItems` and have breaks in appropriate places you can see it 
- Creates a `RealmResults` but **not** a `RealmResultsHandle` (they are only on-demand for enumeration)
- hits `VisitMethodCall` on the `Count`
- recurses to `VisitMethodCall` to evaluate the `Where` stashed in the LINQ tree, **building the query**
- passes the query into `NativeQuery.count` which invokes (in wrappers) a core `Query::count`
