### PR TITLE
Disable debugging symbols for iOS wrappers in Release

### DIFF
--- a/wrappers/wrappers.xcodeproj/project.pbxproj
+++ b/wrappers/wrappers.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				EXECUTABLE_PREFIX = lib;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,


### PR DESCRIPTION
Fixes #628 