### PR TITLE
Change the way CI runs headless unit tests

### DIFF
--- a/Tests/IntegrationTests.XamarinAndroid/TestRunnerInstrumentation.cs
+++ b/Tests/IntegrationTests.XamarinAndroid/TestRunnerInstrumentation.cs
@@ -25,37 +25,37 @@ using Android.Runtime;
 
 namespace IntegrationTests.XamarinAndroid
 {
-	[Instrumentation(Name = "io.realm.xamarintests.TestRunner")]
-	public class TestRunnerInstrumentation : Instrumentation
-	{
-		public TestRunnerInstrumentation (IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
-		{
-		}
+    [Instrumentation(Name = "io.realm.xamarintests.TestRunner")]
+    public class TestRunnerInstrumentation : Instrumentation
+    {
+        public TestRunnerInstrumentation(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+        }
 
-		public override void OnCreate (Bundle arguments)
-		{
-			base.OnCreate (arguments);
+        public override void OnCreate(Bundle arguments)
+        {
+            base.OnCreate(arguments);
 
-			this.Start ();
-		}
+            this.Start();
+        }
 
-		public override void OnStart ()
-		{
+        public override void OnStart()
+        {
             NativeMethods.ALooper_prepare(0);
 
-			using (var output = Context.OpenFileOutput ("TestResults.Android.xml", FileCreationMode.WorldReadable)) 
-			{
-				IntegrationTests.Shared.TestRunner.Run ("Xamarin.Android", output);
-			}
+            using (var output = Context.OpenFileOutput("TestResults.Android.xml", FileCreationMode.WorldReadable))
+            {
+                IntegrationTests.Shared.TestRunner.Run("Android", output);
+            }
 
-			this.Finish (Result.Ok, null);
-		}
+            this.Finish(Result.Ok, null);
+        }
 
         private static class NativeMethods
         {
             [System.Runtime.InteropServices.DllImport("android")]
             internal static extern IntPtr ALooper_prepare(int opts);
         }
-	}
+    }
 }
 

--- a/Tests/IntegrationTests.XamarinIOS/Main.cs
+++ b/Tests/IntegrationTests.XamarinIOS/Main.cs
@@ -15,8 +15,9 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
- 
+
 using System;
+using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -28,14 +29,12 @@ namespace IntegrationTests.XamarinIOS
     public class Application
     {
         // This is the main entry point of the application.
-        static void Main (string[] args)
+        static void Main(string[] args)
         {
-            // run unit tests in a headless mode when we're in Jenkins CI
-            var ci = Environment.GetEnvironmentVariable("WORKSPACE");
-            if (!string.IsNullOrEmpty (ci)) {
-                using (var output = System.IO.File.OpenWrite (System.IO.Path.Combine (ci, "TestResults.iOS.xml"))) 
+            if (NSProcessInfo.ProcessInfo.Arguments.Any("--headless".Equals))) {
+                using (var output = File.OpenWrite(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "TestResults.iOS.xml")))
                 {
-                    IntegrationTests.Shared.TestRunner.Run ("Xamarin.iOS", output);
+                    IntegrationTests.Shared.TestRunner.Run("iOS", output);
                 }
 
                 return;
@@ -43,7 +42,7 @@ namespace IntegrationTests.XamarinIOS
 
             // if you want to use a different Application Delegate class from "UnitTestAppDelegate"
             // you can specify it here.
-            UIApplication.Main (args, null, "UnitTestAppDelegate");
+            UIApplication.Main(args, null, "UnitTestAppDelegate");
         }
     }
 }


### PR DESCRIPTION
On iOS we no longer rely on an environment variable, but on a command-line argument