### PR TITLE
Change ios package in Xamarin Component to unified

### DIFF
--- a/component/component.yaml
+++ b/component/component.yaml
@@ -22,7 +22,7 @@ publisher-url: https://www.realm.io
 packages: 
   android:
     - Realm, Version=0.74.1
-  ios:
+  ios-unified:
     - Realm, Version=0.74.1
 version: 0.74.1
 ...


### PR DESCRIPTION
Otherwise the component shows up as using the legacy 32bit API on Xamarin.iOS.