### PR TITLE
Check if a Realm is closed before notifying on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.xy.z (TBD)
+-------------------
+
+### Minor Changes
+* Fixed a crash on iOS when creating many short-lived realms very rapidly in parallel (#653)
+
 0.76.1 (2016-06-15)
 -------------------
 

--- a/wrappers/src/object-store/src/impl/apple/weak_realm_notifier.cpp
+++ b/wrappers/src/object-store/src/impl/apple/weak_realm_notifier.cpp
@@ -37,7 +37,9 @@ WeakRealmNotifier::WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool c
     ctx.info = new RefCountedWeakPointer{realm, {1}};
     ctx.perform = [](void* info) {
         if (auto realm = static_cast<RefCountedWeakPointer*>(info)->realm.lock()) {
-            realm->notify();
+            if (!realm->is_closed()) {
+                realm->notify();
+            }
         }
     };
     ctx.retain = [](const void* info) {


### PR DESCRIPTION
Fixes #653 