### PR TITLE
Fix woven code so that the Xamarin linker likes it

### DIFF
--- a/Realm.Shared/Attributes.cs
+++ b/Realm.Shared/Attributes.cs
@@ -42,9 +42,9 @@ namespace Realms
         }
     }
 
-    internal class WovenAttribute : Attribute
+    public class WovenAttribute : Attribute
     {
-        public Type HelperType { get; private set; }
+        internal Type HelperType { get; private set; }
 
         public WovenAttribute(Type helperType)
         {
@@ -53,7 +53,7 @@ namespace Realms
     }
 
     [AttributeUsage(AttributeTargets.Property)]
-    internal class WovenPropertyAttribute : Attribute
+    public class WovenPropertyAttribute : Attribute
     {
         internal string BackingFieldName { get; private set; }
 

--- a/RealmWeaver/ModuleWeaver.cs
+++ b/RealmWeaver/ModuleWeaver.cs
@@ -376,12 +376,13 @@ public class ModuleWeaver
 
     private TypeDefinition WeaveRealmObjectHelper(TypeDefinition realmObjectType)
     {
-        var helperType = new TypeDefinition(realmObjectType.Namespace, "RealmHelper",
-            TypeAttributes.Class | TypeAttributes.NestedPrivate, ModuleDefinition.ImportReference(System_Object));
+        var helperType = new TypeDefinition(null, "RealmHelper",
+                                            TypeAttributes.Class | TypeAttributes.NestedPrivate | TypeAttributes.BeforeFieldInit,
+                                            ModuleDefinition.ImportReference(System_Object));
 
         helperType.Interfaces.Add(ModuleDefinition.ImportReference(RealmAssembly.MainModule.GetType("Realms.Weaving.IRealmObjectHelper")));
 
-        var createInstance = new MethodDefinition("CreateInstance", MethodAttributes.Public | MethodAttributes.Virtual, ModuleDefinition.ImportReference(RealmObject));
+        var createInstance = new MethodDefinition("CreateInstance", MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.Virtual | MethodAttributes.NewSlot, ModuleDefinition.ImportReference(RealmObject));
         {
             var il = createInstance.Body.GetILProcessor();
             il.Emit(OpCodes.Newobj, realmObjectType.GetConstructors().Single(c => c.Parameters.Count == 0 && !c.IsStatic));

--- a/Tests/IntegrationTests.XamarinAndroid/IntegrationTests.XamarinAndroid.csproj
+++ b/Tests/IntegrationTests.XamarinAndroid/IntegrationTests.XamarinAndroid.csproj
@@ -26,7 +26,6 @@
     <DefineConstants>DEBUG;ENABLE_INTERNAL_NON_PCL_TESTS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>

--- a/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -20,7 +20,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <MtouchArch>i386</MtouchArch>
-    <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
@@ -36,7 +35,6 @@
     <MtouchArch>ARMv7, ARMv7s, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchLink>None</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <Optimize>true</Optimize>
@@ -46,7 +44,6 @@
     <WarningLevel>4</WarningLevel>
     <MtouchArch>i386</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <MtouchLink>None</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -62,7 +59,6 @@
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchLink>None</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
The Xamarin linker would mess up the parameter of the `WovenAttribute` constructor because the woven helper type had a namespace.

Fixes #577