### PR TITLE
#789 Cope with value semantics in object store of passed in schema

### DIFF
--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -144,6 +144,7 @@ namespace Realms
                     config.EncryptionKey,
                     config.SchemaVersion);
             }
+            schema.Handle.Dispose();  // forget it as value semantics have copied it in ObjectStore and the C++ object has been deleted.
 
             RuntimeHelpers.PrepareConstrainedRegions();
             try { /* Retain handle in a constrained execution region */ }

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2589,3 +2589,13 @@ RealmListPCL.cs
 Renaming ObjectId to PrimaryKey
 
 General search and replace ObjectId with PrimaryKey
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#789 Cope with value semantics in object store of passed in schema
+
+wrappers/shared_realm_cs.cpp
+- shared_realm_open delete the passed in schema after copying
+
+Realm.cs
+- GetInstance dispose the schema handle after opening a Realm.

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -80,8 +80,9 @@ REALM_EXPORT SharedRealm* shared_realm_open(Schema* schema, uint16_t* path, size
             config.schema_mode = SchemaMode::ReadOnly;
         }
         
-        config.schema.emplace(*schema); // TODO: This copies the schema, so the handle kept in .net is wrong.
+        config.schema.emplace(*schema); // warning: This copies the schema, so the handle kept in .net is wrong.
         config.schema_version = schemaVersion;
+        delete schema;  // is now invalid kill and caller must clear its handle
 
         return new SharedRealm{Realm::get_shared_realm(config)};
     });


### PR DESCRIPTION
wrappers/shared_realm_cs.cpp
- shared_realm_open delete the passed in schema after copying

Realm.cs
- GetInstance dispose the schema handle after opening a Realm.

@kristiandupont please review.
I took the safest, destructive route. Now that it is using value semantics inside ObjectStore, there is no way we can safely keep track of the handle so best to stop using it after opening.