### PR TITLE
Ad/bug migration needed exception #507

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 0.77.x (TBD)
+-------------------
+### Bug fixes
+* Now throws a RealmMigrationSchemaNeededException if you have changed a `RealmObject` subclass declaration and not incremented the `SchemaVersion` (#518)
+
+Uses core 1.4.2
+
+0.77.2 (2016-08-11)
+-------------------
 ### Enhancements
 * Setting your **Build Verbosity** to `Detailed` or `Normal` will now display a message for every property woven, which can be useful if you suspect errors with Fody weaving.
 * Better exception messages will helo diagnose _EmptySchema_ problems (#739)
@@ -11,8 +19,8 @@
 ### Bug fixes
 * `RealmResults<T>` should implement `IQueryable.Provider` implicitly (#752)
 * Realms that close implicitly will no longer invalidate other instances (#746)
-* `DateTimeOffset` precision bug fixed (#756)
 
+Uses core 1.4.2
 
 0.77.1 (2016-07-25)
 -------------------

--- a/Realm.Shared/exceptions/RealmException.cs
+++ b/Realm.Shared/exceptions/RealmException.cs
@@ -64,6 +64,9 @@ namespace Realms {
                     return new RealmInvalidTransactionException(message);
 
                 case RealmExceptionCodes.RealmFormatUpgradeRequired :
+                    return new RealmException(message);  // rare unrecoverable case for now
+
+                case RealmExceptionCodes.RealmSchemaMismatch :
                     return new RealmMigrationNeededException(message);
 
                 case RealmExceptionCodes.RealmRowDetached:

--- a/Realm.Shared/exceptions/RealmExceptionCodes.cs
+++ b/Realm.Shared/exceptions/RealmExceptionCodes.cs
@@ -34,6 +34,7 @@ namespace Realms {
         RealmMismatchedConfig = 9,
         RealmInvalidTransaction = 10,
         RealmFormatUpgradeRequired = 13,
+        RealmSchemaMismatch=14,
         RealmRowDetached = 21,
 
         StdArgumentOutOfRange = 100,

--- a/Tests/IntegrationTests.Shared/ConfigurationTests.cs
+++ b/Tests/IntegrationTests.Shared/ConfigurationTests.cs
@@ -254,7 +254,7 @@ namespace IntegrationTests
         }
 
 
-        [Test, Ignore("Currently, a RealmMismatchedConfigException is thrown. Registered as #580")]
+        [Test, Explicit("Currently, a RealmMismatchedConfigException is thrown. Registered as #580")]
         public void ReadOnlyRealmsWillNotAutoMigrate()
         {
             // Arrange

--- a/Tests/IntegrationTests.Shared/RealmMigrationTests.cs
+++ b/Tests/IntegrationTests.Shared/RealmMigrationTests.cs
@@ -50,7 +50,6 @@ namespace IntegrationTests
         }
 
         [Test]
-        [Ignore("this tests for a condition that's only available under manual migrations, which we lack")]
         public void TriggerMigrationBySchemaEditing()
         {
 

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2469,8 +2469,19 @@ RealmMigrationTests.cs
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #507 RealmMigrationSchemaNeededException not thrown
 
-wrappers/error_handling.cpp
-- convert_exception - add case for SchemaMismatchException passed back as RealmFormatUpgradeRequired
+wrappers/error_handling.hpp
+- RealmErrorType added RealmSchemaMismatch=14
 
+wrappers/error_handling.cpp
+- convert_exception - add case for SchemaMismatchException passed back as RealmSchemaMismatch
+
+RealmExceptionCodes.cs
+- RealmExceptionCodes  added RealmSchemaMismatch=14
+
+RealmException.cs
+- RealmException.Create  
+  - added case for RealmSchemaMismatch
+  - RealmFormatUpgradeRequired handled mapping to plain RealmException
+  
 RealmMigrationTests.cs
 - TriggerMigrationBySchemaEditing re-enabled

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2449,7 +2449,6 @@ RealmSchema.cs
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #518 Start Schema Version at zero
 
-
 RealmConfiguration.cs
 - NotVersioned removed
 - SchemaVersion now initialised to zero
@@ -2466,3 +2465,12 @@ ForMigrationsToCopyAndMigrate.realm
 RealmMigrationTests.cs
 - refactored out from ObjectIntegrationTests.cs
 - MigrationTriggersDelete - disabled as it is not triggered due issue 507
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#507 RealmMigrationSchemaNeededException not thrown
+
+wrappers/error_handling.cpp
+- convert_exception - add case for SchemaMismatchException passed back as RealmFormatUpgradeRequired
+
+RealmMigrationTests.cs
+- TriggerMigrationBySchemaEditing re-enabled

--- a/wrappers/src/error_handling.cpp
+++ b/wrappers/src/error_handling.cpp
@@ -76,7 +76,7 @@ namespace realm {
         }
         catch (const SchemaMismatchException& e) {
           // typically shared_realm_open failing because same schemaVersion but changed
-          return { RealmErrorType::RealmFormatUpgradeRequired, e.what() };
+          return { RealmErrorType::RealmSchemaMismatch, e.what() };
         }
         //catch (const util::DecryptionFailed& e) {
         //    return { RealmExceptionCodes::RealmDecryptionFailed, e.what(), nullptr);

--- a/wrappers/src/error_handling.cpp
+++ b/wrappers/src/error_handling.cpp
@@ -74,6 +74,10 @@ namespace realm {
         catch (const UninitializedRealmException& e) {
             return { RealmErrorType::RealmUnitializedRealm, e.what() };
         }
+        catch (const SchemaMismatchException& e) {
+          // typically shared_realm_open failing because same schemaVersion but changed
+          return { RealmErrorType::RealmFormatUpgradeRequired, e.what() };
+        }
         //catch (const util::DecryptionFailed& e) {
         //    return { RealmExceptionCodes::RealmDecryptionFailed, e.what(), nullptr);
         //}

--- a/wrappers/src/realm_error_type.hpp
+++ b/wrappers/src/realm_error_type.hpp
@@ -63,6 +63,8 @@ namespace realm {
 
         RealmFormatUpgradeRequired = 13,
 
+        RealmSchemaMismatch = 14,
+
         RealmRowDetached = 21,
 
         StdArgumentOutOfRange = 100,


### PR DESCRIPTION
Minor change just to catch the exception currently being thrown from ObjectStore and map it to our desire C# exception.

@fealebenpae or @kristiandupont please review

**NOTE** this does **not** fix our `MigrationTriggersDelete` test as that crashes due to schema issues.