### PR TITLE
Remove ToList from expressions mostly in RelationshipTests

### DIFF
--- a/Tests/IntegrationTests.Shared/RelationshipTests.cs
+++ b/Tests/IntegrationTests.Shared/RelationshipTests.cs
@@ -15,7 +15,7 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
- 
+
 using NUnit.Framework;
 using Realms;
 using System;
@@ -45,7 +45,7 @@ namespace IntegrationTests.Shared
         {
             public string Name { get; set; }
             public Dog TopDog { get; set; }
-            public IList<Dog> Dogs { get; } 
+            public IList<Dog> Dogs { get; }
         }
 
         protected Realm realm;
@@ -65,25 +65,25 @@ namespace IntegrationTests.Shared
                     new Dog {Name = "Earl Yippington III" }
                     } };
                     */
-                Owner o1 = realm.CreateObject<Owner> ();
+                Owner o1 = realm.CreateObject<Owner>();
                 o1.Name = "Tim";
 
-                Dog d1 = realm.CreateObject<Dog> ();
+                Dog d1 = realm.CreateObject<Dog>();
                 d1.Name = "Bilbo Fleabaggins";
                 d1.Color = "Black";
                 o1.TopDog = d1;  // set a one-one relationship
-                o1.Dogs.Add (d1);
+                o1.Dogs.Add(d1);
 
-                Dog d2 = realm.CreateObject<Dog> ();
+                Dog d2 = realm.CreateObject<Dog>();
                 d2.Name = "Earl Yippington III";
                 d2.Color = "White";
-                o1.Dogs.Add (d2);
+                o1.Dogs.Add(d2);
 
                 // lonely people and dogs
-                Owner o2 = realm.CreateObject<Owner> ();
+                Owner o2 = realm.CreateObject<Owner>();
                 o2.Name = "Dani";  // the dog-less
 
-                Dog d3 = realm.CreateObject<Dog> ();  // will remain unassigned
+                Dog d3 = realm.CreateObject<Dog>();  // will remain unassigned
                 d3.Name = "Maggie Mongrel";
                 d3.Color = "Grey";
 
@@ -104,7 +104,7 @@ namespace IntegrationTests.Shared
                 new Owner {Name = "Morgan", Dogs = { new Dog { Name = "Rudy Loosebooty" } } };
                 */
 
-                trans.Commit ();
+                trans.Commit();
             }
         }
 
@@ -118,21 +118,21 @@ namespace IntegrationTests.Shared
         [Test]
         public void TimHasATopDog()
         {
-            var tim = realm.All<Owner>().First( p => p.Name == "Tim");
-            Assert.That(tim.TopDog.Name, Is.EqualTo( "Bilbo Fleabaggins"));
+            var tim = realm.All<Owner>().First(p => p.Name == "Tim");
+            Assert.That(tim.TopDog.Name, Is.EqualTo("Bilbo Fleabaggins"));
         }
 
 
         [Test]
         public void TimHasTwoIterableDogs()
         {
-            var tim = realm.All<Owner>().First( p => p.Name == "Tim");
+            var tim = realm.All<Owner>().First(p => p.Name == "Tim");
             var dogNames = new List<string>();
             foreach (var dog in tim.Dogs)  // using foreach here is deliberately testing that syntax
             {
                 dogNames.Add(dog.Name);
             }
-            Assert.That(dogNames, Is.EquivalentTo( new List<String> {"Bilbo Fleabaggins", "Earl Yippington III"}));
+            Assert.That(dogNames, Is.EquivalentTo(new List<String> { "Bilbo Fleabaggins", "Earl Yippington III" }));
         }
 
 
@@ -142,25 +142,25 @@ namespace IntegrationTests.Shared
         [Test]
         public void TimHasTwoIterableDogsListed()
         {
-            var tim = realm.All<Owner>().First( p => p.Name == "Tim");
+            var tim = realm.All<Owner>().First(p => p.Name == "Tim");
             var dogNames = new List<string>();
             var dogList = tim.Dogs.ToList();  // this used to crash - issue 299
             foreach (var dog in dogList)
             {
                 dogNames.Add(dog.Name);
             }
-            Assert.That(dogNames, Is.EquivalentTo( new List<String> {"Bilbo Fleabaggins", "Earl Yippington III"}));
+            Assert.That(dogNames, Is.EquivalentTo(new List<String> { "Bilbo Fleabaggins", "Earl Yippington III" }));
         }
 
 
         [Test]
         public void TimsIterableDogsThrowExceptions()
         {
-            var tim = realm.All<Owner>().First( p => p.Name == "Tim");
-            Assert.Throws<ArgumentNullException> (() => tim.Dogs.CopyTo (null, 0));
-            Dog[] copiedDogs = new Dog[2];
-            Assert.Throws<ArgumentOutOfRangeException> (() => tim.Dogs.CopyTo (copiedDogs, -1));
-            Assert.Throws<ArgumentException> (() => tim.Dogs.CopyTo (copiedDogs, 1));  // insuffiient room
+            var tim = realm.All<Owner>().First(p => p.Name == "Tim");
+            Assert.Throws<ArgumentNullException>(() => tim.Dogs.CopyTo(null, 0));
+            Dog [] copiedDogs = new Dog [2];
+            Assert.Throws<ArgumentOutOfRangeException>(() => tim.Dogs.CopyTo(copiedDogs, -1));
+            Assert.Throws<ArgumentException>(() => tim.Dogs.CopyTo(copiedDogs, 1));  // insuffiient room
         }
 
 
@@ -169,12 +169,13 @@ namespace IntegrationTests.Shared
         [Test]
         public void TimRetiredHisTopDog()
         {
-            var tim = realm.All<Owner>().First( p => p.Name == "Tim");
-            using (var trans = realm.BeginWrite()) {
+            var tim = realm.All<Owner>().First(p => p.Name == "Tim");
+            using (var trans = realm.BeginWrite())
+            {
                 tim.TopDog = null;
-                trans.Commit ();
-            }                
-            var tim2 = realm.All<Owner>().First( p => p.Name == "Tim");
+                trans.Commit();
+            }
+            var tim2 = realm.All<Owner>().First(p => p.Name == "Tim");
             Assert.That(tim2.TopDog, Is.Null);  // the dog departure was saved
         }
 
@@ -182,54 +183,58 @@ namespace IntegrationTests.Shared
         [Test]
         public void TimAddsADogLater()
         {
-            var tim = realm.All<Owner>().First( p => p.Name == "Tim");
-            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));  
-            using (var trans = realm.BeginWrite()) {
-                var dog3 = realm.All<Dog>().Where( p => p.Name == "Maggie Mongrel").ToList().First();
-                tim.Dogs.Add (dog3);
-                trans.Commit ();
+            var tim = realm.All<Owner>().First(p => p.Name == "Tim");
+            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));
+            using (var trans = realm.BeginWrite())
+            {
+                var dog3 = realm.All<Dog>().Where(p => p.Name == "Maggie Mongrel").First();
+                tim.Dogs.Add(dog3);
+                trans.Commit();
             }
-            var tim2 = realm.All<Owner>().First( p => p.Name == "Tim");
-            Assert.That(tim2.Dogs.Count(), Is.EqualTo(3));  
-            Assert.That(tim2.Dogs[2].Name, Is.EqualTo("Maggie Mongrel")); 
+            var tim2 = realm.All<Owner>().First(p => p.Name == "Tim");
+            Assert.That(tim2.Dogs.Count(), Is.EqualTo(3));
+            Assert.That(tim2.Dogs [2].Name, Is.EqualTo("Maggie Mongrel"));
         }
 
 
         [Test]
         public void TimAddsADogByInsert()
         {
-            var tim = realm.All<Owner>().Single( p => p.Name == "Tim");  // use Single for a change
-            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));  
-            using (var trans = realm.BeginWrite()) {
-                var dog3 = realm.All<Dog>().Where( p => p.Name == "Maggie Mongrel").ToList().First();
-                tim.Dogs.Insert (1, dog3);
-                trans.Commit ();
+            var tim = realm.All<Owner>().Single(p => p.Name == "Tim");  // use Single for a change
+            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));
+            using (var trans = realm.BeginWrite())
+            {
+                var dog3 = realm.All<Dog>().First(p => p.Name == "Maggie Mongrel");
+                tim.Dogs.Insert(1, dog3);
+                trans.Commit();
             }
-            var tim2 = realm.All<Owner>().Single( p => p.Name == "Tim");
-            Assert.That(tim2.Dogs.Count(), Is.EqualTo(3));  
-            Assert.That(tim2.Dogs[1].Name, Is.EqualTo("Maggie Mongrel")); 
-            Assert.That(tim2.Dogs[2].Name, Is.EqualTo("Earl Yippington III")); 
+            var tim2 = realm.All<Owner>().Single(p => p.Name == "Tim");
+            Assert.That(tim2.Dogs.Count(), Is.EqualTo(3));
+            Assert.That(tim2.Dogs [1].Name, Is.EqualTo("Maggie Mongrel"));
+            Assert.That(tim2.Dogs [2].Name, Is.EqualTo("Earl Yippington III"));
         }
 
 
         [Test]
         public void TimLosesHisDogsByOrder()
         {
-            var tim = realm.All<Owner>().Single( p => p.Name == "Tim");
-            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));  
-            using (var trans = realm.BeginWrite()) {
+            var tim = realm.All<Owner>().Single(p => p.Name == "Tim");
+            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));
+            using (var trans = realm.BeginWrite())
+            {
                 tim.Dogs.RemoveAt(0);
-                trans.Commit ();
-            }                
-            var tim2 = realm.All<Owner>().Single( p => p.Name == "Tim");
-            Assert.That(tim2.Dogs.Count(), Is.EqualTo(1)); 
-            Assert.That(tim2.Dogs[0].Name, Is.EqualTo("Earl Yippington III")); 
-            using (var trans = realm.BeginWrite()) {
+                trans.Commit();
+            }
+            var tim2 = realm.All<Owner>().Single(p => p.Name == "Tim");
+            Assert.That(tim2.Dogs.Count(), Is.EqualTo(1));
+            Assert.That(tim2.Dogs [0].Name, Is.EqualTo("Earl Yippington III"));
+            using (var trans = realm.BeginWrite())
+            {
                 tim.Dogs.RemoveAt(0);
-                trans.Commit ();
-            }                
-            var tim3 = realm.All<Owner>().Single( p => p.Name == "Tim");
-            Assert.That(tim2.Dogs.Count(), Is.EqualTo(0)); 
+                trans.Commit();
+            }
+            var tim3 = realm.All<Owner>().Single(p => p.Name == "Tim");
+            Assert.That(tim2.Dogs.Count(), Is.EqualTo(0));
             Assert.That(tim3.Dogs.Count(), Is.EqualTo(0)); // reloaded object has same empty related set
         }
 
@@ -239,7 +244,8 @@ namespace IntegrationTests.Shared
         {
             var tim = realm.All<Owner>().Single(p => p.Name == "Tim");
             Assert.That(tim.Dogs.Count(), Is.EqualTo(2));
-            using (var trans = realm.BeginWrite()) {
+            using (var trans = realm.BeginWrite())
+            {
                 tim.Dogs.Clear();
                 trans.Commit();
             }
@@ -251,23 +257,24 @@ namespace IntegrationTests.Shared
         [Test]
         public void TimLosesBilbo()
         {
-            var bilbo = realm.All<Dog> ().First (p => p.Name == "Bilbo Fleabaggins");
-            var tim = realm.All<Owner>().Single( p => p.Name == "Tim");
-            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));  
-            using (var trans = realm.BeginWrite()) {
+            var bilbo = realm.All<Dog>().First(p => p.Name == "Bilbo Fleabaggins");
+            var tim = realm.All<Owner>().Single(p => p.Name == "Tim");
+            Assert.That(tim.Dogs.Count(), Is.EqualTo(2));
+            using (var trans = realm.BeginWrite())
+            {
                 tim.Dogs.Remove(bilbo);
-                trans.Commit ();
-            }                
-            var tim2 = realm.All<Owner>().Single( p => p.Name == "Tim");
-            Assert.That(tim2.Dogs.Count(), Is.EqualTo(1)); 
-            Assert.That(tim2.Dogs[0].Name, Is.EqualTo("Earl Yippington III")); 
+                trans.Commit();
+            }
+            var tim2 = realm.All<Owner>().Single(p => p.Name == "Tim");
+            Assert.That(tim2.Dogs.Count(), Is.EqualTo(1));
+            Assert.That(tim2.Dogs [0].Name, Is.EqualTo("Earl Yippington III"));
         }
 
 
         [Test]
         public void DaniHasNoTopDog()
         {
-            var dani = realm.All<Owner>().Where( p => p.Name == "Dani").First();
+            var dani = realm.All<Owner>().Where(p => p.Name == "Dani").First();
             Assert.That(dani.TopDog, Is.Null);
         }
 
@@ -275,9 +282,9 @@ namespace IntegrationTests.Shared
         [Test]
         public void DaniHasNoDogs()
         {
-            var dani = realm.All<Owner>().Where( p => p.Name == "Dani").Single();
+            var dani = realm.All<Owner>().Where(p => p.Name == "Dani").Single();
             Assert.That(dani.Dogs.Count(), Is.EqualTo(0));  // ToMany relationships always return a RealmList
-            int dogsIterated = 0; 
+            int dogsIterated = 0;
             foreach (var d in dani.Dogs)
             {
                 dogsIterated++;
@@ -295,7 +302,7 @@ namespace IntegrationTests.Shared
             Dog scratch;  // for assignment in following getters
             Assert.Throws<IndexOutOfRangeException>(() => dani.Dogs.Insert(-1, bilbo));
             Assert.Throws<IndexOutOfRangeException>(() => dani.Dogs.Insert(0, bilbo));
-            Assert.Throws<IndexOutOfRangeException>(() => scratch = dani.Dogs[0]);
+            Assert.Throws<IndexOutOfRangeException>(() => scratch = dani.Dogs [0]);
         }
 
 
@@ -303,40 +310,40 @@ namespace IntegrationTests.Shared
         public void TestExceptionsFromIteratingEmptyList()
         {
             var dani = realm.All<Owner>().Where(p => p.Name == "Dani").Single();
-            var iter =  dani.Dogs.GetEnumerator();
+            var iter = dani.Dogs.GetEnumerator();
             Assert.IsNotNull(iter);
             var movedOnToFirstItem = iter.MoveNext();
             Assert.That(movedOnToFirstItem, Is.False);
             Dog currentDog;
-            Assert.Throws<IndexOutOfRangeException>(() => currentDog = iter.Current );
+            Assert.Throws<IndexOutOfRangeException>(() => currentDog = iter.Current);
         }
 
 
         [Test]
         public void TestExceptionsFromTimsDogsOutOfRange()
         {
-            var tim = realm.All<Owner>().Single( p => p.Name == "Tim");
-            Assert.Throws<IndexOutOfRangeException>( () => tim.Dogs.RemoveAt(4) );
-            var bilbo = realm.All<Dog>().Single( p => p.Name == "Bilbo Fleabaggins");
+            var tim = realm.All<Owner>().Single(p => p.Name == "Tim");
+            Assert.Throws<IndexOutOfRangeException>(() => tim.Dogs.RemoveAt(4));
+            var bilbo = realm.All<Dog>().Single(p => p.Name == "Bilbo Fleabaggins");
             Dog scratch;  // for assignment in following getters
-            Assert.Throws<IndexOutOfRangeException>( () => tim.Dogs.Insert(-1, bilbo) );
-            Assert.Throws<IndexOutOfRangeException>( () => tim.Dogs.Insert(3, bilbo) );
-            Assert.Throws<IndexOutOfRangeException>( () => scratch = tim.Dogs[99] );
+            Assert.Throws<IndexOutOfRangeException>(() => tim.Dogs.Insert(-1, bilbo));
+            Assert.Throws<IndexOutOfRangeException>(() => tim.Dogs.Insert(3, bilbo));
+            Assert.Throws<IndexOutOfRangeException>(() => scratch = tim.Dogs [99]);
         }
 
         [Test]
         public void TestSettingStandAloneObjectToRelationship()
         {
-            var owner = realm.All<Owner>().ToList().First();
+            var owner = realm.All<Owner>().First();
             var dog = new Dog { Name = "Astro" };
-            
+
             using (var trans = realm.BeginWrite())
             {
                 owner.TopDog = dog;
                 trans.Commit();
             }
 
-            var dogAgain = realm.All<Dog>().Where(d => d.Name == "Astro").ToList().SingleOrDefault();
+            var dogAgain = realm.All<Dog>().Single(d => d.Name == "Astro");
             Assert.That(dogAgain, Is.Not.Null);
             Assert.That(dog.IsManaged);
         }
@@ -344,7 +351,7 @@ namespace IntegrationTests.Shared
         [Test]
         public void TestAddingStandAloneObjectToToManyRelationship()
         {
-            var owner = realm.All<Owner>().ToList().First();
+            var owner = realm.All<Owner>().First();
             var dog = new Dog { Name = "Astro" };
 
             using (var trans = realm.BeginWrite())
@@ -353,7 +360,7 @@ namespace IntegrationTests.Shared
                 trans.Commit();
             }
 
-            var dogAgain = realm.All<Dog>().Where(d => d.Name == "Astro").ToList().SingleOrDefault();
+            var dogAgain = realm.All<Dog>().Single(d => d.Name == "Astro");
             Assert.That(dogAgain, Is.Not.Null);
             Assert.That(dog.IsManaged);
         }
@@ -361,8 +368,7 @@ namespace IntegrationTests.Shared
         [Test]
         public void TestManagingStandaloneTwoLevelRelationship()
         {
-            var person = new Person
-            {
+            var person = new Person {
                 FullName = "Jack Thorne",
                 Friends = // see NoteOnListInit above
                 {
@@ -381,17 +387,16 @@ namespace IntegrationTests.Shared
 
             Assert.That(person.Friends is RealmList<Person>);
             Assert.That(realm.All<Person>().ToList().Select(p => p.FirstName),
-                        Is.EquivalentTo(new[] { "Jack", "Christian", "Frederick" })
+                        Is.EquivalentTo(new [] { "Jack", "Christian", "Frederick" })
                        );
-        
+
         }
 
 
         [Test]
         public void TestManagingStandaloneThreeLevelRelationship()
         {
-            var sally = new Person
-            {
+            var sally = new Person {
                 FullName = "Sally",
                 Friends =  // see NoteOnListInit above
                 {
@@ -406,19 +411,20 @@ namespace IntegrationTests.Shared
                                 FullName = "Krystal",
                                 Friends =  { new Person {  FullName = "Sally"} }  // Managees a second Sally
                             }
-                        } 
+                        }
 
                     }
                 }
             };
 
-            using (var trans = realm.BeginWrite()) {
+            using (var trans = realm.BeginWrite())
+            {
                 realm.Manage(sally);  // top person Managees entire tree
                 trans.Commit();
             }
 
             Assert.That(realm.All<Person>().ToList().Select(p => p.FirstName),
-                        Is.EquivalentTo(new[] { "Alice", "Joan", "Krystal", "Sally", "Sally" })
+                        Is.EquivalentTo(new [] { "Alice", "Joan", "Krystal", "Sally", "Sally" })
                        );
         }
 
@@ -426,30 +432,29 @@ namespace IntegrationTests.Shared
         [Test]
         public void TestCircularRelationshipsFromStandaloneTwoStage()
         {
-            var sally = new Person
-            {
+            var sally = new Person {
                 FullName = "Sally",
                 Friends =
                 {
                     new Person { FullName = "Alice" },
-                    new Person { FullName = "Joan"  }       
+                    new Person { FullName = "Joan"  }
                 }
             };
-            var joanFriend = new Person()
-            {
+            var joanFriend = new Person() {
                 FullName = "Krystal",
-                Friends = {sally} 
+                Friends = { sally }
             };
 
-            using (var trans = realm.BeginWrite()) {
+            using (var trans = realm.BeginWrite())
+            {
                 realm.Manage(sally);  // top person Managees entire tree
-                sally.Friends[1].Friends.Add(joanFriend);  
+                sally.Friends [1].Friends.Add(joanFriend);
 
                 trans.Commit();
             }
 
-            Assert.That(realm.All<Person>().ToList().Select(p => p.FirstName), 
-                        Is.EquivalentTo(new [] { "Alice", "Joan", "Krystal", "Sally"})
+            Assert.That(realm.All<Person>().ToList().Select(p => p.FirstName),
+                        Is.EquivalentTo(new [] { "Alice", "Joan", "Krystal", "Sally" })
                        );
         }
 
@@ -473,16 +478,18 @@ namespace IntegrationTests.Shared
         }
 
         [Test]
-        public void TestDeleteChildren ()
+        public void TestDeleteChildren()
         {
             // Arrange - setup some hierarchies
-            realm.Write (() => {
-                for (var pid = 1; pid <= 4; ++pid) {
+            realm.Write(() => {
+                for (var pid = 1; pid <= 4; ++pid)
+                {
                     var p = realm.CreateObject<Product>();
                     p.Id = pid; p.Name = $"Product {pid}";
-                    for (var rid = 1; rid <= 5; ++rid) {
+                    for (var rid = 1; rid <= 5; ++rid)
+                    {
                         var r = realm.CreateObject<Report>();
-                        r.Id = rid+pid*1000; r.Ref = $"Report {pid}:{rid}";
+                        r.Id = rid + pid * 1000; r.Ref = $"Report {pid}:{rid}";
                         p.Reports.Add(r);
                     }
                 }

--- a/Tests/IntegrationTests.Shared/StandAloneObjectTests.cs
+++ b/Tests/IntegrationTests.Shared/StandAloneObjectTests.cs
@@ -71,7 +71,7 @@ namespace IntegrationTests.Shared
 
                 Assert.That(_person.IsManaged);
 
-                var p = realm.All<Person>().ToList().Single();
+                var p = realm.All<Person>().Single();
                 Assert.That(p.FirstName, Is.EqualTo("Arthur"));
                 Assert.That(p.LastName, Is.EqualTo("Dent"));
                 Assert.That(p.IsInteresting);


### PR DESCRIPTION
so we don't give people the idea it is needed.

Reformatted to undo the effects of Xamarin Studio silly settings at a previous edit.

@kristiandupont please review, just test changes, no functional changes so no changelog entry.