### PR TITLE
#833 ObjectForPrimaryKey possible failure with interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.78.1 (2016-09-15)
+-------------------
+### Bug fixes
+* `Realm.ObjectForPrimaryKey()` now returns null if it failed to find an object (#833).
+
 0.78.0 (2016-09-09)
 -------------------
 ### Breaking Changes

--- a/Realm.Shared/Realm.cs
+++ b/Realm.Shared/Realm.cs
@@ -695,6 +695,8 @@ namespace Realms
         {
             var metadata = Metadata[typeof(T).Name];
             var rowPtr = NativeTable.RowForPrimaryKey(metadata.Table, metadata.PrimaryKeyColumnIndex, id);
+            if (rowPtr == IntPtr.Zero)
+                return null;
             return (T)MakeObjectForRow(metadata, rowPtr);
         }
 
@@ -710,6 +712,8 @@ namespace Realms
         {
             var metadata = Metadata[typeof(T).Name];
             var rowPtr = NativeTable.RowForPrimaryKey(metadata.Table, metadata.PrimaryKeyColumnIndex, id);
+            if (rowPtr == IntPtr.Zero)
+                return null;
             return (T)MakeObjectForRow(metadata, rowPtr);
         }
 
@@ -725,6 +729,8 @@ namespace Realms
         {
             var metadata = Metadata[className];
             var rowPtr = NativeTable.RowForPrimaryKey(metadata.Table, metadata.PrimaryKeyColumnIndex, id);
+            if (rowPtr == IntPtr.Zero)
+                return null;
             return MakeObjectForRow(metadata, rowPtr);
         }
 
@@ -740,6 +746,8 @@ namespace Realms
         {
             var metadata = Metadata[className];
             var rowPtr = NativeTable.RowForPrimaryKey(metadata.Table, metadata.PrimaryKeyColumnIndex, id);
+            if (rowPtr == IntPtr.Zero)
+                return null;
             return MakeObjectForRow(metadata, rowPtr);
         }
         #endregion ObjectForPrimaryKey

--- a/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
+++ b/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
@@ -113,6 +113,15 @@ namespace IntegrationTests.Shared
             Assert.That(foundObj.Int64Property, Is.EqualTo(42000042));
         }
 
+
+        [Test]
+        public void DontFindByInt64PrimaryKey()
+        {
+            var foundObj = _realm.ObjectForPrimaryKey<PrimaryKeyInt64Object>(3);
+            Assert.IsNull(foundObj);
+        }
+
+
         [Test]
         public void FindByStringPrimaryKey()
         {
@@ -124,6 +133,14 @@ namespace IntegrationTests.Shared
             var foundObj = _realm.ObjectForPrimaryKey<PrimaryKeyStringObject>("Zaphod");
             Assert.IsNotNull(foundObj);
             Assert.That(foundObj.StringProperty, Is.EqualTo("Zaphod"));
+        }
+
+
+        [Test]
+        public void DontFindByStringPrimaryKey()
+        {
+            var foundObj = _realm.ObjectForPrimaryKey<PrimaryKeyStringObject>("Ford");
+            Assert.IsNull(foundObj);
         }
 
 
@@ -140,6 +157,15 @@ namespace IntegrationTests.Shared
             Assert.That(foundObj.Int64Property, Is.EqualTo(42000042));
         }
 
+
+        [Test]
+        public void DontFindDynamicByInt64PrimaryKey()
+        {
+            dynamic foundObj = _realm.ObjectForPrimaryKey("PrimaryKeyInt64Object", 33);
+            Assert.IsNull(foundObj);
+        }
+
+
         [Test]
         public void FindDynamicByStringPrimaryKey()
         {
@@ -151,6 +177,14 @@ namespace IntegrationTests.Shared
             dynamic foundObj = _realm.ObjectForPrimaryKey("PrimaryKeyStringObject", "Zaphod");
             Assert.IsNotNull(foundObj);
             Assert.That(foundObj.StringProperty, Is.EqualTo("Zaphod"));
+        }
+
+
+        [Test]
+        public void DontFindDynamicByStringPrimaryKey()
+        {
+            dynamic foundObj = _realm.ObjectForPrimaryKey("PrimaryKeyStringObject", "Dent");
+            Assert.IsNull(foundObj);
         }
 
 
@@ -230,7 +264,18 @@ namespace IntegrationTests.Shared
             });
         }
 
-    
+
+        [Test]
+        public void PrimaryKeyFailsIfClassNotinRealm()
+        {
+            var conf = RealmConfiguration.DefaultConfiguration.ConfigWithPath("Skinny");
+            conf.ObjectClasses = new []{typeof(Person)};
+            var skinny = Realm.GetInstance(conf);
+            Assert.Throws<KeyNotFoundException>( () => {
+                var obj = skinny.ObjectForPrimaryKey<PrimaryKeyInt64Object>(42);
+            });
+        }
+            
     }
 }
 

--- a/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
+++ b/internals/Realm-dotnet Code Change Diary - Andy Dent.txt
@@ -2724,4 +2724,18 @@ RealmResultsVisitor.cs
   AddQueryGreaterThanOrEqual
 - VisitBinary added detection of Convert on lhs
   
+
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+#833 ObjectForPrimaryKey possible failure with interfaces
+
+PrimaryKeyTests.cs
+- PrimaryKeyFailsIfClassNotinRealm added
+- DontFindByStringPrimaryKey added
+- DontFindByInt64PrimaryKey added
+- DontFindDynamicByInt64PrimaryKey added
+- DontFindDynamicByStringPrimaryKey added
+
+Realm.cs
+- ObjectForPrimaryKey - all variations
+  - check for rowPtr returned as zero and return null to indicate not found
   


### PR DESCRIPTION
@kristiandupont  please review

PrimaryKeyTests.cs
- PrimaryKeyFailsIfClassNotinRealm added
- DontFindByStringPrimaryKey added
- DontFindByInt64PrimaryKey added
- DontFindDynamicByInt64PrimaryKey added
- DontFindDynamicByStringPrimaryKey added

Realm.cs
- ObjectForPrimaryKey - all variations
  - check for rowPtr returned as zero and return null to indicate not found