### PR TITLE
Ad/bug/objectid writing duplicates #655

### DIFF
--- a/Tests/IntegrationTests.Shared/IntegrationTests.Shared.projitems
+++ b/Tests/IntegrationTests.Shared/IntegrationTests.Shared.projitems
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AccessTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ObjectIdAndUniqueTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PeopleTestsBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PerformanceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Person.cs" />

--- a/Tests/IntegrationTests.Shared/ObjectIdAndUniqueTests.cs
+++ b/Tests/IntegrationTests.Shared/ObjectIdAndUniqueTests.cs
@@ -34,7 +34,7 @@ namespace IntegrationTests
         public void SetUp()
         {
             var conf = new RealmConfiguration("ObjectIdandUnique.realm");
-            Realm.DeleteRealm(conf);
+            // Realm.DeleteRealm(conf);  // uncomment to leave all the records created by these tests
             _realm = Realm.GetInstance(conf);
         }
 
@@ -48,15 +48,114 @@ namespace IntegrationTests
         [Test]
         public void ObjectIdCharObjectIsUnique()
         {
-            _realm.Write(() =>
-            {
+            _realm.Write(() => {
                 var o1 = _realm.CreateObject<ObjectIdCharObject>();
                 o1.CharProperty = 'a';
                 o1.Created = DateTimeOffset.Now;
-                var o2 = _realm.CreateObject<ObjectIdCharObject>();
-                o2.CharProperty = 'a';
-                o2.Created = DateTimeOffset.Now;
+                o1.CountCreated = 1;
             });
+            _realm.Write(() => {
+                var o2 = _realm.CreateObject<ObjectIdCharObject>();
+                o2.CharProperty = 'a'; // deliberately reuse id
+                o2.Created = DateTimeOffset.Now;
+                o2.CountCreated = 2;
+            });
+            Assert.That(_realm.All<ObjectIdCharObject>().Count(), Is.EqualTo(1));
         }
+
+
+        [Test]
+        public void ObjectIdByteObjectIsUnique()
+        {
+            _realm.Write(() => {
+                var o1 = _realm.CreateObject<ObjectIdByteObject>();
+                o1.ByteProperty = 42;
+                o1.Created = DateTimeOffset.Now;
+                o1.CountCreated = 1;
+                });
+            _realm.Write(() => {
+                var o2 = _realm.CreateObject<ObjectIdByteObject>();
+                o2.ByteProperty = 42; // deliberately reuse id
+                o2.Created = DateTimeOffset.Now;
+                o2.CountCreated = 2;
+            });
+            Assert.That(_realm.All<ObjectIdByteObject>().Count(), Is.EqualTo(1));
+        }
+
+
+        [Test]
+        public void ObjectIdInt16ObjectIsUnique()
+        {
+            _realm.Write(() => {
+                var o1 = _realm.CreateObject<ObjectIdInt16Object>();
+                o1.Int16Property = 4242;
+                o1.Created = DateTimeOffset.Now;
+                o1.CountCreated = 1;
+            });
+            _realm.Write(() => {
+                var o2 = _realm.CreateObject<ObjectIdInt16Object>();
+                o2.Int16Property = 4242; // deliberately reuse id
+                o2.Created = DateTimeOffset.Now;
+                o2.CountCreated = 2;
+            });
+            Assert.That(_realm.All<ObjectIdInt16Object>().Count(), Is.EqualTo(1));
+        }
+
+
+        [Test]
+        public void ObjectIdInt32ObjectIsUnique()
+        {
+            _realm.Write(() => {
+                var o1 = _realm.CreateObject<ObjectIdInt32Object>();
+                o1.Int32Property = 42042;
+                o1.Created = DateTimeOffset.Now;
+                o1.CountCreated = 1;
+            });
+            _realm.Write(() => {
+                var o2 = _realm.CreateObject<ObjectIdInt32Object>();
+                o2.Int32Property = 42042; // deliberately reuse id
+                o2.Created = DateTimeOffset.Now;
+                o2.CountCreated = 2;
+            });
+            Assert.That(_realm.All<ObjectIdInt32Object>().Count(), Is.EqualTo(1));
+        }
+
+
+        [Test]
+        public void ObjectIdInt64ObjectIsUnique()
+        {
+            _realm.Write(() => {
+                var o1 = _realm.CreateObject<ObjectIdInt64Object>();
+                o1.Int64Property = 424242;
+                o1.Created = DateTimeOffset.Now;
+                o1.CountCreated = 1;
+            });
+            _realm.Write(() => {
+                var o2 = _realm.CreateObject<ObjectIdInt64Object>();
+                o2.Int64Property = 424242; // deliberately reuse id
+                o2.Created = DateTimeOffset.Now;
+                o2.CountCreated = 2;
+            });
+            Assert.That(_realm.All<ObjectIdInt64Object>().Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ObjectIdStringObjectIsUnique()
+        {
+            _realm.Write(() => {
+                var o1 = _realm.CreateObject<ObjectIdStringObject>();
+                o1.StringProperty = "Zaphod";
+                o1.Created = DateTimeOffset.Now;
+                o1.CountCreated = 1;
+            });
+            _realm.Write(() => {
+                var o2 = _realm.CreateObject<ObjectIdStringObject>();
+                o2.StringProperty = "Zaphod"; // deliberately reuse id
+                o2.Created = DateTimeOffset.Now;
+                o2.CountCreated = 2;
+            });
+            Assert.That(_realm.All<ObjectIdStringObject>().Count(), Is.EqualTo(1));
+        }
+
     }
 }

--- a/Tests/IntegrationTests.Shared/ObjectIdAndUniqueTests.cs
+++ b/Tests/IntegrationTests.Shared/ObjectIdAndUniqueTests.cs
@@ -1,0 +1,62 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using IntegrationTests.Shared;
+using NUnit.Framework;
+using Realms;
+
+namespace IntegrationTests
+{
+    [TestFixture]
+    class ObjectIdAndUniqueTests
+    {
+        private Realm _realm;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var conf = new RealmConfiguration("ObjectIdandUnique.realm");
+            Realm.DeleteRealm(conf);
+            _realm = Realm.GetInstance(conf);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _realm.Close();
+            // leave file on disk so can check with browser, delete before next run
+        }
+
+        [Test]
+        public void ObjectIdCharObjectIsUnique()
+        {
+            _realm.Write(() =>
+            {
+                var o1 = _realm.CreateObject<ObjectIdCharObject>();
+                o1.CharProperty = 'a';
+                o1.Created = DateTimeOffset.Now;
+                var o2 = _realm.CreateObject<ObjectIdCharObject>();
+                o2.CharProperty = 'a';
+                o2.Created = DateTimeOffset.Now;
+            });
+        }
+    }
+}

--- a/Tests/IntegrationTests.Shared/TestObjects.cs
+++ b/Tests/IntegrationTests.Shared/TestObjects.cs
@@ -49,31 +49,37 @@ namespace IntegrationTests.Shared
 
     public class ObjectIdCharObject : RealmObject
     {
-        [ObjectId] public char CharProperty { get; set; }
+        [ObjectId] public char CharProperty { get; set; } 
+        public DateTimeOffset Created { get; set; }
     }
 
     public class ObjectIdByteObject : RealmObject
     {
         [ObjectId] public byte ByteProperty { get; set; }
+        public DateTimeOffset Created { get; set; }
     }
 
     public class ObjectIdInt16Object : RealmObject
     {
         [ObjectId] public short Int16Property { get; set; }
+        public DateTimeOffset Created { get; set; }
     }
 
     public class ObjectIdInt32Object : RealmObject
     {
         [ObjectId] public int Int32Property { get; set; }
+        public DateTimeOffset Created { get; set; }
     }
 
     public class ObjectIdInt64Object : RealmObject
     {
         [ObjectId] public long Int64Property { get; set; }
+        public DateTimeOffset Created { get; set; }
     }
 
     public class ObjectIdStringObject : RealmObject
     {
         [ObjectId] public string StringProperty { get; set; }
+        public DateTimeOffset Created { get; set; }
     }
 }

--- a/Tests/IntegrationTests.Shared/TestObjects.cs
+++ b/Tests/IntegrationTests.Shared/TestObjects.cs
@@ -51,35 +51,41 @@ namespace IntegrationTests.Shared
     {
         [ObjectId] public char CharProperty { get; set; } 
         public DateTimeOffset Created { get; set; }
+        public int CountCreated { get; set; }
     }
 
     public class ObjectIdByteObject : RealmObject
     {
         [ObjectId] public byte ByteProperty { get; set; }
         public DateTimeOffset Created { get; set; }
+        public int CountCreated { get; set; }
     }
 
     public class ObjectIdInt16Object : RealmObject
     {
         [ObjectId] public short Int16Property { get; set; }
         public DateTimeOffset Created { get; set; }
+        public int CountCreated { get; set; }
     }
 
     public class ObjectIdInt32Object : RealmObject
     {
         [ObjectId] public int Int32Property { get; set; }
         public DateTimeOffset Created { get; set; }
+        public int CountCreated { get; set; }
     }
 
     public class ObjectIdInt64Object : RealmObject
     {
         [ObjectId] public long Int64Property { get; set; }
         public DateTimeOffset Created { get; set; }
+        public int CountCreated { get; set; }
     }
 
     public class ObjectIdStringObject : RealmObject
     {
         [ObjectId] public string StringProperty { get; set; }
         public DateTimeOffset Created { get; set; }
+        public int CountCreated { get; set; }
     }
 }

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2251,3 +2251,14 @@ SortingTests.cs
 
 RelationshipTests.cs
 - TestDeleteChildren added with Product and Report class definitions
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#655 ObjectId confirmation
+
+TestObjects.cs
+- added Created property to ObjectId*Object Classes
+
+ObjectIdAndUniqueTests.cs
+- added
+


### PR DESCRIPTION
Tests showing we are not writing duplicates but **are overwriting** objects. This needs binding or object-store level change to check an object exists and throw if we try saving a new one with the same id.