### PR TITLE
Add automatic support for INotifyPropertyChanged via weaver.

### DIFF
--- a/Tests/WeaverTests/AssemblyToProcess/TestObjects.cs
+++ b/Tests/WeaverTests/AssemblyToProcess/TestObjects.cs
@@ -18,11 +18,38 @@
 
 using System;
 using Realms;
+using System.ComponentModel;
 
 namespace AssemblyToProcess
 {
     public class AllTypesObject : RealmObject
     {
+        public char CharProperty { get; set; }
+        public byte ByteProperty { get; set; }
+        public short Int16Property { get; set; }
+        public int Int32Property { get; set; }
+        public long Int64Property { get; set; }
+        public float SingleProperty { get; set; }
+        public double DoubleProperty { get; set; }
+        public bool BooleanProperty { get; set; }
+
+        public string StringProperty { get; set; }
+        public DateTimeOffset DateTimeOffsetProperty { get; set; }
+
+        public char? NullableCharProperty { get; set; }
+        public byte? NullableByteProperty { get; set; }
+        public short? NullableInt16Property { get; set; }
+        public int? NullableInt32Property { get; set; }
+        public long? NullableInt64Property { get; set; }
+        public float? NullableSingleProperty { get; set; }
+        public double? NullableDoubleProperty { get; set; }
+        public bool? NullableBooleanProperty { get; set; }
+    }
+
+    public class AllTypesObjectPropertyChanged : RealmObject, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
         public char CharProperty { get; set; }
         public byte ByteProperty { get; set; }
         public short Int16Property { get; set; }

--- a/Tests/WeaverTests/RealmWeaver.Tests/RealmWeaver.Tests.csproj
+++ b/Tests/WeaverTests/RealmWeaver.Tests/RealmWeaver.Tests.csproj
@@ -11,6 +11,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,6 +55,9 @@
       <HintPath>..\..\..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PropertyChanged.Fody">
+      <HintPath>..\..\..\packages\PropertyChanged.Fody.1.51.0\PropertyChanged.Fody.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -61,6 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="WeaverOptions.cs" />
     <Compile Include="WeaverTests.cs" />
     <Compile Include="Verifier.cs" />
   </ItemGroup>
@@ -80,6 +86,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/Tests/WeaverTests/RealmWeaver.Tests/WeaverOptions.cs
+++ b/Tests/WeaverTests/RealmWeaver.Tests/WeaverOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    public enum WeaverOptions
+    {
+        RealmOnlyNoPropertyChanged,
+        RealmBeforePropertyChanged,
+        RealmAfterPropertyChanged
+    }
+}

--- a/Tests/WeaverTests/RealmWeaver.Tests/packages.config
+++ b/Tests/WeaverTests/RealmWeaver.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FodyCecil" version="1.29.4" targetFramework="net45" developmentDependency="true" userInstalled="true" />
+  <package id="Fody" version="1.29.2" targetFramework="net45" developmentDependency="true" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
+  <package id="PropertyChanged.Fody" version="1.51.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Hi folks,

I've added basic support for INotifyPropertyChanged, having checked out and experimented with Realm, I was hoping for something I could drop in next to my UI code and see live updates. This seems to do the trick.

I had initially tried to use PropertyChanged.Fody in conjunction with Realm, but once an object became managed, the early return short-circuited raising the property changed at the end of the setter.

This seems to be related to the following issue: https://github.com/realm/realm-dotnet/issues/253

Cheers,
Joe