### PR TITLE
WeakRealmNotifier should use POSIX write correctly

### DIFF
--- a/wrappers/src/object-store/src/impl/android/weak_realm_notifier.cpp
+++ b/wrappers/src/object-store/src/impl/android/weak_realm_notifier.cpp
@@ -99,7 +99,7 @@ void WeakRealmNotifier::notify()
         // to do so we allocate a weak pointer on the heap and send its address over a pipe.
         // the other end of the pipe is read by the realm thread. when it's done with the pointer, it deletes it.
         auto realm_ptr = new std::weak_ptr<Realm>(realm());
-        if (write(m_message_pipe.write, realm_ptr, sizeof(realm_ptr)) != sizeof(realm_ptr)) {
+        if (write(m_message_pipe.write, &realm_ptr, sizeof(realm_ptr)) != sizeof(realm_ptr)) {
             delete realm_ptr;
             LOGE("Buffer overrun when writing to WeakRealmNotifier's ALooper message pipe.");
         }


### PR DESCRIPTION
We need to call write(2) with the address of the buffer, not the buffer itself, d'oh