### PR TITLE
Ad/bug/same primarykey should throw #655

### DIFF
--- a/Realm.PCL/Realm.PCL.csproj
+++ b/Realm.PCL/Realm.PCL.csproj
@@ -114,6 +114,9 @@
     <Compile Include="..\Realm.Shared\exceptions\RealmClassLacksPrimaryKeyException.cs">
       <Link>Exceptions\RealmClassLacksPrimaryKeyException.cs</Link>
     </Compile>
+    <Compile Include="..\Realm.Shared\exceptions\RealmDuplicatePrimaryKeyValueException.cs">
+      <Link>Exceptions\RealmDuplicatePrimaryKeyValueException.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Realm.Shared/Realm.Shared.projitems
+++ b/Realm.Shared/Realm.Shared.projitems
@@ -70,6 +70,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Schema\PropertyTypeEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)exceptions\RealmClosedException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)exceptions\RealmClassLacksPrimaryKeyException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)exceptions\RealmDuplicatePrimaryKeyValueException.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)weaving\" />

--- a/Realm.Shared/RealmObject.cs
+++ b/Realm.Shared/RealmObject.cs
@@ -280,6 +280,12 @@ namespace Realms
 
         #region Setters
 
+        private void ThrowDuplicatePrimaryKey(string propertyName, string value)
+        {
+            throw new RealmDuplicatePrimaryKeyValueException($"Class {ObjectSchema.Name} already has a primary key in {propertyName} with value '{value}'");
+        }
+
+
         protected void SetStringValue(string propertyName, string value)
         {
             Debug.Assert(_realm != null, "Object is not managed, but managed access was attempted");
@@ -297,7 +303,8 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            NativeTable.SetStringUnique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
+            if (!NativeTable.SetStringUnique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
+                ThrowDuplicatePrimaryKey(propertyName, value);
         }
 
         protected void SetCharValue(string propertyName, char value)
@@ -317,7 +324,9 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
+            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
+                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
+
         }
 
         protected void SetNullableCharValue(string propertyName, char? value)
@@ -347,7 +356,8 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
+            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
+                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
         }
 
         protected void SetNullableByteValue(string propertyName, byte? value)
@@ -377,7 +387,8 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
+            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
+                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
         }
 
         protected void SetNullableInt16Value(string propertyName, short? value)
@@ -407,7 +418,8 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
+            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
+                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
         }
 
         protected void SetNullableInt32Value(string propertyName, int? value)
@@ -437,7 +449,8 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
+            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
+                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
         }
 
         protected void SetNullableInt64Value(string propertyName, long? value)

--- a/Realm.Shared/RealmObject.cs
+++ b/Realm.Shared/RealmObject.cs
@@ -280,12 +280,6 @@ namespace Realms
 
         #region Setters
 
-        private void ThrowDuplicatePrimaryKey(string propertyName, string value)
-        {
-            throw new RealmDuplicatePrimaryKeyValueException($"Class {ObjectSchema.Name} already has a primary key in {propertyName} with value '{value}'");
-        }
-
-
         protected void SetStringValue(string propertyName, string value)
         {
             Debug.Assert(_realm != null, "Object is not managed, but managed access was attempted");
@@ -303,8 +297,7 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            if (!NativeTable.SetStringUnique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
-                ThrowDuplicatePrimaryKey(propertyName, value);
+            NativeTable.SetStringUnique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
         }
 
         protected void SetCharValue(string propertyName, char value)
@@ -324,8 +317,7 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
-                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
+            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
 
         }
 
@@ -356,8 +348,7 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
-                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
+            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
         }
 
         protected void SetNullableByteValue(string propertyName, byte? value)
@@ -387,8 +378,7 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
-                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
+            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
         }
 
         protected void SetNullableInt16Value(string propertyName, short? value)
@@ -418,8 +408,7 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
-                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
+            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
         }
 
         protected void SetNullableInt32Value(string propertyName, int? value)
@@ -449,8 +438,7 @@ namespace Realms
             if (!_realm.IsInTransaction)
                 throw new RealmOutsideTransactionException("Cannot set values outside transaction");
 
-            if (!NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value))
-                ThrowDuplicatePrimaryKey(propertyName, $"{value}");
+            NativeTable.SetInt64Unique(_metadata.Table, _metadata.ColumnIndices[propertyName], _rowHandle.RowIndex, value);
         }
 
         protected void SetNullableInt64Value(string propertyName, long? value)

--- a/Realm.Shared/exceptions/RealmDuplicatePrimaryKeyValueException.cs
+++ b/Realm.Shared/exceptions/RealmDuplicatePrimaryKeyValueException.cs
@@ -1,0 +1,27 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Realms
+{
+    public class RealmDuplicatePrimaryKeyValueException : RealmException
+    {
+        internal RealmDuplicatePrimaryKeyValueException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/Realm.Shared/exceptions/RealmException.cs
+++ b/Realm.Shared/exceptions/RealmException.cs
@@ -76,7 +76,7 @@ namespace Realms {
                     return new RealmClassLacksPrimaryKeyException(message);
 
                 case RealmExceptionCodes.RealmDuplicatePrimaryKeyValue :
-                return new RealmDuplicatePrimaryKeyValueException(message);
+                    return new RealmDuplicatePrimaryKeyValueException(message);
 
                 case RealmExceptionCodes.StdArgumentOutOfRange :
                     return new ArgumentOutOfRangeException(message);

--- a/Realm.Shared/exceptions/RealmException.cs
+++ b/Realm.Shared/exceptions/RealmException.cs
@@ -75,6 +75,9 @@ namespace Realms {
                 case RealmExceptionCodes.RealmTableHasNoPrimaryKey :
                     return new RealmClassLacksPrimaryKeyException(message);
 
+                case RealmExceptionCodes.RealmDuplicatePrimaryKeyValue :
+                return new RealmDuplicatePrimaryKeyValueException(message);
+
                 case RealmExceptionCodes.StdArgumentOutOfRange :
                     return new ArgumentOutOfRangeException(message);
 

--- a/Realm.Shared/exceptions/RealmExceptionCodes.cs
+++ b/Realm.Shared/exceptions/RealmExceptionCodes.cs
@@ -37,6 +37,7 @@ namespace Realms {
         RealmSchemaMismatch=14,
         RealmRowDetached = 21,
         RealmTableHasNoPrimaryKey = 22,
+        RealmDuplicatePrimaryKeyValue = 23,
 
         StdArgumentOutOfRange = 100,
         StdIndexOutOfRange = 101,

--- a/Realm.Shared/native/NativeTable.cs
+++ b/Realm.Shared/native/NativeTable.cs
@@ -98,19 +98,18 @@ namespace Realms
         private static extern void set_string(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx,
             [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
 
-        public static bool SetStringUnique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, string value)
+        public static void SetStringUnique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, string value)
         {
             if (value == null)
                 throw new ArgumentException("Object identifiers cannot be null");
 
             NativeException nativeException;
-            bool wasUnique = set_string_unique(tableHandle, columnIndex, rowIndex, value, (IntPtr)value.Length, out nativeException);
+            set_string_unique(tableHandle, columnIndex, rowIndex, value, (IntPtr)value.Length, out nativeException);
             nativeException.ThrowIfNecessary();
-            return wasUnique;
         }
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_set_string_unique", CallingConvention = CallingConvention.Cdecl)]
-        private static extern bool set_string_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx,
+        private static extern void set_string_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx,
             [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
 
         public static string GetString(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex)
@@ -272,16 +271,15 @@ namespace Realms
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_set_int64", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_int64(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx, Int64 value, out NativeException ex);
 
-        public static bool SetInt64Unique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, long value)
+        public static void SetInt64Unique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, long value)
         {
             NativeException nativeException;
-            bool wasUnique = set_int64_unique(tableHandle, columnIndex, rowIndex, value, out nativeException);
+            set_int64_unique(tableHandle, columnIndex, rowIndex, value, out nativeException);
             nativeException.ThrowIfNecessary();
-            return wasUnique;
         }
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_set_int64_unique", CallingConvention = CallingConvention.Cdecl)]
-        private static extern bool set_int64_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx, Int64 value, out NativeException ex);
+        private static extern void set_int64_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx, Int64 value, out NativeException ex);
 
         public static long GetInt64(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex)
         {

--- a/Realm.Shared/native/NativeTable.cs
+++ b/Realm.Shared/native/NativeTable.cs
@@ -98,18 +98,19 @@ namespace Realms
         private static extern void set_string(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx,
             [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
 
-        public static void SetStringUnique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, string value)
+        public static bool SetStringUnique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, string value)
         {
             if (value == null)
                 throw new ArgumentException("Object identifiers cannot be null");
 
             NativeException nativeException;
-            set_string_unique(tableHandle, columnIndex, rowIndex, value, (IntPtr)value.Length, out nativeException);
+            bool wasUnique = set_string_unique(tableHandle, columnIndex, rowIndex, value, (IntPtr)value.Length, out nativeException);
             nativeException.ThrowIfNecessary();
+            return wasUnique;
         }
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_set_string_unique", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void set_string_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx,
+        private static extern bool set_string_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx,
             [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
 
         public static string GetString(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex)
@@ -271,15 +272,16 @@ namespace Realms
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_set_int64", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_int64(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx, Int64 value, out NativeException ex);
 
-        public static void SetInt64Unique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, long value)
+        public static bool SetInt64Unique(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex, long value)
         {
             NativeException nativeException;
-            set_int64_unique(tableHandle, columnIndex, rowIndex, value, out nativeException);
+            bool wasUnique = set_int64_unique(tableHandle, columnIndex, rowIndex, value, out nativeException);
             nativeException.ThrowIfNecessary();
+            return wasUnique;
         }
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_set_int64_unique", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void set_int64_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx, Int64 value, out NativeException ex);
+        private static extern bool set_int64_unique(TableHandle tablePtr, IntPtr columnNdx, IntPtr rowNdx, Int64 value, out NativeException ex);
 
         public static long GetInt64(TableHandle tableHandle, IntPtr columnIndex, IntPtr rowIndex)
         {

--- a/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
+++ b/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
@@ -195,6 +195,41 @@ namespace IntegrationTests.Shared
 
             Assert.That(foundValue, Is.EqualTo(42000042));
         }
+
+
+        [Test]
+        public void PrimaryKeyStringObjectIsUnique()
+        {
+            _realm.Write(() => {
+                var o1 = _realm.CreateObject<PrimaryKeyStringObject>();
+                o1.StringProperty = "Zaphod";
+            });
+
+            Assert.Throws<RealmDuplicatePrimaryKeyValueException>( () => {
+                _realm.Write(() => {
+                    var o2 = _realm.CreateObject<PrimaryKeyStringObject>();
+                    o2.StringProperty = "Zaphod"; // deliberately reuse id
+                });
+            });
+        }
+
+
+        [Test]
+        public void PrimaryKeyIntObjectIsUnique()
+        {
+            _realm.Write(() => {
+                var o1 = _realm.CreateObject<PrimaryKeyInt64Object>();
+                o1.Int64Property = 9999000;
+            });
+
+            Assert.Throws<RealmDuplicatePrimaryKeyValueException>( () => {
+                _realm.Write(() => {
+                    var o2 = _realm.CreateObject<PrimaryKeyInt64Object>();
+                    o2.Int64Property = 9999000; // deliberately reuse id
+                });
+            });
+        }
+
     
     }
 }

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2646,3 +2646,22 @@ ObjectSchema.cs
  
 wrappers/schema_cs.cpp
 - schema_create now set the primary_key string to name of property specified as [PrimaryKey]
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#655 Protect primary key so detects attempt to set twice
+
+wrappers/table_cs.cpp
+- table_set_int64_unique and  table_set_string_unique
+  change return type to bool and check if key already exists
+
+NativeTable.cs
+- set_int64_unique and set_string_unique return bools
+
+RealmDuplicatePrimaryKeyValueException.cs
+- added
+
+RealmObject.cs
+- ThrowDuplicatePrimaryKey added
+- SetStringValueUnique, SetCharValueUnique, SetByteValueUnique, SetInt16ValueUnique,
+  SetInt32ValueUnique & SetInt64ValueUnique 
+  check return type and call ThrowDuplicatePrimaryKey

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2650,18 +2650,30 @@ wrappers/schema_cs.cpp
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #655 Protect primary key so detects attempt to set twice
 
-wrappers/table_cs.cpp
-- table_set_int64_unique and  table_set_string_unique
-  change return type to bool and check if key already exists
-
-NativeTable.cs
-- set_int64_unique and set_string_unique return bools
-
 RealmDuplicatePrimaryKeyValueException.cs
 - added
 
-RealmObject.cs
-- ThrowDuplicatePrimaryKey added
-- SetStringValueUnique, SetCharValueUnique, SetByteValueUnique, SetInt16ValueUnique,
-  SetInt32ValueUnique & SetInt64ValueUnique 
-  check return type and call ThrowDuplicatePrimaryKey
+RealmExceptionCodes.cs
+- RealmDuplicatePrimaryKeyValue added
+
+RealmExceptions.cs
+- Create - map RealmDuplicatePrimaryKeyValue to RealmDuplicatePrimaryKeyValueException
+    
+wrappers/realm_error_type.hpp
+- RealmDuplicatePrimaryKeyValue added
+
+
+wrappers/error_handling.hpp
+- add decl of SetDuplicatePrimaryKeyValueException
+
+wrappers/error_handling.cpp
+- map the existing objectstore DuplicatePrimaryKeyValueException and  SetDuplicatePrimaryKeyValueException to RealmDuplicatePrimaryKeyValue
+
+wrappers/table_cs.cpp
+- table_set_int64_unique and  table_set_string_unique
+  change return type to bool and check if key already exists
+- table_set_null throw std::invalid_argument object not a new std::invalid_argument
+
+PrimaryKeyTests.cs
+- PrimaryKeyIntObjectIsUnique added
+- PrimaryKeyStringObjectIsUnique added

--- a/wrappers/src/error_handling.cpp
+++ b/wrappers/src/error_handling.cpp
@@ -34,7 +34,7 @@ namespace realm {
 
     SetDuplicatePrimaryKeyValueException::SetDuplicatePrimaryKeyValueException(std::string object_type, std::string property, std::string value)
         : std::runtime_error(util::format(
-            "Primary key property '%1.%2' already has a primary key '%3'",
+            "A %1 object already exists with primary key property %2 == '%3'",
         object_type, property, value))
     {}
 

--- a/wrappers/src/error_handling.cpp
+++ b/wrappers/src/error_handling.cpp
@@ -32,6 +32,13 @@
 
 namespace realm {
 
+    SetDuplicatePrimaryKeyValueException::SetDuplicatePrimaryKeyValueException(std::string object_type, std::string property, std::string value)
+        : std::runtime_error(util::format(
+            "Primary key property '%1.%2' already has a primary key '%3'",
+        object_type, property, value))
+    {}
+
+
     /**
     @note mostly copied from util.cpp in Java but has a much richer range of exceptions
     @warning if you update these codes also update the matching RealmExceptionCodes.cs
@@ -93,6 +100,12 @@ namespace realm {
         }
         catch (const MissingPrimaryKeyException& e) {
             return { RealmErrorType::RealmTableHasNoPrimaryKey, e.what() };
+        }
+        catch (const DuplicatePrimaryKeyValueException& e) {
+            return { RealmErrorType::RealmDuplicatePrimaryKeyValue, e.what() };
+        }
+        catch (const SetDuplicatePrimaryKeyValueException& e) {
+            return { RealmErrorType::RealmDuplicatePrimaryKeyValue, e.what() };  // map to same as DuplicatePrimaryKeyValueException
         }
         catch (const std::bad_alloc& e) {
             return { RealmErrorType::RealmOutOfMemory, e.what() };

--- a/wrappers/src/error_handling.hpp
+++ b/wrappers/src/error_handling.hpp
@@ -52,6 +52,13 @@ public:
     RowDetachedException() : std::runtime_error("Attempted to access detached row") {}
 };
 
+
+class SetDuplicatePrimaryKeyValueException : public std::runtime_error {
+public:
+    SetDuplicatePrimaryKeyValueException(std::string object_type, std::string property, std::string value);
+};
+
+
 NativeException convert_exception();
 
 void throw_managed_exception(const NativeException& exception);

--- a/wrappers/src/realm_error_type.hpp
+++ b/wrappers/src/realm_error_type.hpp
@@ -69,6 +69,8 @@ namespace realm {
 
         RealmTableHasNoPrimaryKey = 22,
 
+        RealmDuplicatePrimaryKeyValue = 23,
+
         StdArgumentOutOfRange = 100,
 
         StdIndexOutOfRange = 101,

--- a/wrappers/src/table_cs.cpp
+++ b/wrappers/src/table_cs.cpp
@@ -231,10 +231,13 @@ REALM_EXPORT void table_set_int64(Table* table_ptr, size_t column_ndx, size_t ro
     });
 }
 
-REALM_EXPORT void table_set_int64_unique(Table* table_ptr, size_t column_ndx, size_t row_ndx, int64_t value, NativeException::Marshallable& ex)
+REALM_EXPORT bool table_set_int64_unique(Table* table_ptr, size_t column_ndx, size_t row_ndx, int64_t value, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
+        if (table_ptr->find_first_int(column_ndx, value) != not_found)
+            return false;  // already exists
         table_ptr->set_int_unique(column_ndx, row_ndx, value);
+        return true;
     });
 }
 
@@ -260,11 +263,14 @@ REALM_EXPORT void table_set_string(Table* table_ptr, size_t column_ndx, size_t r
     });
 }
 
-REALM_EXPORT void table_set_string_unique(Table* table_ptr, size_t column_ndx, size_t row_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+REALM_EXPORT bool table_set_string_unique(Table* table_ptr, size_t column_ndx, size_t row_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
         Utf16StringAccessor str(value, value_len);
+        if (table_ptr->find_first_string(column_ndx, str) != not_found)
+            return false;  // already exists
         table_ptr->set_string_unique(column_ndx, row_ndx, str);
+        return true;
     });
 }
 

--- a/wrappers/src/table_cs.cpp
+++ b/wrappers/src/table_cs.cpp
@@ -235,8 +235,7 @@ REALM_EXPORT void table_set_int64(Table* table_ptr, size_t column_ndx, size_t ro
 REALM_EXPORT void table_set_int64_unique(Table* table_ptr, size_t column_ndx, size_t row_ndx, int64_t value, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
-        if (table_ptr->find_first_int(column_ndx, value) != not_found)
-        {
+        if (table_ptr->find_first_int(column_ndx, value) != not_found) {
             throw SetDuplicatePrimaryKeyValueException(
                     table_ptr->get_name(),
                     table_ptr->get_column_name(column_ndx),
@@ -273,8 +272,7 @@ REALM_EXPORT void table_set_string_unique(Table* table_ptr, size_t column_ndx, s
 {
     return handle_errors(ex, [&]() {
         Utf16StringAccessor str(value, value_len);
-        if (table_ptr->find_first_string(column_ndx, str) != not_found)
-        {
+        if (table_ptr->find_first_string(column_ndx, str) != not_found) {
             throw SetDuplicatePrimaryKeyValueException(
                     table_ptr->get_name(),
                     table_ptr->get_column_name(column_ndx),


### PR DESCRIPTION
@kristiandupont please review
Has exception handling with a new exception from OS as discussed

RealmDuplicatePrimaryKeyValueException.cs
- added

RealmExceptionCodes.cs
- RealmDuplicatePrimaryKeyValue added

RealmExceptions.cs
- Create - map RealmDuplicatePrimaryKeyValue to RealmDuplicatePrimaryKeyValueException
    
wrappers/realm_error_type.hpp
- RealmDuplicatePrimaryKeyValue added

wrappers/error_handling.hpp
- add decl of SetDuplicatePrimaryKeyValueException

wrappers/error_handling.cpp
- map the existing objectstore DuplicatePrimaryKeyValueException and  SetDuplicatePrimaryKeyValueException to RealmDuplicatePrimaryKeyValue

wrappers/table_cs.cpp
- table_set_int64_unique and  table_set_string_unique
  change return type to bool and check if key already exists
- table_set_null throw std::invalid_argument object not a new std::invalid_argument

PrimaryKeyTests.cs
- PrimaryKeyIntObjectIsUnique added
- PrimaryKeyStringObjectIsUnique added
