### PR TITLE
Refactor and extract AssemblyInfo.cs files

### DIFF
--- a/Realm.PCL/Properties/AssemblyInfo.cs
+++ b/Realm.PCL/Properties/AssemblyInfo.cs
@@ -1,28 +1,21 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
-// Information about this assembly is defined by the following attributes.
-// Change them to the values specific to your project.
+using System.Reflection;
 
 [assembly: AssemblyTitle("Realm.PCL")]
-[assembly: AssemblyDescription("Realm is a mobile database: a replacement for SQLite")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCopyright("Copyright © 2016 Realm")]
-[assembly: AssemblyCompany("Realm Inc.")]
-[assembly: AssemblyProduct("Realm C#")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-
-// The following attributes are used to specify the signing key for the assembly,
-// if desired. See the Mono documentation for more information about signing.
-
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion(("0.76.0.0"))]
-[assembly: AssemblyFileVersion(("0.76.0.0"))]

--- a/Realm.PCL/Realm.PCL.csproj
+++ b/Realm.PCL/Realm.PCL.csproj
@@ -29,6 +29,9 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\RealmAssemblyInfo.cs">
+      <Link>Properties\RealmAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RealmPCLHelpers.cs" />
     <Compile Include="TransactionPCL.cs" />

--- a/Realm.Win32/Properties/AssemblyInfo.cs
+++ b/Realm.Win32/Properties/AssemblyInfo.cs
@@ -1,41 +1,23 @@
-﻿using System.Reflection;
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Realm.Win32")]
-[assembly: AssemblyDescription("Realm is a mobile database: a replacement for SQLite")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCopyright("Copyright © 2016 Realm")]
-[assembly: AssemblyCompany("Realm Inc.")]
-[assembly: AssemblyProduct("Realm C#")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("c211ede7-cc8e-4f53-a9df-0b105a350bbf")]
-
-
-
 [assembly: InternalsVisibleTo("IntegrationTests.Win32")]
-[assembly: InternalsVisibleTo("Playground.Win32")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion(("0.76.0.0"))]
-[assembly: AssemblyFileVersion(("0.76.0.0"))]

--- a/Realm.Win32/Realm.Win32.csproj
+++ b/Realm.Win32/Realm.Win32.csproj
@@ -73,6 +73,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\RealmAssemblyInfo.cs">
+      <Link>Properties\RealmAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="InteropConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Realm.XamarinAndroid/Realm.XamarinAndroid.csproj
+++ b/Realm.XamarinAndroid/Realm.XamarinAndroid.csproj
@@ -44,6 +44,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\RealmAssemblyInfo.cs">
+      <Link>Properties\RealmAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="InteropConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Realm.XamarinIOS/Properties/AssemblyInfo.cs
+++ b/Realm.XamarinIOS/Properties/AssemblyInfo.cs
@@ -1,39 +1,28 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;  // for InternalsVisibleTo
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
-using Foundation;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 // This attribute allows you to mark your assemblies as “safe to link”.
 // When the attribute is present, the linker—if enabled—will process the assembly
 // even if you’re using the “Link SDK assemblies only” option, which is the default for device builds.
-
-[assembly: LinkerSafe]
-
-// Information about this assembly is defined by the following attributes.
-// Change them to the values specific to your project.
+[assembly: Foundation.LinkerSafe]
 
 [assembly: AssemblyTitle("Realm.XamarinIOS")]
-[assembly: AssemblyDescription("Realm is a mobile database: a replacement for Core Data & SQLite")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCopyright("Copyright © 2016 Realm")]
-[assembly: AssemblyCompany("Realm Inc.")]
-[assembly: AssemblyProduct("Realm C#")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-
-// The following attributes are used to specify the signing key for the assembly,
-// if desired. See the Mono documentation for more information about signing.
-
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]
-
 [assembly: InternalsVisibleTo("IntegrationTestsXamarinIOS")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion(("0.76.0.0"))]
-[assembly: AssemblyFileVersion(("0.76.0.0"))]

--- a/RealmAssemblyInfo.cs
+++ b/RealmAssemblyInfo.cs
@@ -22,7 +22,10 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright © 2016 Realm")]
 [assembly: AssemblyCompany("Realm Inc.")]
 [assembly: AssemblyProduct("Realm C#")]
-    
+
+[assembly: AssemblyVersion("0.76.0.0")]
+[assembly: AssemblyFileVersion("0.76.0.0")]
+
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/RealmAssemblyInfo.cs
+++ b/RealmAssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
 //
 // Copyright 2016 Realm Inc.
 //
@@ -17,7 +17,14 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle("Realm.XamarinAndroid")]
-[assembly: InternalsVisibleTo("IntegrationTests.XamarinAndroid")]
+[assembly: AssemblyDescription("Realm is a mobile database: a replacement for SQLite")]
+[assembly: AssemblyCopyright("Copyright © 2016 Realm")]
+[assembly: AssemblyCompany("Realm Inc.")]
+[assembly: AssemblyProduct("Realm C#")]
+    
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug")]
+#else
+[assembly: AssemblyConfiguration("Release")]
+#endif

--- a/RealmWeaver/Properties/AssemblyInfo.cs
+++ b/RealmWeaver/Properties/AssemblyInfo.cs
@@ -19,10 +19,3 @@
 using System.Reflection;
 
 [assembly: AssemblyTitle("RealmWeaver")]
-[assembly: AssemblyProduct("Realm C#")]
-
-[assembly: AssemblyCopyright("Copyright © 2016 Realm")]
-[assembly: AssemblyCompany("Realm Inc.")]
-
-[assembly: AssemblyVersion("0.76.0.0")]
-[assembly: AssemblyFileVersion("0.76.0.0")]

--- a/RealmWeaver/RealmWeaver.Fody.csproj
+++ b/RealmWeaver/RealmWeaver.Fody.csproj
@@ -54,7 +54,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="..\RealmAssemblyInfo.cs">
+      <Link>Properties\RealmAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="extensions\MethodReferenceExtensions.cs" />
     <Compile Include="extensions\PropertyDefinitionExtensions.cs" />
     <Compile Include="extensions\TypeReferenceExtensions.cs" />


### PR DESCRIPTION
Extract all the common parts of all the various AssemblyInfo files in a central one. This makes it easier to stamp versions in CI.