### PR TITLE
Ensure thread safety in the Android WeakRealmNotifier

### DIFF
--- a/wrappers/src/object-store/src/impl/android/external_commit_helper.cpp
+++ b/wrappers/src/object-store/src/impl/android/external_commit_helper.cpp
@@ -27,18 +27,23 @@
 #include <sys/time.h>
 #include <system_error>
 #include <unistd.h>
-#include <android/log.h>
 
-#include "../../../../debug.hpp"
+#ifdef __ANDROID__
+#include <android/log.h>
+#define ANDROID_LOG __android_log_print
+#else
+#define ANDROID_LOG(...)
+#endif
+
 #include <errno.h>
 #include <sstream>
 
 using namespace realm;
 using namespace realm::_impl;
 
-#define LOG(fmt...) do { \
+#define LOGE(fmt...) do { \
     fprintf(stderr, fmt); \
-    __android_log_print(ANDROID_LOG_ERROR, "REALM", fmt); \
+    ANDROID_LOG(ANDROID_LOG_ERROR, "REALM", fmt); \
 } while (0)
 
 namespace {
@@ -133,11 +138,11 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
             listen();
         }
         catch (std::exception const& e) {
-            LOG("uncaught exception in notifier thread: %s: %s\n", typeid(e).name(), e.what());
+            LOGE("uncaught exception in notifier thread: %s: %s\n", typeid(e).name(), e.what());
             throw;
         }
         catch (...) {
-            LOG("uncaught exception in notifier thread\n");
+            LOGE("uncaught exception in notifier thread\n");
             throw;
         }
     });

--- a/wrappers/src/object-store/src/impl/android/weak_realm_notifier.hpp
+++ b/wrappers/src/object-store/src/impl/android/weak_realm_notifier.hpp
@@ -18,6 +18,8 @@
 
 #include "impl/weak_realm_notifier_base.hpp"
 
+#include <atomic>
+
 namespace realm {
 class Realm;
 
@@ -26,7 +28,7 @@ namespace _impl {
 class WeakRealmNotifier : public WeakRealmNotifierBase {
 public:
     WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool cache);
-    ~WeakRealmNotifier();
+    ~WeakRealmNotifier() { close(); }
 
     WeakRealmNotifier(WeakRealmNotifier&&);
     WeakRealmNotifier& operator=(WeakRealmNotifier&&);
@@ -38,9 +40,11 @@ public:
     void notify();
 
 private:
+    void close();
+    
     static int looper_callback(int fd, int events, void* data); 
 
-    bool m_thread_has_looper = false;
+    std::atomic<bool> m_thread_has_looper;
 
     // pipe file descriptor pair we use to signal ALooper
     struct {


### PR DESCRIPTION
WeakRealmNotifier's move assignment operator could be invoked on another thread so we need to make sure to remove ourselves from the looper always on the looper thread.