### PR TITLE
Make Android tests debuggable always

### DIFF
--- a/Tests/IntegrationTests.XamarinAndroid/Properties/AndroidManifest.xml
+++ b/Tests/IntegrationTests.XamarinAndroid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="io.realm.xamarintests">
 	<uses-sdk android:minSdkVersion="10" />
-	<application android:label="IntegrationTests.XamarinAndroid" android:icon="@drawable/icon"></application>
+	<application android:label="IntegrationTests.XamarinAndroid" android:icon="@drawable/icon" android:debuggable="true"></application>
 </manifest>


### PR DESCRIPTION
That way we can run headless unit tests in CI when building for Release.