### PR TITLE
Make wrappers build on Windows again

### DIFF
--- a/wrappers/src/object-store/src/impl/generic/external_commit_helper.cpp
+++ b/wrappers/src/object-store/src/impl/generic/external_commit_helper.cpp
@@ -27,18 +27,18 @@ using namespace realm;
 using namespace realm::_impl;
 
 ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
-//: m_parent(parent)
-//, m_history(realm::make_client_history(parent.get_path(), parent.get_encryption_key().data()))
-//, m_sg(*m_history, parent.is_in_memory() ? SharedGroup::durability_MemOnly : SharedGroup::durability_Full,
-//       parent.get_encryption_key().data())
-//, m_thread(std::async(std::launch::async, [=] {
-//    m_sg.begin_read();
-//    while (m_sg.wait_for_change()) {
-//        m_sg.end_read();
-//        m_sg.begin_read();
-//        m_parent.on_change();
-//    }
-//}))
+: m_parent(parent)
+, m_history(realm::make_client_history(parent.get_path(), parent.get_encryption_key().data()))
+, m_sg(*m_history, parent.is_in_memory() ? SharedGroup::durability_MemOnly : SharedGroup::durability_Full,
+       parent.get_encryption_key().data())
+, m_thread(std::async(std::launch::async, [=] {
+    m_sg.begin_read();
+    //while (m_sg.wait_for_change()) {
+    //    m_sg.end_read();
+    //    m_sg.begin_read();
+    //    m_parent.on_change();
+    //}
+}))
 {
 }
 

--- a/wrappers/wrappers.vcxproj
+++ b/wrappers/wrappers.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="src\error_handling.cpp" />
     <ClCompile Include="src\linklist_cs.cpp" />
     <ClCompile Include="src\marshalling.cpp" />
+    <ClCompile Include="src\object-store\src\collection_notifications.cpp" />
     <ClCompile Include="src\object-store\src\impl\android\external_commit_helper.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -47,9 +48,12 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="src\object-store\src\impl\async_query.cpp" />
+    <ClCompile Include="src\object-store\src\impl\collection_change_builder.cpp" />
+    <ClCompile Include="src\object-store\src\impl\collection_notifier.cpp" />
     <ClCompile Include="src\object-store\src\impl\generic\external_commit_helper.cpp" />
+    <ClCompile Include="src\object-store\src\impl\list_notifier.cpp" />
     <ClCompile Include="src\object-store\src\impl\realm_coordinator.cpp" />
+    <ClCompile Include="src\object-store\src\impl\results_notifier.cpp" />
     <ClCompile Include="src\object-store\src\impl\transact_log_handler.cpp" />
     <ClCompile Include="src\object-store\src\index_set.cpp" />
     <ClCompile Include="src\object-store\src\list.cpp" />
@@ -72,15 +76,19 @@
     <ClInclude Include="src\error_handling.hpp" />
     <ClInclude Include="src\marshalling.hpp" />
     <ClInclude Include="src\object-store\src\binding_context.hpp" />
+    <ClInclude Include="src\object-store\src\collection_notifications.hpp" />
     <ClInclude Include="src\object-store\src\impl\android\external_commit_helper.hpp" />
     <ClInclude Include="src\object-store\src\impl\android\weak_realm_notifier.hpp" />
     <ClInclude Include="src\object-store\src\impl\apple\external_commit_helper.hpp" />
     <ClInclude Include="src\object-store\src\impl\apple\weak_realm_notifier.hpp" />
-    <ClInclude Include="src\object-store\src\impl\async_query.hpp" />
+    <ClInclude Include="src\object-store\src\impl\collection_change_builder.hpp" />
+    <ClInclude Include="src\object-store\src\impl\collection_notifier.hpp" />
     <ClInclude Include="src\object-store\src\impl\external_commit_helper.hpp" />
     <ClInclude Include="src\object-store\src\impl\generic\external_commit_helper.hpp" />
     <ClInclude Include="src\object-store\src\impl\generic\weak_realm_notifier.hpp" />
+    <ClInclude Include="src\object-store\src\impl\list_notifier.hpp" />
     <ClInclude Include="src\object-store\src\impl\realm_coordinator.hpp" />
+    <ClInclude Include="src\object-store\src\impl\results_notifier.hpp" />
     <ClInclude Include="src\object-store\src\impl\transact_log_handler.hpp" />
     <ClInclude Include="src\object-store\src\impl\weak_realm_notifier.hpp" />
     <ClInclude Include="src\object-store\src\impl\weak_realm_notifier_base.hpp" />
@@ -173,7 +181,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WRAPPERS_EXPORTS;HAVE_STRUCT_TIMESPEC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WRAPPERS_EXPORTS;HAVE_STRUCT_TIMESPEC;__unused=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\realm-core\src;..\..\realm-core\src\win32\pthread;src\object-store\src;src\object-store\src\impl;src\object-store\src\impl\generic;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/DPTW32_STATIC_LIB /DREALM_DEBUG /DREALM_ENABLE_REPLICATION %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -189,7 +197,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WRAPPERS_EXPORTS;HAVE_STRUCT_TIMESPEC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;WRAPPERS_EXPORTS;HAVE_STRUCT_TIMESPEC;__unused=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\realm-core\src;..\..\realm-core\src\win32\pthread;src\object-store\src;src\object-store\src\impl;src\object-store\src\impl\generic;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/DPTW32_STATIC_LIB /DREALM_DEBUG /DREALM_ENABLE_REPLICATION %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/wrappers/wrappers.vcxproj.filters
+++ b/wrappers/wrappers.vcxproj.filters
@@ -117,14 +117,26 @@
     <ClCompile Include="src\object-store\src\impl\apple\weak_realm_notifier.cpp">
       <Filter>Source Files\object-store\impl\apple</Filter>
     </ClCompile>
-    <ClCompile Include="src\object-store\src\impl\async_query.cpp">
-      <Filter>Source Files\object-store\impl</Filter>
-    </ClCompile>
     <ClCompile Include="src\debug.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\results_cs.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\object-store\src\impl\collection_change_builder.cpp">
+      <Filter>Source Files\object-store\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="src\object-store\src\impl\collection_notifier.cpp">
+      <Filter>Source Files\object-store\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="src\object-store\src\collection_notifications.cpp">
+      <Filter>Source Files\object-store</Filter>
+    </ClCompile>
+    <ClCompile Include="src\object-store\src\impl\list_notifier.cpp">
+      <Filter>Source Files\object-store\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="src\object-store\src\impl\results_notifier.cpp">
+      <Filter>Source Files\object-store\impl</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -200,9 +212,6 @@
     <ClInclude Include="src\object-store\src\impl\generic\weak_realm_notifier.hpp">
       <Filter>Header Files\object-store\impl\generic</Filter>
     </ClInclude>
-    <ClInclude Include="src\object-store\src\impl\async_query.hpp">
-      <Filter>Header Files\object-store</Filter>
-    </ClInclude>
     <ClInclude Include="src\object-store\src\impl\weak_realm_notifier.hpp">
       <Filter>Header Files\object-store\impl</Filter>
     </ClInclude>
@@ -211,6 +220,21 @@
     </ClInclude>
     <ClInclude Include="src\debug.hpp">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\object-store\src\impl\collection_change_builder.hpp">
+      <Filter>Header Files\object-store\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="src\object-store\src\impl\collection_notifier.hpp">
+      <Filter>Header Files\object-store\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="src\object-store\src\collection_notifications.hpp">
+      <Filter>Header Files\object-store</Filter>
+    </ClInclude>
+    <ClInclude Include="src\object-store\src\impl\list_notifier.hpp">
+      <Filter>Header Files\object-store\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="src\object-store\src\impl\results_notifier.hpp">
+      <Filter>Header Files\object-store\impl</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This allows us to build wrappers with VS again. Note that the external commit helper is broken, but we're not using it on Windows anywhere so it doesn't break anything at the moment.