### PR TITLE
#739 Better empty schema exception messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.77.x (TBD)
 ### Enhancements
 * Setting your **Build Verbosity** to `Detailed` or `Normal` will now display a message for every property woven, which can be useful if you suspect errors with Fody weaving.
+* Better exception messages will helo diagnose _EmptySchema_ problems (#739)
 
 ### Bug fixes
 * `RealmResults<T>` should implement `IQueryable.Provider` implicitly (#752)

--- a/Realm.Shared/Schema/ObjectSchema.cs
+++ b/Realm.Shared/Schema/ObjectSchema.cs
@@ -115,7 +115,11 @@ namespace Realms.Schema
 
             public ObjectSchema Build()
             {
-                if (Count == 0) throw new InvalidOperationException("Cannot build an empty ObjectSchema");
+                if (Count == 0) 
+                {
+                    throw new InvalidOperationException(
+                        $"No properties in {Name}, has linker stripped it? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");                    throw new InvalidOperationException("Cannot build an empty ObjectSchema");
+                }
                 Contract.EndContractBlock();
 
                 return new ObjectSchema(Name, this.ToDictionary(p => p.Name));

--- a/Realm.Shared/Schema/ObjectSchema.cs
+++ b/Realm.Shared/Schema/ObjectSchema.cs
@@ -118,7 +118,7 @@ namespace Realms.Schema
                 if (Count == 0) 
                 {
                     throw new InvalidOperationException(
-                        $"No properties in {Name}, has linker stripped it? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");                    throw new InvalidOperationException("Cannot build an empty ObjectSchema");
+                        $"No properties in {Name}, has linker stripped it? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");
                 }
                 Contract.EndContractBlock();
 

--- a/Realm.Shared/Schema/RealmSchema.cs
+++ b/Realm.Shared/Schema/RealmSchema.cs
@@ -126,7 +126,7 @@ namespace Realms
                 if (Count == 0) 
                 {
                     throw new InvalidOperationException(
-                        "No RealmObjects. Has linker stripped them? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");                    throw new InvalidOperationException("Cannot build an empty ObjectSchema");
+                        "No RealmObjects. Has linker stripped them? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");
                 }
                 Contract.EndContractBlock();
 

--- a/Realm.Shared/Schema/RealmSchema.cs
+++ b/Realm.Shared/Schema/RealmSchema.cs
@@ -123,7 +123,11 @@ namespace Realms
 
             internal RealmSchema Build(SchemaHandle schemaHandle)
             {
-                if (Count == 0) throw new InvalidOperationException("Cannot build an empty RealmSchema");
+                if (Count == 0) 
+                {
+                    throw new InvalidOperationException(
+                        "No RealmObjects. Has linker stripped them? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");                    throw new InvalidOperationException("Cannot build an empty ObjectSchema");
+                }
                 Contract.EndContractBlock();
 
                 var objects = new List<SchemaObject>();

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2435,3 +2435,14 @@ PurePCLBuildableTest/Class1.cs
 
 PurePCLBuildableTest
 - TestBuildingRealmFromPCL.MakeARealmWithPCL added
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#739 Better empty schema exception messages
+
+ObjectSchema.cs
+- Builder.Build - throw message identifying bad schema name with URL for docs
+
+RealmSchema.cs
+- Builder.Build - throw message saying no RealmObjects, with URL for docs
+
+


### PR DESCRIPTION
ObjectSchema.cs
- Builder.Build - throw message identifying bad schema name with URL for docs

RealmSchema.cs
- Builder.Build - throw message saying no RealmObjects, with URL for docs