### PR TITLE
Remove RowIndex from ObjectHandle

### DIFF
--- a/Realm.Shared/Handles/ObjectHandle.cs
+++ b/Realm.Shared/Handles/ObjectHandle.cs
@@ -127,7 +127,12 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_remove_row", CallingConvention = CallingConvention.Cdecl)]
             public static extern void remove_row(ObjectHandle handle, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_equals_object", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr equals_object(ObjectHandle handle, ObjectHandle otherHandle, out NativeException ex);
         }
+
+        public static readonly ObjectHandle Null = new ObjectHandle(null);
 
         public bool IsValid
         {
@@ -137,18 +142,6 @@ namespace Realms
                 var result = NativeMethods.get_is_valid(this, out nativeException);
                 nativeException.ThrowIfNecessary();
                 return result == (IntPtr)1;  // inline equiv of IntPtrToBool
-            }
-        }
-
-        public IntPtr RowIndex
-        {
-            get
-            {
-                NativeException nativeException;
-                var result = NativeMethods.get_row_index(this, out nativeException);
-                nativeException.ThrowIfNecessary();
-
-                return result;
             }
         }
 
@@ -173,7 +166,17 @@ namespace Realms
                 return true;
             }
 
-            return RowIndex == (obj as ObjectHandle)?.RowIndex;
+            var otherHandle = obj as ObjectHandle;
+            if (ReferenceEquals(otherHandle, null))
+            {
+                return false;
+            }
+
+            NativeException nativeException;
+            var result = NativeMethods.equals_object(this, otherHandle, out nativeException);
+            nativeException.ThrowIfNecessary();
+
+            return MarshalHelpers.IntPtrToBool(result);
         }
 
         protected override void Unbind()

--- a/Realm.Shared/Handles/ObjectHandle.cs
+++ b/Realm.Shared/Handles/ObjectHandle.cs
@@ -129,10 +129,9 @@ namespace Realms
             public static extern void remove_row(ObjectHandle handle, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_equals_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr equals_object(ObjectHandle handle, ObjectHandle otherHandle, out NativeException ex);
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static extern bool equals_object(ObjectHandle handle, ObjectHandle otherHandle, out NativeException ex);
         }
-
-        public static readonly ObjectHandle Null = new ObjectHandle(null);
 
         public bool IsValid
         {
@@ -176,7 +175,7 @@ namespace Realms
             var result = NativeMethods.equals_object(this, otherHandle, out nativeException);
             nativeException.ThrowIfNecessary();
 
-            return MarshalHelpers.IntPtrToBool(result);
+            return result;
         }
 
         protected override void Unbind()

--- a/Realm.Shared/RealmList.cs
+++ b/Realm.Shared/RealmList.cs
@@ -183,8 +183,7 @@ namespace Realms
         public void Add(T item)
         {
             this.ManageObjectIfNeeded(item);
-            var rowIndex = item.ObjectHandle.RowIndex;
-            _listHandle.Add(rowIndex);
+            _listHandle.Add(item.ObjectHandle);
         }
 
         /// <summary>
@@ -257,8 +256,7 @@ namespace Realms
                 throw new ArgumentException("Value does not belong to a realm", nameof(item));
             }
 
-            var rowIndex = item.ObjectHandle.RowIndex;
-            return (int)_listHandle.Find(rowIndex, IntPtr.Zero);
+            return (int)_listHandle.Find(item.ObjectHandle, IntPtr.Zero);
         }
 
         /// <summary>
@@ -275,8 +273,7 @@ namespace Realms
             }
 
             this.ManageObjectIfNeeded(item);
-            var rowIndex = item.ObjectHandle.RowIndex;
-            _listHandle.Insert((IntPtr)index, rowIndex);
+            _listHandle.Insert((IntPtr)index, item.ObjectHandle);
         }
 
         /// <summary>

--- a/Realm.Shared/handles/LinkListHandle.cs
+++ b/Realm.Shared/handles/LinkListHandle.cs
@@ -26,13 +26,13 @@ namespace Realms
         private static class NativeMethods
         {
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "linklist_add", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add(LinkListHandle linklistHandle, IntPtr row_ndx, out NativeException ex);
+            public static extern void add(LinkListHandle linklistHandle, ObjectHandle objectHandle, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "linklist_insert", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void insert(LinkListHandle linklistHandle, IntPtr link_ndx, IntPtr row_ndx, out NativeException ex);
+            public static extern void insert(LinkListHandle linklistHandle, IntPtr targetIndex, ObjectHandle objectHandle, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "linklist_erase", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void erase(LinkListHandle linklistHandle, IntPtr row_ndx, out NativeException ex);
+            public static extern void erase(LinkListHandle linklistHandle, IntPtr rowIndex, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "linklist_clear", CallingConvention = CallingConvention.Cdecl)]
             public static extern void clear(LinkListHandle linklistHandle, out NativeException ex);
@@ -41,7 +41,7 @@ namespace Realms
             public static extern IntPtr get(LinkListHandle linklistHandle, SharedRealmHandle realmHandle, IntPtr link_ndx, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "linklist_find", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr find(LinkListHandle linklistHandle, IntPtr link_ndx, IntPtr start_from, out NativeException ex);
+            public static extern IntPtr find(LinkListHandle linklistHandle, ObjectHandle objectHandle, IntPtr start_from, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "linklist_size", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr size(LinkListHandle linklistHandle, out NativeException ex);
@@ -59,17 +59,17 @@ namespace Realms
             NativeMethods.destroy(handle);
         }
 
-        public void Add(IntPtr rowIndex)
+        public void Add(ObjectHandle objectHandle)
         {
             NativeException nativeException;
-            NativeMethods.add(this, rowIndex, out nativeException);
+            NativeMethods.add(this, objectHandle, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void Insert(IntPtr linkIndex, IntPtr rowIndex)
+        public void Insert(IntPtr targetIndex, ObjectHandle objectHandle)
         {
             NativeException nativeException;
-            NativeMethods.insert(this, linkIndex, rowIndex, out nativeException);
+            NativeMethods.insert(this, targetIndex, objectHandle, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
@@ -95,10 +95,10 @@ namespace Realms
             return result;
         }
 
-        public IntPtr Find(IntPtr linkIndex, IntPtr startFrom)
+        public IntPtr Find(ObjectHandle objectHandle, IntPtr startFrom)
         {
             NativeException nativeException;
-            var result = NativeMethods.find(this, linkIndex, startFrom, out nativeException);
+            var result = NativeMethods.find(this, objectHandle, startFrom, out nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm.Shared/handles/QueryHandle.cs
+++ b/Realm.Shared/handles/QueryHandle.cs
@@ -169,7 +169,7 @@ namespace Realms
             public static extern IntPtr findDirect(QueryHandle queryHandle, IntPtr beginAtIndex, SharedRealmHandle realmHandle, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_find_next", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr findNext(QueryHandle queryHandle, ObjectHandle previousObject, SharedRealmHandle realmHandle, out NativeException ex);
+            public static extern IntPtr findNext(QueryHandle queryHandle, ObjectHandle previousObject, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_get_column_index", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_column_index(QueryHandle queryPtr,
@@ -499,15 +499,10 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public IntPtr FindNext(SharedRealmHandle sharedRealm, ObjectHandle afterObject)
+        public IntPtr FindNext(ObjectHandle afterObject)
         {
-            if (afterObject == null)
-            {
-                return FindDirect(sharedRealm);
-            }
-
             NativeException nativeException;
-            var result = NativeMethods.findNext(this, afterObject, sharedRealm, out nativeException);
+            var result = NativeMethods.findNext(this, afterObject, out nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm.Shared/handles/QueryHandle.cs
+++ b/Realm.Shared/handles/QueryHandle.cs
@@ -168,6 +168,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_find", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr findDirect(QueryHandle queryHandle, IntPtr beginAtIndex, SharedRealmHandle realmHandle, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_find_next", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr findNext(QueryHandle queryHandle, ObjectHandle previousObject, SharedRealmHandle realmHandle, out NativeException ex);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_get_column_index", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_column_index(QueryHandle queryPtr,
                         [MarshalAs(UnmanagedType.LPWStr)] string columnName, IntPtr columnNameLen, out NativeException ex);
@@ -496,10 +499,23 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public IntPtr FindDirect(IntPtr beginAtIndex, SharedRealmHandle sharedRealm)
+        public IntPtr FindNext(SharedRealmHandle sharedRealm, ObjectHandle afterObject)
+        {
+            if (afterObject == null)
+            {
+                return FindDirect(sharedRealm);
+            }
+
+            NativeException nativeException;
+            var result = NativeMethods.findNext(this, afterObject, sharedRealm, out nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public IntPtr FindDirect(SharedRealmHandle sharedRealm, IntPtr? beginAtIndex = null)
         {
             NativeException nativeException;
-            var result = NativeMethods.findDirect(this, beginAtIndex, sharedRealm, out nativeException);
+            var result = NativeMethods.findDirect(this, beginAtIndex ?? IntPtr.Zero, sharedRealm, out nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm.Shared/linq/RealmResultsVisitor.cs
+++ b/Realm.Shared/linq/RealmResultsVisitor.cs
@@ -268,7 +268,7 @@ namespace Realms
                     }
 
                     var firstObject = Realm.CreateObjectHandle(firstObjectPtr, _realm.SharedRealmHandle);
-                    var nextObjectPtr = CoreQueryHandle.FindNext(_realm.SharedRealmHandle, firstObject);
+                    var nextObjectPtr = CoreQueryHandle.FindNext(firstObject);
                     if (nextObjectPtr != IntPtr.Zero)
                     {
                         throw new InvalidOperationException("Sequence contains more than one matching element");

--- a/Realm.Shared/linq/RealmResultsVisitor.cs
+++ b/Realm.Shared/linq/RealmResultsVisitor.cs
@@ -136,7 +136,7 @@ namespace Realms
             ObjectHandle obj;
             if (OptionalSortDescriptorBuilder == null)
             {
-                var objectPtr = CoreQueryHandle.FindDirect((IntPtr)index, _realm.SharedRealmHandle);
+                var objectPtr = CoreQueryHandle.FindDirect(_realm.SharedRealmHandle, (IntPtr)index);
                 obj = Realm.CreateObjectHandle(objectPtr, _realm.SharedRealmHandle);
             }
             else
@@ -201,7 +201,7 @@ namespace Realms
                 if (m.Method.Name == nameof(Queryable.Any))
                 {
                     RecurseToWhereOrRunLambda(m);
-                    var foundAny = CoreQueryHandle.FindDirect(IntPtr.Zero, _realm.SharedRealmHandle) != IntPtr.Zero;
+                    var foundAny = CoreQueryHandle.FindDirect(_realm.SharedRealmHandle) != IntPtr.Zero;
                     return Expression.Constant(foundAny);
                 }
 
@@ -211,7 +211,7 @@ namespace Realms
                     var firstObjectPtr = IntPtr.Zero;
                     if (OptionalSortDescriptorBuilder == null)
                     {
-                        firstObjectPtr = CoreQueryHandle.FindDirect(IntPtr.Zero, _realm.SharedRealmHandle);
+                        firstObjectPtr = CoreQueryHandle.FindDirect(_realm.SharedRealmHandle);
                     }
                     else
                     {
@@ -255,7 +255,7 @@ namespace Realms
                 if (m.Method.Name.StartsWith(nameof(Queryable.Single)))  // same as unsorted First with extra checks
                 {
                     RecurseToWhereOrRunLambda(m);
-                    var firstObjectPtr = CoreQueryHandle.FindDirect(IntPtr.Zero, _realm.SharedRealmHandle);
+                    var firstObjectPtr = CoreQueryHandle.FindDirect(_realm.SharedRealmHandle);
                     if (firstObjectPtr == IntPtr.Zero)
                     {
                         if (m.Method.Name == nameof(Queryable.Single))
@@ -268,8 +268,7 @@ namespace Realms
                     }
 
                     var firstObject = Realm.CreateObjectHandle(firstObjectPtr, _realm.SharedRealmHandle);
-                    var nextIndex = firstObject.RowIndex + 1;
-                    var nextObjectPtr = CoreQueryHandle.FindDirect(nextIndex, _realm.SharedRealmHandle);
+                    var nextObjectPtr = CoreQueryHandle.FindNext(_realm.SharedRealmHandle, firstObject);
                     if (nextObjectPtr != IntPtr.Zero)
                     {
                         throw new InvalidOperationException("Sequence contains more than one matching element");

--- a/wrappers/src/linklist_cs.cpp
+++ b/wrappers/src/linklist_cs.cpp
@@ -30,21 +30,21 @@ using namespace realm::binding;
 
 extern "C" {
   
-REALM_EXPORT void linklist_add(SharedLinkViewRef* linklist_ptr, size_t row_ndx, NativeException::Marshallable& ex)
+REALM_EXPORT void linklist_add(SharedLinkViewRef* linklist_ptr, const Object& object_ptr, NativeException::Marshallable& ex)
 {
-  handle_errors(ex, [&]() {
-    (**linklist_ptr)->add(row_ndx);
-  });
+    handle_errors(ex, [&]() {
+        (**linklist_ptr)->add(object_ptr.row().get_index());
+    });
 }
 
-REALM_EXPORT void linklist_insert(SharedLinkViewRef* linklist_ptr, size_t link_ndx, size_t row_ndx, NativeException::Marshallable& ex)
+REALM_EXPORT void linklist_insert(SharedLinkViewRef* linklist_ptr, size_t link_ndx, const Object& object_ptr, NativeException::Marshallable& ex)
 {
-  handle_errors(ex, [&]() {
-    const size_t count = (**linklist_ptr)->size();
-    if (link_ndx >= count)
-      throw IndexOutOfRangeException("Insert into RealmList", link_ndx, count);
-    (**linklist_ptr)->insert(link_ndx, row_ndx);
-  });
+    handle_errors(ex, [&]() {
+        const size_t count = (**linklist_ptr)->size();
+        if (link_ndx >= count)
+            throw IndexOutOfRangeException("Insert into RealmList", link_ndx, count);
+        (**linklist_ptr)->insert(link_ndx, object_ptr.row().get_index());
+    });
 }
 
 REALM_EXPORT Object* linklist_get(SharedLinkViewRef* linklist_ptr, SharedRealm* realm, size_t link_ndx, NativeException::Marshallable& ex)
@@ -60,30 +60,29 @@ REALM_EXPORT Object* linklist_get(SharedLinkViewRef* linklist_ptr, SharedRealm* 
     });
 }
 
-REALM_EXPORT size_t linklist_find(SharedLinkViewRef* linklist_ptr, size_t row_ndx, size_t start_from, NativeException::Marshallable& ex)
+REALM_EXPORT size_t linklist_find(SharedLinkViewRef* linklist_ptr, const Object& object_ptr, size_t start_from, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
-        return (**linklist_ptr)->find(row_ndx, start_from);
+        return (**linklist_ptr)->find(object_ptr.row().get_index(), start_from);
     });
 }
 
 REALM_EXPORT void linklist_erase(SharedLinkViewRef* linklist_ptr, size_t link_ndx, NativeException::Marshallable& ex)
 {
-  handle_errors(ex, [&]() {
-    const size_t count = (**linklist_ptr)->size();
-    if (link_ndx >= count)
-      throw IndexOutOfRangeException("Erase item in RealmList", link_ndx, count);
-    _impl::LinkListFriend::do_remove(***linklist_ptr,  link_ndx);
-  });
+    handle_errors(ex, [&]() {
+        const size_t count = (**linklist_ptr)->size();
+        if (link_ndx >= count)
+            throw IndexOutOfRangeException("Erase item in RealmList", link_ndx, count);
+        _impl::LinkListFriend::do_remove(***linklist_ptr,  link_ndx);
+    });
 }
 
 REALM_EXPORT void linklist_clear(SharedLinkViewRef* linklist_ptr, NativeException::Marshallable& ex)
 {
-  handle_errors(ex, [&]() {
-    (**linklist_ptr)->clear();
-  });
+    handle_errors(ex, [&]() {
+        (**linklist_ptr)->clear();
+    });
 }
-
 
 REALM_EXPORT size_t linklist_size(SharedLinkViewRef* linklist_ptr, NativeException::Marshallable& ex)
 {
@@ -91,7 +90,6 @@ REALM_EXPORT size_t linklist_size(SharedLinkViewRef* linklist_ptr, NativeExcepti
         return (**linklist_ptr)->size();
     });
 }
-
   
 REALM_EXPORT void linklist_destroy(SharedLinkViewRef* linklist_ptr)
 {

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -29,10 +29,10 @@ using namespace realm;
 using namespace realm::binding;
 
 extern "C" {
-    REALM_EXPORT size_t object_get_is_valid(const Object* object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_is_valid(const Object& object_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            return bool_to_size_t(object_ptr->is_valid());
+            return bool_to_size_t(object_ptr.is_valid());
         });
     }
     
@@ -41,160 +41,160 @@ extern "C" {
         delete object_ptr;
     }
     
-    REALM_EXPORT size_t object_get_row_index(const Object* object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_row_index(const Object& object_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            if (!object_ptr->is_valid())
+            if (!object_ptr.is_valid())
                 throw RowDetachedException();
-            return object_ptr->row().get_index();
+            return object_ptr.row().get_index();
         });
     }
     
     
-    REALM_EXPORT Object* object_get_link(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT Object* object_get_link(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() -> Object* {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            const size_t link_row_ndx = object_ptr->row().get_link(column_ndx);
+            const size_t link_row_ndx = object_ptr.row().get_link(column_ndx);
             if (link_row_ndx == realm::npos)
                 return nullptr;
             
-            auto target_table_ptr = object_ptr->row().get_table()->get_link_target(column_ndx);
+            auto target_table_ptr = object_ptr.row().get_table()->get_link_target(column_ndx);
             const std::string target_name(ObjectStore::object_type_for_table_name(target_table_ptr->get_name()));
-            auto& target_schema = *object_ptr->realm()->schema().find(target_name);
-            return new Object(object_ptr->realm(), target_schema, Row((*target_table_ptr)[link_row_ndx]));
+            auto& target_schema = *object_ptr.realm()->schema().find(target_name);
+            return new Object(object_ptr.realm(), target_schema, Row((*target_table_ptr)[link_row_ndx]));
         });
     }
     
-    REALM_EXPORT SharedLinkViewRef* object_get_linklist(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT SharedLinkViewRef* object_get_linklist(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() -> SharedLinkViewRef* {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
             return new SharedLinkViewRef {
-                std::make_shared<LinkViewRef>(object_ptr->row().get_linklist(column_ndx))
+                std::make_shared<LinkViewRef>(object_ptr.row().get_linklist(column_ndx))
             };  // weird double-layering necessary to get a raw pointer to a shared_ptr
         });
     }
     
-    REALM_EXPORT size_t object_linklist_is_empty(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_linklist_is_empty(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return bool_to_size_t(object_ptr->row().linklist_is_empty(column_ndx));
+            return bool_to_size_t(object_ptr.row().linklist_is_empty(column_ndx));
         });
     }
     
     
-    REALM_EXPORT size_t object_get_bool(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_bool(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return bool_to_size_t(object_ptr->row().get_bool(column_ndx));
+            return bool_to_size_t(object_ptr.row().get_bool(column_ndx));
         });
     }
     
     // Return value is a boolean indicating whether result has a value (i.e. is not null). If true (1), ret_value will contain the actual value.
-    REALM_EXPORT size_t object_get_nullable_bool(const Object* object_ptr, size_t property_ndx, size_t& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_bool(const Object& object_ptr, size_t property_ndx, size_t& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr->row().is_null(column_ndx))
+            if (object_ptr.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = bool_to_size_t(object_ptr->row().get_bool(column_ndx));
+            ret_value = bool_to_size_t(object_ptr.row().get_bool(column_ndx));
             return 1;
         });
     }
     
-    REALM_EXPORT int64_t object_get_int64(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT int64_t object_get_int64(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return object_ptr->row().get_int(column_ndx);
+            return object_ptr.row().get_int(column_ndx);
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_int64(const Object* object_ptr, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_int64(const Object& object_ptr, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr->row().is_null(column_ndx))
+            if (object_ptr.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = object_ptr->row().get_int(column_ndx);
+            ret_value = object_ptr.row().get_int(column_ndx);
             return 1;
         });
     }
     
-    REALM_EXPORT float object_get_float(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT float object_get_float(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return object_ptr->row().get_float(column_ndx);
+            return object_ptr.row().get_float(column_ndx);
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_float(const Object* object_ptr, size_t property_ndx, float& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_float(const Object& object_ptr, size_t property_ndx, float& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr->row().is_null(column_ndx))
+            if (object_ptr.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = object_ptr->row().get_float(column_ndx);
+            ret_value = object_ptr.row().get_float(column_ndx);
             return 1;
         });
     }
     
-    REALM_EXPORT double object_get_double(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT double object_get_double(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return object_ptr->row().get_double(column_ndx);
+            return object_ptr.row().get_double(column_ndx);
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_double(const Object* object_ptr, size_t property_ndx, double& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_double(const Object& object_ptr, size_t property_ndx, double& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr->row().is_null(column_ndx))
+            if (object_ptr.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = object_ptr->row().get_double(column_ndx);
+            ret_value = object_ptr.row().get_double(column_ndx);
             return 1;
         });
     }
     
-    REALM_EXPORT size_t object_get_string(const Object* object_ptr, size_t property_ndx, uint16_t * datatochsarp, size_t bufsize, bool* is_null, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_string(const Object& object_ptr, size_t property_ndx, uint16_t * datatochsarp, size_t bufsize, bool* is_null, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() -> size_t {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            const StringData fielddata(object_ptr->row().get_string(column_ndx));
+            const StringData fielddata(object_ptr.row().get_string(column_ndx));
             if ((*is_null = fielddata.is_null()))
                 return 0;
             
@@ -202,13 +202,13 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT size_t object_get_binary(const Object* object_ptr, size_t property_ndx, const char*& return_buffer, size_t& return_size, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_binary(const Object& object_ptr, size_t property_ndx, const char*& return_buffer, size_t& return_size, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            const BinaryData fielddata = object_ptr->row().get_binary(column_ndx);
+            const BinaryData fielddata = object_ptr.row().get_binary(column_ndx);
             
             if (fielddata.is_null())
                 return 0;
@@ -219,175 +219,183 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT int64_t object_get_timestamp_ticks(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT int64_t object_get_timestamp_ticks(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return to_ticks(object_ptr->row().get_timestamp(column_ndx));
+            return to_ticks(object_ptr.row().get_timestamp(column_ndx));
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_timestamp_ticks(const Object* object_ptr, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_timestamp_ticks(const Object& object_ptr, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_get(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr->row().is_null(column_ndx))
+            if (object_ptr.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = to_ticks(object_ptr->row().get_timestamp(column_ndx));
+            ret_value = to_ticks(object_ptr.row().get_timestamp(column_ndx));
             return 1;
         });
     }
     
-    REALM_EXPORT void object_set_link(const Object* object_ptr, size_t property_ndx, const Object* target_object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_link(const Object& object_ptr, size_t property_ndx, const Object& target_object_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().set_link(column_ndx, target_object_ptr->row().get_index());
+            object_ptr.row().set_link(column_ndx, target_object_ptr.row().get_index());
         });
     }
     
-    REALM_EXPORT void object_clear_link(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_clear_link(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().nullify_link(column_ndx);
+            object_ptr.row().nullify_link(column_ndx);
         });
     }
     
-    REALM_EXPORT void object_set_null(const Object* object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_null(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (!object_ptr->row().get_table()->is_nullable(column_ndx))
+            if (!object_ptr.row().get_table()->is_nullable(column_ndx))
                 throw std::invalid_argument("Column is not nullable");
             
-            object_ptr->row().set_null(column_ndx);
+            object_ptr.row().set_null(column_ndx);
         });
     }
     
-    REALM_EXPORT void object_set_bool(const Object* object_ptr, size_t property_ndx, size_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_bool(const Object& object_ptr, size_t property_ndx, size_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().set_bool(column_ndx, size_t_to_bool(value));
+            object_ptr.row().set_bool(column_ndx, size_t_to_bool(value));
         });
     }
     
-    REALM_EXPORT void object_set_int64(const Object* object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_int64(const Object& object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().set_int(column_ndx, value);
+            object_ptr.row().set_int(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_int64_unique(const Object* object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_int64_unique(const Object& object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr->row().get_table()->find_first_int(column_ndx, value) != not_found) {
+            if (object_ptr.row().get_table()->find_first_int(column_ndx, value) != not_found) {
                 throw SetDuplicatePrimaryKeyValueException(
-                                                           object_ptr->row().get_table()->get_name(),
-                                                           object_ptr->row().get_table()->get_column_name(column_ndx),
+                                                           object_ptr.row().get_table()->get_name(),
+                                                           object_ptr.row().get_table()->get_column_name(column_ndx),
                                                            util::format("%1", value)
                                                            );
             }
-            object_ptr->row().set_int_unique(column_ndx, value);
+            object_ptr.row().set_int_unique(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_float(const Object* object_ptr, size_t property_ndx, float value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_float(const Object& object_ptr, size_t property_ndx, float value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().set_float(column_ndx, value);
+            object_ptr.row().set_float(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_double(const Object* object_ptr, size_t property_ndx, double value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_double(const Object& object_ptr, size_t property_ndx, double value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().set_double(column_ndx, value);
+            object_ptr.row().set_double(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_string(const Object* object_ptr, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
-    {
-        return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
-            
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            Utf16StringAccessor str(value, value_len);
-            object_ptr->row().set_string(column_ndx, str);
-        });
-    }
-    
-    REALM_EXPORT void object_set_string_unique(const Object* object_ptr, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_string(const Object& object_ptr, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
             Utf16StringAccessor str(value, value_len);
-            if (object_ptr->row().get_table()->find_first_string(column_ndx, str) != not_found) {
+            object_ptr.row().set_string(column_ndx, str);
+        });
+    }
+    
+    REALM_EXPORT void object_set_string_unique(const Object& object_ptr, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [&]() {
+            verify_can_set(object_ptr);
+            
+            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
+            Utf16StringAccessor str(value, value_len);
+            if (object_ptr.row().get_table()->find_first_string(column_ndx, str) != not_found) {
                 throw SetDuplicatePrimaryKeyValueException(
-                                                           object_ptr->row().get_table()->get_name(),
-                                                           object_ptr->row().get_table()->get_column_name(column_ndx),
+                                                           object_ptr.row().get_table()->get_name(),
+                                                           object_ptr.row().get_table()->get_column_name(column_ndx),
                                                            str.to_string()
                                                            );
             }
-            object_ptr->row().set_string_unique(column_ndx, str);
+            object_ptr.row().set_string_unique(column_ndx, str);
         });
     }
     
-    REALM_EXPORT void object_set_binary(const Object* object_ptr, size_t property_ndx, char* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_binary(const Object& object_ptr, size_t property_ndx, char* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().set_binary(column_ndx, BinaryData(value, value_len));
+            object_ptr.row().set_binary(column_ndx, BinaryData(value, value_len));
         });
     }
     
-    REALM_EXPORT void object_set_timestamp_ticks(const Object* object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_timestamp_ticks(const Object& object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
             const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr->row().set_timestamp(column_ndx, from_ticks(value));
+            object_ptr.row().set_timestamp(column_ndx, from_ticks(value));
         });
     }
     
-    REALM_EXPORT void object_remove_row(Object* object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_remove_row(const Object& object_ptr, NativeException::Marshallable& ex)
     {
         handle_errors(ex, [&]() {
             verify_can_set(object_ptr);
             
-            object_ptr->row().get_table()->move_last_over(object_ptr -> row().get_index());
+            object_ptr.row().get_table()->move_last_over(object_ptr.row().get_index());
+        });
+    }
+    
+    REALM_EXPORT size_t object_equals_object(const Object& object_ptr, const Object& other_object_ptr, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [&]() {
+            auto are_equal = object_ptr.row().get_index() == other_object_ptr.row().get_index();
+            return bool_to_size_t(are_equal);
         });
     }
     

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -29,172 +29,172 @@ using namespace realm;
 using namespace realm::binding;
 
 extern "C" {
-    REALM_EXPORT size_t object_get_is_valid(const Object& object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_is_valid(const Object& object, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            return bool_to_size_t(object_ptr.is_valid());
+            return bool_to_size_t(object.is_valid());
         });
     }
     
-    REALM_EXPORT void object_destroy(Object* object_ptr)
+    REALM_EXPORT void object_destroy(Object* object)
     {
-        delete object_ptr;
+        delete object;
     }
     
-    REALM_EXPORT size_t object_get_row_index(const Object& object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_row_index(const Object& object, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            if (!object_ptr.is_valid())
+            if (!object.is_valid())
                 throw RowDetachedException();
-            return object_ptr.row().get_index();
+            return object.row().get_index();
         });
     }
     
     
-    REALM_EXPORT Object* object_get_link(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT Object* object_get_link(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() -> Object* {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            const size_t link_row_ndx = object_ptr.row().get_link(column_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            const size_t link_row_ndx = object.row().get_link(column_ndx);
             if (link_row_ndx == realm::npos)
                 return nullptr;
             
-            auto target_table_ptr = object_ptr.row().get_table()->get_link_target(column_ndx);
+            auto target_table_ptr = object.row().get_table()->get_link_target(column_ndx);
             const std::string target_name(ObjectStore::object_type_for_table_name(target_table_ptr->get_name()));
-            auto& target_schema = *object_ptr.realm()->schema().find(target_name);
-            return new Object(object_ptr.realm(), target_schema, Row((*target_table_ptr)[link_row_ndx]));
+            auto& target_schema = *object.realm()->schema().find(target_name);
+            return new Object(object.realm(), target_schema, Row((*target_table_ptr)[link_row_ndx]));
         });
     }
     
-    REALM_EXPORT SharedLinkViewRef* object_get_linklist(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT SharedLinkViewRef* object_get_linklist(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() -> SharedLinkViewRef* {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
             return new SharedLinkViewRef {
-                std::make_shared<LinkViewRef>(object_ptr.row().get_linklist(column_ndx))
+                std::make_shared<LinkViewRef>(object.row().get_linklist(column_ndx))
             };  // weird double-layering necessary to get a raw pointer to a shared_ptr
         });
     }
     
-    REALM_EXPORT size_t object_linklist_is_empty(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_linklist_is_empty(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return bool_to_size_t(object_ptr.row().linklist_is_empty(column_ndx));
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            return bool_to_size_t(object.row().linklist_is_empty(column_ndx));
         });
     }
     
     
-    REALM_EXPORT size_t object_get_bool(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_bool(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return bool_to_size_t(object_ptr.row().get_bool(column_ndx));
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            return bool_to_size_t(object.row().get_bool(column_ndx));
         });
     }
     
     // Return value is a boolean indicating whether result has a value (i.e. is not null). If true (1), ret_value will contain the actual value.
-    REALM_EXPORT size_t object_get_nullable_bool(const Object& object_ptr, size_t property_ndx, size_t& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_bool(const Object& object, size_t property_ndx, size_t& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr.row().is_null(column_ndx))
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            if (object.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = bool_to_size_t(object_ptr.row().get_bool(column_ndx));
+            ret_value = bool_to_size_t(object.row().get_bool(column_ndx));
             return 1;
         });
     }
     
-    REALM_EXPORT int64_t object_get_int64(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT int64_t object_get_int64(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return object_ptr.row().get_int(column_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            return object.row().get_int(column_ndx);
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_int64(const Object& object_ptr, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_int64(const Object& object, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr.row().is_null(column_ndx))
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            if (object.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = object_ptr.row().get_int(column_ndx);
+            ret_value = object.row().get_int(column_ndx);
             return 1;
         });
     }
     
-    REALM_EXPORT float object_get_float(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT float object_get_float(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return object_ptr.row().get_float(column_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            return object.row().get_float(column_ndx);
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_float(const Object& object_ptr, size_t property_ndx, float& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_float(const Object& object, size_t property_ndx, float& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr.row().is_null(column_ndx))
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            if (object.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = object_ptr.row().get_float(column_ndx);
+            ret_value = object.row().get_float(column_ndx);
             return 1;
         });
     }
     
-    REALM_EXPORT double object_get_double(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT double object_get_double(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return object_ptr.row().get_double(column_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            return object.row().get_double(column_ndx);
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_double(const Object& object_ptr, size_t property_ndx, double& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_double(const Object& object, size_t property_ndx, double& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr.row().is_null(column_ndx))
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            if (object.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = object_ptr.row().get_double(column_ndx);
+            ret_value = object.row().get_double(column_ndx);
             return 1;
         });
     }
     
-    REALM_EXPORT size_t object_get_string(const Object& object_ptr, size_t property_ndx, uint16_t * datatochsarp, size_t bufsize, bool* is_null, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_string(const Object& object, size_t property_ndx, uint16_t * datatochsarp, size_t bufsize, bool* is_null, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() -> size_t {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            const StringData fielddata(object_ptr.row().get_string(column_ndx));
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            const StringData fielddata(object.row().get_string(column_ndx));
             if ((*is_null = fielddata.is_null()))
                 return 0;
             
@@ -202,13 +202,13 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT size_t object_get_binary(const Object& object_ptr, size_t property_ndx, const char*& return_buffer, size_t& return_size, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_binary(const Object& object, size_t property_ndx, const char*& return_buffer, size_t& return_size, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            const BinaryData fielddata = object_ptr.row().get_binary(column_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            const BinaryData fielddata = object.row().get_binary(column_ndx);
             
             if (fielddata.is_null())
                 return 0;
@@ -219,183 +219,182 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT int64_t object_get_timestamp_ticks(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT int64_t object_get_timestamp_ticks(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            return to_ticks(object_ptr.row().get_timestamp(column_ndx));
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            return to_ticks(object.row().get_timestamp(column_ndx));
         });
     }
     
-    REALM_EXPORT size_t object_get_nullable_timestamp_ticks(const Object& object_ptr, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
+    REALM_EXPORT size_t object_get_nullable_timestamp_ticks(const Object& object, size_t property_ndx, int64_t& ret_value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_get(object_ptr);
+            verify_can_get(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr.row().is_null(column_ndx))
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            if (object.row().is_null(column_ndx))
                 return 0;
             
-            ret_value = to_ticks(object_ptr.row().get_timestamp(column_ndx));
+            ret_value = to_ticks(object.row().get_timestamp(column_ndx));
             return 1;
         });
     }
     
-    REALM_EXPORT void object_set_link(const Object& object_ptr, size_t property_ndx, const Object& target_object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_link(const Object& object, size_t property_ndx, const Object& target_object, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().set_link(column_ndx, target_object_ptr.row().get_index());
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().set_link(column_ndx, target_object.row().get_index());
         });
     }
     
-    REALM_EXPORT void object_clear_link(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_clear_link(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().nullify_link(column_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().nullify_link(column_ndx);
         });
     }
     
-    REALM_EXPORT void object_set_null(const Object& object_ptr, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_null(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (!object_ptr.row().get_table()->is_nullable(column_ndx))
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            if (!object.row().get_table()->is_nullable(column_ndx))
                 throw std::invalid_argument("Column is not nullable");
             
-            object_ptr.row().set_null(column_ndx);
+            object.row().set_null(column_ndx);
         });
     }
     
-    REALM_EXPORT void object_set_bool(const Object& object_ptr, size_t property_ndx, size_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_bool(const Object& object, size_t property_ndx, size_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().set_bool(column_ndx, size_t_to_bool(value));
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().set_bool(column_ndx, size_t_to_bool(value));
         });
     }
     
-    REALM_EXPORT void object_set_int64(const Object& object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_int64(const Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().set_int(column_ndx, value);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().set_int(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_int64_unique(const Object& object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_int64_unique(const Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            if (object_ptr.row().get_table()->find_first_int(column_ndx, value) != not_found) {
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            if (object.row().get_table()->find_first_int(column_ndx, value) != not_found) {
                 throw SetDuplicatePrimaryKeyValueException(
-                                                           object_ptr.row().get_table()->get_name(),
-                                                           object_ptr.row().get_table()->get_column_name(column_ndx),
+                                                           object.row().get_table()->get_name(),
+                                                           object.row().get_table()->get_column_name(column_ndx),
                                                            util::format("%1", value)
                                                            );
             }
-            object_ptr.row().set_int_unique(column_ndx, value);
+            object.row().set_int_unique(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_float(const Object& object_ptr, size_t property_ndx, float value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_float(const Object& object, size_t property_ndx, float value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().set_float(column_ndx, value);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().set_float(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_double(const Object& object_ptr, size_t property_ndx, double value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_double(const Object& object, size_t property_ndx, double value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().set_double(column_ndx, value);
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().set_double(column_ndx, value);
         });
     }
     
-    REALM_EXPORT void object_set_string(const Object& object_ptr, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_string(const Object& object, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
             Utf16StringAccessor str(value, value_len);
-            object_ptr.row().set_string(column_ndx, str);
+            object.row().set_string(column_ndx, str);
         });
     }
     
-    REALM_EXPORT void object_set_string_unique(const Object& object_ptr, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_string_unique(const Object& object, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
+            const size_t column_ndx = get_column_index(object, property_ndx);
             Utf16StringAccessor str(value, value_len);
-            if (object_ptr.row().get_table()->find_first_string(column_ndx, str) != not_found) {
+            if (object.row().get_table()->find_first_string(column_ndx, str) != not_found) {
                 throw SetDuplicatePrimaryKeyValueException(
-                                                           object_ptr.row().get_table()->get_name(),
-                                                           object_ptr.row().get_table()->get_column_name(column_ndx),
+                                                           object.row().get_table()->get_name(),
+                                                           object.row().get_table()->get_column_name(column_ndx),
                                                            str.to_string()
                                                            );
             }
-            object_ptr.row().set_string_unique(column_ndx, str);
+            object.row().set_string_unique(column_ndx, str);
         });
     }
     
-    REALM_EXPORT void object_set_binary(const Object& object_ptr, size_t property_ndx, char* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_binary(const Object& object, size_t property_ndx, char* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().set_binary(column_ndx, BinaryData(value, value_len));
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().set_binary(column_ndx, BinaryData(value, value_len));
         });
     }
     
-    REALM_EXPORT void object_set_timestamp_ticks(const Object& object_ptr, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_timestamp_ticks(const Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            const size_t column_ndx = get_column_index(object_ptr, property_ndx);
-            object_ptr.row().set_timestamp(column_ndx, from_ticks(value));
+            const size_t column_ndx = get_column_index(object, property_ndx);
+            object.row().set_timestamp(column_ndx, from_ticks(value));
         });
     }
     
-    REALM_EXPORT void object_remove_row(const Object& object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_remove_row(const Object& object, NativeException::Marshallable& ex)
     {
         handle_errors(ex, [&]() {
-            verify_can_set(object_ptr);
+            verify_can_set(object);
             
-            object_ptr.row().get_table()->move_last_over(object_ptr.row().get_index());
+            object.row().get_table()->move_last_over(object.row().get_index());
         });
     }
     
-    REALM_EXPORT size_t object_equals_object(const Object& object_ptr, const Object& other_object_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT bool object_equals_object(const Object& object, const Object& other_object, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            auto are_equal = object_ptr.row().get_index() == other_object_ptr.row().get_index();
-            return bool_to_size_t(are_equal);
+            return object.row().get_index() == other_object.row().get_index();
         });
     }
     

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -243,7 +243,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_link(const Object& object, size_t property_ndx, const Object& target_object, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_link(Object& object, size_t property_ndx, const Object& target_object, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -253,7 +253,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_clear_link(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_clear_link(Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -263,7 +263,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_null(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_null(Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -276,7 +276,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_bool(const Object& object, size_t property_ndx, size_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_bool(Object& object, size_t property_ndx, size_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -286,7 +286,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_int64(const Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_int64(Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -296,7 +296,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_int64_unique(const Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_int64_unique(Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -313,7 +313,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_float(const Object& object, size_t property_ndx, float value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_float(Object& object, size_t property_ndx, float value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -323,7 +323,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_double(const Object& object, size_t property_ndx, double value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_double(Object& object, size_t property_ndx, double value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -333,7 +333,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_string(const Object& object, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_string(Object& object, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -344,7 +344,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_string_unique(const Object& object, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_string_unique(Object& object, size_t property_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -362,7 +362,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_binary(const Object& object, size_t property_ndx, char* value, size_t value_len, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_binary(Object& object, size_t property_ndx, char* value, size_t value_len, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -372,7 +372,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_set_timestamp_ticks(const Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_timestamp_ticks(Object& object, size_t property_ndx, int64_t value, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
@@ -382,7 +382,7 @@ extern "C" {
         });
     }
     
-    REALM_EXPORT void object_remove_row(const Object& object, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_remove_row(Object& object, NativeException::Marshallable& ex)
     {
         handle_errors(ex, [&]() {
             verify_can_set(object);

--- a/wrappers/src/object_cs.hpp
+++ b/wrappers/src/object_cs.hpp
@@ -19,27 +19,27 @@
 #include "object_accessor.hpp"
 
 namespace realm {
-    inline void verify_can_get(const Object* object_ptr) {
-        if (object_ptr->realm()->is_closed())
+    inline void verify_can_get(const Object& object_ptr) {
+        if (object_ptr.realm()->is_closed())
             throw RealmClosedException();
         
-        if (!object_ptr->is_valid())
+        if (!object_ptr.is_valid())
             throw RowDetachedException();
         
-        object_ptr->realm()->verify_thread();
+        object_ptr.realm()->verify_thread();
     }
     
-    inline void verify_can_set(const Object* object_ptr) {
-        if (object_ptr->realm()->is_closed())
+    inline void verify_can_set(const Object& object_ptr) {
+        if (object_ptr.realm()->is_closed())
             throw RealmClosedException();
         
-        if (!object_ptr->is_valid())
+        if (!object_ptr.is_valid())
             throw RowDetachedException();
         
-        object_ptr->realm()->verify_in_write();
+        object_ptr.realm()->verify_in_write();
     }
     
-    inline size_t get_column_index(const Object* object_ptr, size_t property_index) {
-        return object_ptr->get_object_schema().persisted_properties[property_index].table_column;
+    inline size_t get_column_index(const Object& object_ptr, size_t property_index) {
+        return object_ptr.get_object_schema().persisted_properties[property_index].table_column;
     }
 }

--- a/wrappers/src/object_cs.hpp
+++ b/wrappers/src/object_cs.hpp
@@ -19,27 +19,27 @@
 #include "object_accessor.hpp"
 
 namespace realm {
-    inline void verify_can_get(const Object& object_ptr) {
-        if (object_ptr.realm()->is_closed())
+    inline void verify_can_get(const Object& object) {
+        if (object.realm()->is_closed())
             throw RealmClosedException();
         
-        if (!object_ptr.is_valid())
+        if (!object.is_valid())
             throw RowDetachedException();
         
-        object_ptr.realm()->verify_thread();
+        object.realm()->verify_thread();
     }
     
-    inline void verify_can_set(const Object& object_ptr) {
-        if (object_ptr.realm()->is_closed())
+    inline void verify_can_set(const Object& object) {
+        if (object.realm()->is_closed())
             throw RealmClosedException();
         
-        if (!object_ptr.is_valid())
+        if (!object.is_valid())
             throw RowDetachedException();
         
-        object_ptr.realm()->verify_in_write();
+        object.realm()->verify_in_write();
     }
     
-    inline size_t get_column_index(const Object& object_ptr, size_t property_index) {
-        return object_ptr.get_object_schema().persisted_properties[property_index].table_column;
+    inline size_t get_column_index(const Object& object, size_t property_index) {
+        return object.get_object_schema().persisted_properties[property_index].table_column;
     }
 }

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -55,7 +55,12 @@ REALM_EXPORT Object* query_find(Query* query_ptr, size_t begin_at_table_row, Sha
         return new Object(*realm, object_schema, Row((*query_ptr->get_table())[row_ndx]));
     });
 }
-
+    
+REALM_EXPORT Object* query_find_next(Query* query_ptr, const Object& after_object, SharedRealm* realm, NativeException::Marshallable& ex)
+{
+    return query_find(query_ptr, after_object.row().get_index() + 1, realm, ex);
+}
+    
 REALM_EXPORT size_t query_count(Query * query_ptr, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -56,9 +56,10 @@ REALM_EXPORT Object* query_find(Query* query_ptr, size_t begin_at_table_row, Sha
     });
 }
     
-REALM_EXPORT Object* query_find_next(Query* query_ptr, const Object& after_object, SharedRealm* realm, NativeException::Marshallable& ex)
+REALM_EXPORT Object* query_find_next(Query* query_ptr, const Object& after_object, NativeException::Marshallable& ex)
 {
-    return query_find(query_ptr, after_object.row().get_index() + 1, realm, ex);
+    auto realm = after_object.realm();
+    return query_find(query_ptr, after_object.row().get_index() + 1, &realm, ex);
 }
     
 REALM_EXPORT size_t query_count(Query * query_ptr, NativeException::Marshallable& ex)


### PR DESCRIPTION
A follow-up to #866 - this removes the now-unnecessary `RowIndex` from the newly created `ObjectHandle`.