### PR TITLE
Add test showing how you can get a PK name as is from iterating schema

### DIFF
--- a/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
+++ b/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
@@ -290,11 +290,11 @@ namespace IntegrationTests.Shared
                 else
                 {
                     classesWithPK++;
-                    Debug.WriteLine($"PK test - {objSchema.Name} has a PK {primaryKeyProp.Name}");
+                    // uncomment the next line to see output list all primary keys in all classes in all unit tests
+                    // Debug.WriteLine($"PK test - {objSchema.Name} has a PK {primaryKeyProp.Name}");
                 }
             }
-            Assert.That(classesWitoutPK > classesWithPK);  // slightly crap assertion to ensure test works
-
+            Assert.That(classesWitoutPK > classesWithPK);  // simple assertion likely to remain valid regardless how many classes in test suite overall
         }
             
     }

--- a/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
+++ b/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
@@ -18,7 +18,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using System.Threading;
@@ -274,6 +274,27 @@ namespace IntegrationTests.Shared
             Assert.Throws<KeyNotFoundException>( () => {
                 var obj = skinny.ObjectForPrimaryKey<PrimaryKeyInt64Object>(42);
             });
+        }
+
+        // mostly a little test to show iterating schema and getting primary key names
+        [Test]
+        public void CanGetNameOfPrimaryKeyFromSchema()
+        {
+            int classesWithPK = 0;
+            int classesWitoutPK = 0;
+            foreach (var objSchema in _realm.Schema)
+            {
+                var primaryKeyProp = objSchema.Where(prop => prop.IsPrimaryKey).FirstOrDefault();
+                if (string.IsNullOrEmpty(primaryKeyProp.Name))
+                    classesWitoutPK++;
+                else
+                {
+                    classesWithPK++;
+                    Debug.WriteLine($"PK test - {objSchema.Name} has a PK {primaryKeyProp.Name}");
+                }
+            }
+            Assert.That(classesWitoutPK > classesWithPK);  // slightly crap assertion to ensure test works
+
         }
             
     }

--- a/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
+++ b/Tests/IntegrationTests.Shared/PrimaryKeyTests.cs
@@ -280,13 +280,13 @@ namespace IntegrationTests.Shared
         [Test]
         public void CanGetNameOfPrimaryKeyFromSchema()
         {
-            int classesWithPK = 0;
-            int classesWitoutPK = 0;
+            var classesWithPK = 0;
+            var classesWithoutPK = 0;
             foreach (var objSchema in _realm.Schema)
             {
-                var primaryKeyProp = objSchema.Where(prop => prop.IsPrimaryKey).FirstOrDefault();
+                var primaryKeyProp = objSchema.FirstOrDefault(prop => prop.IsPrimaryKey);
                 if (string.IsNullOrEmpty(primaryKeyProp.Name))
-                    classesWitoutPK++;
+                    classesWithoutPK++;
                 else
                 {
                     classesWithPK++;
@@ -294,7 +294,7 @@ namespace IntegrationTests.Shared
                     // Debug.WriteLine($"PK test - {objSchema.Name} has a PK {primaryKeyProp.Name}");
                 }
             }
-            Assert.That(classesWitoutPK > classesWithPK);  // simple assertion likely to remain valid regardless how many classes in test suite overall
+            Assert.That(classesWithoutPK > classesWithPK);  // simple assertion likely to remain valid regardless how many classes in test suite overall
         }
             
     }


### PR DESCRIPTION
I thought I might need a code change but ended up just adding this sample as a unit test to prove our existing schema info allows you to iterate classes and determine which have primary keys.

The need came from someone doing a complicated abstraction layer who wanted to use the dynamic form of `ObjectForPrimaryKey`
