### PR TITLE
Fix `attempting to JIT compile` exception in Notifications API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Minor Changes
 * The `Realm` static constructor will no longer throw a `TypeLoadException` when there is an active `System.Reflection.Emit.AssemblyBuilder` in the current `AppDomain`.
+* Fixed `Attempting to JIT compile` exception when using the Notifications API on iOS devices.
 
 0.76.0 (2016-06-09)
 -------------------

--- a/NuGet/NuGet.Library/Realm.nuspec
+++ b/NuGet/NuGet.Library/Realm.nuspec
@@ -17,6 +17,7 @@
     <tags>Realm database db persistence sqlite</tags>
     <dependencies>
       <dependency id="Fody" version="1.29.4"/>
+      <dependency id="DotNetCross.Memory.Unsafe" version="0.2.2"/>
     </dependencies>
   </metadata>
   <files>

--- a/Realm.Win32/Realm.Win32.csproj
+++ b/Realm.Win32/Realm.Win32.csproj
@@ -65,6 +65,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetCross.Memory.Unsafe, Version=0.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetCross.Memory.Unsafe.0.2.2\lib\net11\DotNetCross.Memory.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -97,6 +101,9 @@
       <Project>{A1E763AD-24B9-4D6B-AACA-282BB33E350F}</Project>
       <Name>wrappers</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Realm.Shared\Realm.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Realm.Win32/packages.config
+++ b/Realm.Win32/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="net452" />
+</packages>

--- a/Realm.XamarinAndroid/Realm.XamarinAndroid.csproj
+++ b/Realm.XamarinAndroid/Realm.XamarinAndroid.csproj
@@ -36,6 +36,10 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetCross.Memory.Unsafe, Version=0.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetCross.Memory.Unsafe.0.2.2\lib\dotnet\DotNetCross.Memory.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />
@@ -52,6 +56,9 @@
       <Project>{C3578A7B-09A6-4444-9383-0DEAFA4958BD}</Project>
       <Name>RealmWeaver.Fody</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Realm.Shared\Realm.Shared.projitems" Label="Shared" Condition="Exists('..\Realm.Shared\Realm.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Realm.XamarinAndroid/packages.config
+++ b/Realm.XamarinAndroid/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="monoandroid60" />
+</packages>

--- a/Realm.XamarinIOS/Realm.XamarinIOS.csproj
+++ b/Realm.XamarinIOS/Realm.XamarinIOS.csproj
@@ -63,6 +63,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetCross.Memory.Unsafe, Version=0.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetCross.Memory.Unsafe.0.2.2\lib\dotnet\DotNetCross.Memory.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
@@ -96,5 +100,8 @@
       <Project>{C3578A7B-09A6-4444-9383-0DEAFA4958BD}</Project>
       <Name>RealmWeaver.Fody</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Realm.XamarinIOS/packages.config
+++ b/Realm.XamarinIOS/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="xamarinios10" />
-  <package id="Fody" version="1.29.4" targetFramework="xamarinios10" developmentDependency="true" />
 </packages>

--- a/Tests/IntegrationTests.XamarinAndroid/IntegrationTests.XamarinAndroid.csproj
+++ b/Tests/IntegrationTests.XamarinAndroid/IntegrationTests.XamarinAndroid.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,6 +40,10 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetCross.Memory.Unsafe, Version=0.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetCross.Memory.Unsafe.0.2.2\lib\dotnet\DotNetCross.Memory.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />

--- a/Tests/IntegrationTests.XamarinAndroid/packages.config
+++ b/Tests/IntegrationTests.XamarinAndroid/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DotNetCross.Memory.Unsafe" version="0.2.2" targetFramework="monoandroid51" />
   <package id="Fody" version="1.29.4" targetFramework="MonoAndroid44" developmentDependency="true" />
 </packages>

--- a/Tests/IntegrationTests.XamarinIOS/Info.plist
+++ b/Tests/IntegrationTests.XamarinIOS/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>IntegrationTests.XamarinIOS</string>
-	<key>CFBundleIdentifier</key>
-	<string>com.companyname.IntegrationTests.XamarinIOS</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
@@ -21,5 +19,9 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>CFBundleName</key>
+	<string>IntegrationTests.XamarinIOS</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.realm.xamarintests</string>
 </dict>
 </plist>

--- a/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -29,6 +29,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
+    <DefineConstants>ENABLE_INTERNAL_NON_PCL_TESTS;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
@@ -50,7 +51,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;ENABLE_INTERNAL_NON_PCL_TESTS;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -62,6 +62,10 @@
     <MtouchDebug>true</MtouchDebug>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetCross.Memory.Unsafe, Version=0.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetCross.Memory.Unsafe.0.2.2\lib\dotnet\DotNetCross.Memory.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
The notification payload on Realm collections contains generic structures that need to be marshalled. Mono JIT compiles the wrapper code that marshals a type that the AOT compiler hasn't emitted a `PtrToStructure`/`StructureToPtr` method pair for, but the AOT compiler does not do so for generic types as their size is only known when the generic is closed.

Fixes #620  