### PR TITLE
Update RealmResultsCollectionChanged.cs

### DIFF
--- a/Realm.Shared/extensions/RealmResultsCollectionChanged.cs
+++ b/Realm.Shared/extensions/RealmResultsCollectionChanged.cs
@@ -69,7 +69,7 @@ namespace Realms
             return new ReadOnlyObservableCollection<T>(new Adapter<T>((RealmResults<T>)results, errorCallback, coalesceMultipleChangesIntoReset));
         }
 
-        sealed class Adapter<T> : ObservableCollection<T> where T : RealmObject
+        public sealed class Adapter<T> : ObservableCollection<T> where T : RealmObject
         {
             readonly RealmResults<T> _results;
             readonly IDisposable _token;


### PR DESCRIPTION
I'd like to return a different collection than ReadOnlyObservableCollection from the extension method to support incremental loading. This collection still adheres to ObservableCollection, except it implements an extra interface with incremental loading support. 

However, Adapter is not publicly available. This PR is making the Adapter public.