### PR TITLE
Ignore types from dynamic assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.76.1 (TBD)
+-------------------
+
+### Minor Changes
+* The `Realm` static constructor will no longer throw a `TypeLoadException` when there is an active `System.Reflection.Emit.AssemblyBuilder` in the current `AppDomain`.
+
 0.76.0 (2016-06-09)
 -------------------
 

--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -55,6 +55,10 @@ namespace Realms
         static Realm()
         {
             RealmObjectClasses = AppDomain.CurrentDomain.GetAssemblies()
+                                          #if !__IOS__
+                                          // we need to exclude dynamic assemblies. see https://bugzilla.xamarin.com/show_bug.cgi?id=39679
+                                          .Where(a => !(a is System.Reflection.Emit.AssemblyBuilder))
+                                          #endif
                                           .SelectMany(a => a.GetTypes())
                                           .Where(t => t.IsSubclassOf(typeof(RealmObject)))
                                           .ToArray();


### PR DESCRIPTION
Calling `Assembly.GetTypes()` on an assembly that is a `System.Reflection.Emit.AssemblyBuilder` throws an exception if any of the types in the assembly aren't fully built yet.

We don't care about dynamic assemblies because there's no way for them to be woven anyway.