### PR TITLE
Standalone objects should not crash on equals

### DIFF
--- a/Realm.Shared/RealmObject.cs
+++ b/Realm.Shared/RealmObject.cs
@@ -785,6 +785,10 @@ namespace Realms
             if (this.GetType() != obj.GetType())
                 return false;
 
+            // standalone objects cannot participate in the same store check
+            if (!IsManaged)
+                return false;
+
             // Return true if the fields match. 
             // Note that the base class is not invoked because it is 
             // System.Object, which defines Equals as reference equality. 

--- a/Tests/IntegrationTests.Shared/StandAloneObjectTests.cs
+++ b/Tests/IntegrationTests.Shared/StandAloneObjectTests.cs
@@ -77,5 +77,13 @@ namespace IntegrationTests.Shared
                 Assert.That(p.IsInteresting);
             }
         }
+
+        [Test]
+        public void RealmObject_WhenStandalone_ShouldHaveDefaultEqualsImplementation()
+        {
+            var otherPerson = new Person();
+
+            Assert.DoesNotThrow(() => _person.Equals(otherPerson));
+        }
     }
 }


### PR DESCRIPTION
Fix #587