### PR TITLE
Ad/linq/feature/char queries #708

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@
 * The term `ObjectId` has been replaced with `PrimaryKey` in order to align with the other SDKs. This affects the `[ObjectId]` attribute used to decorate a property.
 
 ### Enhancements
-* You can retrieve single objects quickly using `Realm.ObjectForPrimaryKey()` if they have a `[PrimaryKey]` property specified.
-* Manual migrations are now supported. You can specify exactly how your data should be migrated when updating your data model.
+* You can retrieve single objects quickly using `Realm.ObjectForPrimaryKey()` if they have a `[PrimaryKey]` property specified. (#402)
+* Manual migrations are now supported. You can specify exactly how your data should be migrated when updating your data model. (#545)
+* LINQ searches no longer throw a `NotSupportedException` if your integer type on the other side of an expression fails to exactly match your property's integer type.
+* Additional LINQ methods now supported: (#802)
+    * Last
+    * LastOrDefault
+    * FirstOrDefault
+    * SingleOrDefault
+    * ElementAt
+    * ElementAtOrDefault
 
 ### Bug fixes
+* Searching char field types now works. (#708)
 * Now throws a RealmMigrationSchemaNeededException if you have changed a `RealmObject` subclass declaration and not incremented the `SchemaVersion` (#518)
 * Fixed a bug where disposing a `Transaction` would throw an `ObjectDisposedException` if its `Realm` was garbage-collected (#779)
 * Corrected the exception being thrown `IndexOutOfRangeException` to be  `ArgumentOutOfRangeException`

--- a/Realm.Shared/linq/RealmResultsVisitor.cs
+++ b/Realm.Shared/linq/RealmResultsVisitor.cs
@@ -367,10 +367,22 @@ namespace Realms
             else
             {
                 var leftMember = b.Left as MemberExpression;
-                if (leftMember == null)
-                    throw new NotSupportedException(
-                        $"The lhs of the binary operator '{b.NodeType}' should be a member expression. \nUnable to process `{b.Left}`");
-                var leftName = leftMember.Member.Name;
+                string leftName = null;  // yes you need to init this for the if statement below
+                if (leftMember == null) {
+                    // bit of a hack to cope with the way LINQ changes the RHS of a char literal to an Int32
+                    // so an incoming lambda looks like {p => (Convert(p.CharProperty) == 65)}
+                    // from Where(p => p.CharProperty == 'A')
+                    var leftConvert = b.Left as UnaryExpression;
+                    if (leftConvert?.NodeType == ExpressionType.Convert) {
+                        var leftConvertMember = leftConvert.Operand as MemberExpression;
+                        leftName = leftConvertMember?.Member.Name;
+                    }
+                    if (leftName == null)
+                        throw new NotSupportedException(
+                            $"The lhs of the binary operator '{b.NodeType}' should be a member expression. \nUnable to process `{b.Left}`");
+                }
+                else
+                    leftName = leftMember.Member.Name;
 
                 var rightValue = ExtractConstantValue(b.Right);
                 if (rightValue == null)
@@ -419,6 +431,8 @@ namespace Realms
                 queryHandle.StringEqual(columnIndex, (string)value);
             else if (value is bool)
                 queryHandle.BoolEqual(columnIndex, (bool)value);
+            else if (value is char)
+                queryHandle.IntEqual(columnIndex, (int)value);
             else if (value is int)
                 queryHandle.IntEqual(columnIndex, (int)value);
             else if (value is long)
@@ -459,6 +473,8 @@ namespace Realms
                 queryHandle.StringNotEqual(columnIndex, (string)value);
             else if (value is bool)
                 queryHandle.BoolNotEqual(columnIndex, (bool)value);
+            else if (value is char)
+                queryHandle.IntNotEqual(columnIndex, (int)value);
             else if (value is int)
                 queryHandle.IntNotEqual(columnIndex, (int)value);
             else if (value is long)
@@ -495,7 +511,9 @@ namespace Realms
         {
             var columnIndex = queryHandle.GetColumnIndex(columnName);
 
-            if (value is int)
+            if (value is char)
+                queryHandle.IntLess(columnIndex, (int)value);
+            else if (value is int)
                 queryHandle.IntLess(columnIndex, (int)value);
             else if (value is long)
                 queryHandle.LongLess(columnIndex, (long)value);
@@ -515,7 +533,9 @@ namespace Realms
         {
             var columnIndex = queryHandle.GetColumnIndex(columnName);
 
-            if (value is int)
+            if (value is char)
+                queryHandle.IntLessEqual(columnIndex, (int)value);
+            else if (value is int)
                 queryHandle.IntLessEqual(columnIndex, (int)value);
             else if (value is long)
                 queryHandle.LongLessEqual(columnIndex, (long)value);
@@ -535,7 +555,9 @@ namespace Realms
         {
             var columnIndex = queryHandle.GetColumnIndex(columnName);
 
-            if (value is int)
+            if (value is char)
+                queryHandle.IntGreater(columnIndex, (int)value);
+            else if (value is int)
                 queryHandle.IntGreater(columnIndex, (int)value);
             else if (value is long)
                 queryHandle.LongGreater(columnIndex, (long)value);
@@ -555,7 +577,9 @@ namespace Realms
         {
             var columnIndex = queryHandle.GetColumnIndex(columnName);
 
-            if (value is int)
+            if (value is char)
+                queryHandle.IntGreaterEqual(columnIndex, (int)value);
+            else if (value is int)
                 queryHandle.IntGreaterEqual(columnIndex, (int)value);
             else if (value is long)
                 queryHandle.LongGreaterEqual(columnIndex, (long)value);

--- a/Tests/IntegrationTests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Tests/IntegrationTests.Shared/RealmResults/SimpleLINQtests.cs
@@ -586,18 +586,5 @@ namespace IntegrationTests
             Assert.That(johnScorer.FullName, Is.EqualTo("John Doe"));
         }
 
-        /// <summary>
-        ///  Test primarily to see our message when user has wrong parameter type.
-        /// </summary>
-        [Test]
-        public void IntegerConversionTriggersError()
-        {
-            long biggerInt = 12;
-            //if you want to see the error message, comment out the assert
-            Assert.Throws<System.NotSupportedException>(() => {
-                _realm.All<PrimaryKeyInt16Object>().First(p => p.Int16Property == biggerInt);
-            });
-        }
-
     } // SimpleLINQtests
 }

--- a/Tests/IntegrationTests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Tests/IntegrationTests.Shared/RealmResults/SimpleLINQtests.cs
@@ -286,6 +286,53 @@ namespace IntegrationTests
         }
 
         [Test]
+        public void SearchComparingChar()
+        {
+            _realm.Write( () => {
+                var c1 = _realm.CreateObject<PrimaryKeyCharObject>();
+                c1.CharProperty = 'A';
+                var c2 = _realm.CreateObject<PrimaryKeyCharObject>();
+                c2.CharProperty = 'B';
+                var c3 = _realm.CreateObject<PrimaryKeyCharObject>();
+                c3.CharProperty = 'c';
+                var c4 = _realm.CreateObject<PrimaryKeyCharObject>();
+                c4.CharProperty = 'a';
+            });
+            var equality = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty == 'A').ToArray();
+            Assert.That(equality.Select(p => p.CharProperty), Is.EquivalentTo(
+                new []{'A'}));
+            
+
+            var inequality =_realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty != 'c').ToArray();
+            Assert.That(inequality.Select(p => p.CharProperty), Is.EquivalentTo(
+                new []{'A', 'B', 'a'}));
+
+            var lessThan =_realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty < 'c').ToArray();
+            Assert.That(lessThan.Select(p => p.CharProperty), Is.EquivalentTo(
+                new []{'A', 'B', 'a'}));
+
+            var lessOrEqualThan =_realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty <= 'c').ToArray();
+            Assert.That(lessOrEqualThan.Select(p => p.CharProperty), Is.EquivalentTo(
+                new []{'A', 'B', 'a', 'c'}));
+
+            var greaterThan =_realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty > 'a').ToArray();
+            Assert.That(greaterThan.Select(p => p.CharProperty), Is.EquivalentTo(
+                new []{'c'}));
+
+            var greaterOrEqualThan =_realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty >= 'B').ToArray();
+            Assert.That(greaterOrEqualThan.Select(p => p.CharProperty), Is.EquivalentTo(
+                new []{'B', 'a', 'c'}));
+
+            var between =_realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty > 'A' && p.CharProperty < 'a').ToArray();
+            Assert.That(between.Select(p => p.CharProperty), Is.EquivalentTo(
+                new []{'B'}));
+            
+            var missing = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty == 'X').ToArray();
+            Assert.That(missing.Length, Is.EqualTo(0));
+        }
+
+
+        [Test]
         public void AnySucceeds()
         {
             Assert.That(_realm.All<Person>().Where(p => p.Latitude > 50).Any());

--- a/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -19,7 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>

--- a/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
+++ b/Tests/IntegrationTests.XamarinIOS/IntegrationTests.XamarinIOS.csproj
@@ -19,7 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchArch>i386</MtouchArch>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2706,3 +2706,22 @@ RealmResultsVisitor.cs
   - added case for ElementAtOrDefault
 
 Global search and replace IndexOutOfRangeException with ArgumentOutOfRangeException
+
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#708 Support queries on char types
+
+SimpleLinqTests.cs
+- SearchComparingChar added
+
+RealmResultsVisitor.cs
+- add a case for char to
+  AddQueryEqual
+  AddQueryNotEqual
+  AddQueryLessThan
+  AddQueryLessThanOrEqual
+  AddQueryGreaterThan
+  AddQueryGreaterThanOrEqual
+- VisitBinary added detection of Convert on lhs
+  
+  


### PR DESCRIPTION
Fairly mechanical extension except ran into a weird LINQ behaviour at the top level - the lambda converts a literal char on the RHS into an `Int32` them wraps the character property on the LHS in a `Convert` which needed unpacking as a `UnaryExpression`. A nice side-effect is that also fixes errors if people use a different int type from their property, which has already caused at least one user bug report.

Branched off the `more-elements` branch rather than master as I expect to do a bunch of LINQ work before people have time to review, with absences this week.

@fealebenpae please review if you have time.