### PR TITLE
Add a weaver warning when using DateTime? property

### DIFF
--- a/RealmWeaver/ModuleWeaver.cs
+++ b/RealmWeaver/ModuleWeaver.cs
@@ -414,6 +414,12 @@ public class ModuleWeaver
                 $"class '{type.Name}' field '{prop.Name}' is a DateTime which is not supported - use DateTimeOffset instead.",
                 sequencePoint);
         }
+        else if (prop.PropertyType.FullName == "System.Nullable`1<System.DateTime>")
+        {
+            LogErrorPoint(
+                $"class '{type.Name}' field '{prop.Name}' is a DateTime? which is not supported - use DateTimeOffset? instead.",
+                sequencePoint);
+        }
         else
         {
             LogErrorPoint(

--- a/Tests/WeaverTests/AssemblyToProcess/FaultyClasses.cs
+++ b/Tests/WeaverTests/AssemblyToProcess/FaultyClasses.cs
@@ -89,4 +89,19 @@ namespace AssemblyToProcess
         [Ignored]
         public int IgnoredProperty { get; set; }
     }
+
+    public class NotSupportedProperties : RealmObject
+    {
+        public DateTime DateTimeProperty { get; set; }
+
+        public DateTime? NullableDateTimeProperty { get; set; }
+
+        public MyEnum EnumProperty { get; set; }
+
+        public enum MyEnum
+        {
+            Value1,
+            Value2
+        }
+    }
 }

--- a/Tests/WeaverTests/RealmWeaver.Tests/WeaverTests.cs
+++ b/Tests/WeaverTests/RealmWeaver.Tests/WeaverTests.cs
@@ -464,7 +464,10 @@ namespace RealmWeaver
                 "PrimaryKeyProperties.SingleProperty is marked as [PrimaryKey] which is only allowed on integral and string types, not on System.Single",
                 "The type AssemblyToProcess.Employee indirectly inherits from RealmObject which is not supported",
                 "class DefaultConstructorMissing must have a public constructor that takes no parameters",
-                "class NoPersistedProperties is a RealmObject but has no persisted properties"
+                "class NoPersistedProperties is a RealmObject but has no persisted properties",
+                "class 'NotSupportedProperties' field 'DateTimeProperty' is a DateTime which is not supported - use DateTimeOffset instead.",
+                "class 'NotSupportedProperties' field 'NullableDateTimeProperty' is a DateTime? which is not supported - use DateTimeOffset? instead.",
+                "class 'NotSupportedProperties' field 'EnumProperty' is a 'AssemblyToProcess.NotSupportedProperties/MyEnum' which is not yet supported"
             };
 
             Assert.That(_errors, Is.EquivalentTo(expectedErrors));


### PR DESCRIPTION
Also, add a unit test for unsupported properties.

Fixes #686 