### PR TITLE
#499 Add Readonly

### DIFF
--- a/Realm.PCL/Realm.PCL.csproj
+++ b/Realm.PCL/Realm.PCL.csproj
@@ -85,6 +85,9 @@
     <Compile Include="..\Realm.Shared\weaving\IRealmObjectHelper.cs">
       <Link>IRealmObjectHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Realm.Shared\exceptions\RealmInvalidTransactionException.cs">
+      <Link>Exceptions\RealmInvalidTransactionException.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Realm.Shared/Realm.Shared.projitems
+++ b/Realm.Shared/Realm.Shared.projitems
@@ -61,6 +61,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)native\NativeSortOrder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)weaving\IRealmObjectHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)handles\AsyncQueryCancellationTokenHandle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)exceptions\RealmInvalidTransactionException.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)weaving\" />

--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -123,7 +123,7 @@ namespace Realms
 
             var srHandle = new SharedRealmHandle();
 
-            var readOnly = MarshalHelpers.BoolToIntPtr(false);
+            var readOnly = MarshalHelpers.BoolToIntPtr(config.ReadOnly);
             var durability = MarshalHelpers.BoolToIntPtr(false);
             var databasePath = config.DatabasePath;
             IntPtr srPtr = IntPtr.Zero;

--- a/Realm.Shared/RealmConfiguration.cs
+++ b/Realm.Shared/RealmConfiguration.cs
@@ -41,6 +41,11 @@ namespace Realms
         public readonly bool ShouldDeleteIfMigrationNeeded;
 
         /// <summary>
+        /// Flag to indicate Realm is opened readonly so can open from locked locations such as bundled with an application.
+        /// </summary>
+        public bool ReadOnly;
+
+        /// <summary>
         /// The full path of any realms opened with this configuration, may be overriden by passing in a separate name.
         /// </summary>
         public string DatabasePath {get; private set;}

--- a/Realm.Shared/exceptions/RealmException.cs
+++ b/Realm.Shared/exceptions/RealmException.cs
@@ -46,6 +46,9 @@ namespace Realms {
                 case RealmExceptionCodes.RealmMismatchedConfig:
                     return new RealmMismatchedConfigException(message);
 
+                case RealmExceptionCodes.RealmInvalidTransaction:
+                    return new RealmInvalidTransactionException(message);
+
                 case RealmExceptionCodes.RealmFormatUpgradeRequired :
                     return new RealmMigrationNeededException(message);
 

--- a/Realm.Shared/exceptions/RealmExceptionCodes.cs
+++ b/Realm.Shared/exceptions/RealmExceptionCodes.cs
@@ -16,6 +16,7 @@ namespace Realms {
         RealmOutOfMemory = 6,
         RealmPermissionDenied = 7,
         RealmMismatchedConfig = 9,
+        RealmInvalidTransaction = 10,
         RealmFormatUpgradeRequired = 13,
 
         StdArgumentOutOfRange = 100,

--- a/Realm.Shared/exceptions/RealmInvalidTransactionException.cs
+++ b/Realm.Shared/exceptions/RealmInvalidTransactionException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Realms
+{
+    public class RealmInvalidTransactionException : RealmException
+    {
+        public RealmInvalidTransactionException(string message) : base(message)
+        {
+        }
+    }
+}
+

--- a/Tests/IntegrationTests.Shared/ObjectIntegrationTests.cs
+++ b/Tests/IntegrationTests.Shared/ObjectIntegrationTests.cs
@@ -262,7 +262,7 @@ namespace IntegrationTests
         }
 
         [Test]
-        [Ignore("this tests for a condition thst's only available under manual migrations, which we lack")]
+        [Ignore("this tests for a condition that's only available under manual migrations, which we lack")]
         public void TriggerMigrationBySchemaEditing()
         {
             

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2106,3 +2106,31 @@ FodyWeavers.xml.install.xdt
 FodyWeavers.xml.uninstall.xdt
 - added
 
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#499 Add Readonly
+
+RealmConfiguration.cs
+- ReadOnly added
+
+Realm.cs
+- GetInstance - pass in readOnly flag from RealmConfifuraion
+
+RealmExceptionCodes.cs
+- RealmExceptionCodes - added RealmInvalidTransaction
+
+RealmException.cs
+- Create add case for RealmInvalidTransaction
+
+RealmInvalidTransactionException.cs
+- added
+
+Realm.Shared.csproj
+- added RealmInvalidTransactionException
+
+Realm.PCL.csproj
+- added link to RealmInvalidTransactionException
+ConfigurationTests.cs
+- ReadOnlyRealmsArentWritable added
+- ReadOnlyFilesMustExist added
+- ReadOnlyRealmsWillNotAutoMigrate added
+


### PR DESCRIPTION
RealmConfiguration.cs
- ReadOnly added

Realm.cs
- GetInstance - pass in readOnly flag from RealmConfifuraion

RealmExceptionCodes.cs
- RealmExceptionCodes - added RealmInvalidTransaction

RealmException.cs
- Create add case for RealmInvalidTransaction

RealmInvalidTransactionException.cs
- added

Realm.Shared.csproj
- added RealmInvalidTransactionException

Realm.PCL.csproj
- added link to RealmInvalidTransactionException
  ConfigurationTests.cs
- ReadOnlyRealmsArentWritable added
- ReadOnlyFilesMustExist added
- ReadOnlyRealmsWillNotAutoMigrate added
