### PR TITLE
#553 IOS Build for Armv7s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * File format of Realm files is changed. Files will be automatically upgraded but opening a Realm file with older versions of Realm is not possible.
 * `RealmResults<T>` no longer implicitly implements `INotifyCollectionChanged`.
 
+### Minor Fixes
+* ARMv7s builds are now supported for IOS devices (issue #553)
+
 Work in progress
 ----------------
 

--- a/Realm.XamarinIOS/libwrappers.linkwith.cs
+++ b/Realm.XamarinIOS/libwrappers.linkwith.cs
@@ -19,4 +19,4 @@
 using System;
 using ObjCRuntime;
 
-[assembly: LinkWith ("libwrappers.a", LinkTarget.ArmV7 | LinkTarget.Simulator | LinkTarget.Simulator64 | LinkTarget.Arm64, SmartLink = true, LinkerFlags = "-lstdc++ -lz")]
+[assembly: LinkWith ("libwrappers.a", LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Simulator | LinkTarget.Simulator64 | LinkTarget.Arm64, SmartLink = true, LinkerFlags = "-lstdc++ -lz")]

--- a/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARMv7, ARMv7s, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
@@ -56,7 +56,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARMv7, ARMv7s, ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2135,7 +2135,7 @@ ConfigurationTests.cs
 - ReadOnlyRealmsWillNotAutoMigrate added
 
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-#541 Android crash in GetInstance
+#541 Android crash in GetInstance - Better notification of failed weave
 
 Realm.cs
 - Realm static ctor
@@ -2145,4 +2145,15 @@ Realm.cs
     
 
   
-  
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#553 IOS Build for Armv7s
+
+IntegrationTests.XamarinIOS
+- Build - IOS Build - Supported Architextures changed from ARMV7+ARM64 to   ARMv7+ARMv7s+ARM64
+
+
+libwrappers.linkwith.cs
+- added LinkTarget.ArmV7s
+
+wrappers.xcodeproj
+- extended ARCHS_STANDARD with armv7s (no longer included in "standard" as of XCode 6)

--- a/wrappers/wrappers.xcodeproj/project.pbxproj
+++ b/wrappers/wrappers.xcodeproj/project.pbxproj
@@ -460,6 +460,10 @@
 		48D1013D1B39902E004A4B2C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				EXECUTABLE_PREFIX = lib;
@@ -483,6 +487,10 @@
 		48D1013E1B39902E004A4B2C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				EXECUTABLE_PREFIX = lib;


### PR DESCRIPTION
IntegrationTests.XamarinIOS
- Build - IOS Build - Supported Architextures changed from ARMV7+ARM64 to   ARMv7+ARMv7s+ARM64

libwrappers.linkwith.cs
- added LinkTarget.ArmV7s

wrappers.xcodeproj
- extended ARCHS_STANDARD with armv7s (no longer included in "standard" as of XCode 6)