### PR TITLE
Don't crash when binding to removed object with relationship

### DIFF
--- a/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
+++ b/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
@@ -20,13 +20,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Realms
 {
     /// <summary>
     /// Base for any object that can be persisted in a Realm.
     /// </summary>
-    public class RealmObject
+    public class RealmObject : IReflectableType
     {
         private Realm _realm;  // may not be used but wanted it included in definition of IsManaged below.
 
@@ -333,6 +334,12 @@ namespace Realms
         {
             RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
             return false;
+        }
+
+        public TypeInfo GetTypeInfo()
+        {
+            RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
+            return null;
         }
     }
 }

--- a/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
+++ b/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
@@ -336,7 +336,7 @@ namespace Realms
             return false;
         }
 
-        public TypeInfo GetTypeInfo()
+        TypeInfo IReflectableType.GetTypeInfo()
         {
             RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
             return null;

--- a/Shared/Realm.Shared/Realm.Shared.projitems
+++ b/Shared/Realm.Shared/Realm.Shared.projitems
@@ -77,10 +77,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Exceptions\ManagedExceptionDuringMigrationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handles\UnownedRealmHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Handles\ObjectHandle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReflectableType\RealmObjectTypeInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReflectableType\WovenPropertyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReflectableType\WovenGetterMethodInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Weaving\" />
     <Folder Include="$(MSBuildThisFileDirectory)Schema\" />
     <Folder Include="$(MSBuildThisFileDirectory)Dynamic\" />
+    <Folder Include="$(MSBuildThisFileDirectory)ReflectableType\" />
   </ItemGroup>
 </Project>

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -19,6 +19,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
 
 namespace Realms
 {
@@ -29,7 +32,7 @@ namespace Realms
     /// Has a Preserve attribute to attempt to preserve all subtypes without having to weave.
     /// </remarks>
     [Preserve(AllMembers = true, Conditional = false)]
-    public class RealmObject
+    public class RealmObject : IReflectableType
     {
         private Realm _realm;
         private ObjectHandle _objectHandle;
@@ -530,6 +533,11 @@ namespace Realms
             // Note that the base class is not invoked because it is 
             // System.Object, which defines Equals as reference equality. 
             return ObjectHandle.Equals(((RealmObject)obj).ObjectHandle);
+        }
+
+        public TypeInfo GetTypeInfo()
+        {
+            return new RealmObjectTypeInfo(this.GetType());
         }
     }
 }

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -535,7 +535,7 @@ namespace Realms
             return ObjectHandle.Equals(((RealmObject)obj).ObjectHandle);
         }
 
-        public TypeInfo GetTypeInfo()
+        TypeInfo IReflectableType.GetTypeInfo()
         {
             return new RealmObjectTypeInfo(this.GetType());
         }

--- a/Shared/Realm.Shared/ReflectableType/RealmObjectTypeInfo.cs
+++ b/Shared/Realm.Shared/ReflectableType/RealmObjectTypeInfo.cs
@@ -1,0 +1,42 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Reflection;
+
+namespace Realms
+{
+    internal class RealmObjectTypeInfo : TypeDelegator
+    {
+        public RealmObjectTypeInfo(Type type) : base(type)
+        {
+        }
+
+        public override PropertyInfo GetDeclaredProperty(string name)
+        {
+            var pi = base.GetDeclaredProperty(name);
+            var wovenAttribute = pi.GetCustomAttribute<WovenPropertyAttribute>();
+            if (wovenAttribute != null)
+            {
+                return new WovenPropertyInfo(pi);
+            }
+
+            return pi;
+        }
+    }
+}

--- a/Shared/Realm.Shared/ReflectableType/WovenGetterMethodInfo.cs
+++ b/Shared/Realm.Shared/ReflectableType/WovenGetterMethodInfo.cs
@@ -1,0 +1,81 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Globalization;
+using System.Reflection;
+
+namespace Realms
+{
+    internal class WovenGetterMethodInfo : MethodInfo
+    {
+        private readonly MethodInfo _mi;
+
+        public override MethodAttributes Attributes => _mi.Attributes;
+
+        public override Type DeclaringType => _mi.DeclaringType;
+
+        public override RuntimeMethodHandle MethodHandle => _mi.MethodHandle;
+
+        public override string Name => _mi.Name;
+
+        public override Type ReflectedType => _mi.ReflectedType;
+
+        public override ICustomAttributeProvider ReturnTypeCustomAttributes => _mi.ReturnTypeCustomAttributes;
+
+        public override Type ReturnType => _mi.ReturnType;
+
+        public WovenGetterMethodInfo(MethodInfo mi)
+        {
+            if (mi == null)
+            {
+                throw new ArgumentNullException(nameof(mi));
+            }
+
+            _mi = mi;
+        }
+
+        public override MethodInfo GetBaseDefinition() => _mi.GetBaseDefinition();
+
+        public override object[] GetCustomAttributes(bool inherit) => _mi.GetCustomAttributes(inherit);
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => _mi.GetCustomAttributes(attributeType, inherit);
+
+        public override MethodImplAttributes GetMethodImplementationFlags() => _mi.GetMethodImplementationFlags();
+
+        public override ParameterInfo[] GetParameters() => _mi.GetParameters();
+
+        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        {
+            var ro = obj as RealmObject;
+            if ((ro?.IsValid).GetValueOrDefault(true))
+            {
+                return _mi.Invoke(obj, invokeAttr, binder, parameters, culture);
+            }
+
+            if (ReturnType.IsValueType)
+            {
+                return Activator.CreateInstance(ReturnType);
+            }
+
+            return null;
+        }
+
+        public override bool IsDefined(Type attributeType, bool inherit) => _mi.IsDefined(attributeType, inherit);
+    }
+}

--- a/Shared/Realm.Shared/ReflectableType/WovenGetterMethodInfo.cs
+++ b/Shared/Realm.Shared/ReflectableType/WovenGetterMethodInfo.cs
@@ -63,7 +63,7 @@ namespace Realms
         public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
         {
             var ro = obj as RealmObject;
-            if ((ro?.IsValid).GetValueOrDefault(true))
+            if (ro == null || ro.IsValid)
             {
                 return _mi.Invoke(obj, invokeAttr, binder, parameters, culture);
             }

--- a/Shared/Realm.Shared/ReflectableType/WovenPropertyInfo.cs
+++ b/Shared/Realm.Shared/ReflectableType/WovenPropertyInfo.cs
@@ -1,0 +1,75 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Globalization;
+using System.Reflection;
+
+namespace Realms
+{
+    internal class WovenPropertyInfo : PropertyInfo
+    {
+        private readonly PropertyInfo _pi;
+
+        public override PropertyAttributes Attributes => _pi.Attributes;
+
+        public override bool CanRead => _pi.CanRead;
+
+        public override bool CanWrite => _pi.CanWrite;
+
+        public override Type DeclaringType => _pi.DeclaringType;
+
+        public override string Name => _pi.Name;
+
+        public override Type PropertyType => _pi.PropertyType;
+
+        public override Type ReflectedType => _pi.ReflectedType;
+
+        public WovenPropertyInfo(PropertyInfo pi)
+        {
+            if (pi == null)
+            {
+                throw new ArgumentNullException(nameof(pi));
+            }
+
+            _pi = pi;
+        }
+
+        public override MethodInfo[] GetAccessors(bool nonPublic) => _pi.GetAccessors(nonPublic);
+
+        public override object[] GetCustomAttributes(bool inherit) => _pi.GetCustomAttributes(inherit);
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => _pi.GetCustomAttributes(attributeType, inherit);
+
+        public override MethodInfo GetGetMethod(bool nonPublic)
+        {
+            var mi = _pi.GetGetMethod(nonPublic);
+            return new WovenGetterMethodInfo(mi);
+        }
+
+        public override ParameterInfo[] GetIndexParameters() => _pi.GetIndexParameters();
+
+        public override MethodInfo GetSetMethod(bool nonPublic) => _pi.GetSetMethod(nonPublic);
+
+        public override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture) => _pi.GetValue(obj, invokeAttr, binder, index, culture);
+
+        public override bool IsDefined(Type attributeType, bool inherit) => _pi.IsDefined(attributeType, inherit);
+
+        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture) => _pi.SetValue(obj, value, invokeAttr, binder, index, culture);
+    }
+}

--- a/Shared/Tests.Shared/ReflectableTypeTests.cs
+++ b/Shared/Tests.Shared/ReflectableTypeTests.cs
@@ -1,0 +1,83 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using Realms;
+
+namespace IntegrationTests.Shared
+{
+    [TestFixture, Preserve(AllMembers = true)]
+    public class ReflectableTypeTests
+    {
+        protected Realm _realm;
+
+        [SetUp]
+        public void Setup()
+        {
+            Realm.DeleteRealm(RealmConfiguration.DefaultConfiguration);
+            _realm = Realm.GetInstance();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _realm.Close();
+            Realm.DeleteRealm(_realm.Config);
+        }
+
+        [Test]
+        public void ReflectedGetter_WhenObjectIsRemoved_ShouldReturnNull()
+        {
+            var owner = new Owner
+            {
+                TopDog = new Dog
+                {
+                    Name = "Sharo"
+                },
+                Name = "Peter"
+            };
+
+            _realm.Write(() =>
+            {
+                _realm.Manage(owner);
+            });
+
+            var typeInfo = owner.GetTypeInfo();
+            var topDogProperty = typeInfo.GetDeclaredProperty("TopDog");
+            var getter = topDogProperty.GetMethod;
+
+            var topDogBeforeRemove = getter.Invoke(owner, null) as Dog;
+            Assert.That(topDogBeforeRemove, Is.Not.Null);
+            Assert.That(topDogBeforeRemove.Name, Is.EqualTo("Sharo"));
+
+            _realm.Write(() =>
+            {
+                _realm.Remove(owner);
+            });
+
+            var topDogAfterRemove = getter.Invoke(owner, null);
+            Assert.That(topDogAfterRemove, Is.Null);
+            Assert.Throws<RealmInvalidObjectException>(() =>
+            {
+                var directDog = owner.TopDog;
+            });
+        }
+    }
+}

--- a/Shared/Tests.Shared/ReflectableTypeTests.cs
+++ b/Shared/Tests.Shared/ReflectableTypeTests.cs
@@ -50,7 +50,7 @@ namespace IntegrationTests.Shared
         {
             var owner = AddDogAndOwner();
 
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var topDogProperty = typeInfo.GetDeclaredProperty(nameof(Owner.TopDog));
             var getter = topDogProperty.GetMethod;
 
@@ -64,7 +64,7 @@ namespace IntegrationTests.Shared
         {
             var owner = AddDogAndOwner();
 
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var topDogProperty = typeInfo.GetDeclaredProperty(nameof(Owner.TopDog));
 
             var topDog = topDogProperty.GetValue(owner, null) as Dog;
@@ -91,7 +91,7 @@ namespace IntegrationTests.Shared
                 _realm.Remove(owner);
             });
 
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var topDogProperty = typeInfo.GetDeclaredProperty(nameof(Owner.TopDog));
             var getter = topDogProperty.GetMethod;
 
@@ -109,7 +109,7 @@ namespace IntegrationTests.Shared
                 _realm.Remove(owner);
             });
 
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var topDogProperty = typeInfo.GetDeclaredProperty(nameof(Owner.TopDog));
 
             var topDog = topDogProperty.GetValue(owner, null);
@@ -136,7 +136,7 @@ namespace IntegrationTests.Shared
         {
             var owner = AddDogAndOwner();
 
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var nameGetter = typeInfo.GetDeclaredProperty(nameof(Owner.Name)).GetMethod;
 
             var name = nameGetter.Invoke(owner, null);
@@ -159,7 +159,7 @@ namespace IntegrationTests.Shared
                 _realm.Remove(owner);
             });
 
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var nameGetter = typeInfo.GetDeclaredProperty(nameof(Owner.Name)).GetMethod;
 
             var name = nameGetter.Invoke(owner, null);
@@ -185,7 +185,7 @@ namespace IntegrationTests.Shared
         public void ReflectedSetter_WhenObjectIsValid_ShouldSetValue()
         {
             var owner = AddDogAndOwner();
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var nameSetter = typeInfo.GetDeclaredProperty(nameof(Owner.Name)).SetMethod;
 
             _realm.Write(() =>
@@ -205,16 +205,16 @@ namespace IntegrationTests.Shared
                 _realm.Remove(owner);
             });
 
-            var typeInfo = owner.GetTypeInfo();
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
             var nameSetter = typeInfo.GetDeclaredProperty(nameof(Owner.Name)).SetMethod;
 
-            Assert.Throws<TargetInvocationException>(() =>
+            Assert.That(() =>
             {
                 _realm.Write(() =>
                 {
                     nameSetter.Invoke(owner, new[] { "John" });
                 });
-            });
+            }, Throws.InnerException.TypeOf<RealmInvalidObjectException>());
         }
 
         private Owner AddDogAndOwner()

--- a/Shared/Tests.Shared/RelationshipTests.cs
+++ b/Shared/Tests.Shared/RelationshipTests.cs
@@ -31,26 +31,6 @@ namespace IntegrationTests.Shared
     [TestFixture, Preserve(AllMembers = true)]
     public class RelationshipTests
     {
-        private class Dog : RealmObject
-        {
-            public string Name { get; set; }
-
-            public string Color { get; set; }
-
-            public bool Vaccinated { get; set; }
-            
-            // Owner Owner { get; set; }  will uncomment when verifying that we have back-links from ToMany relationships
-        }
-
-        private class Owner : RealmObject
-        {
-            public string Name { get; set; }
-
-            public Dog TopDog { get; set; }
-
-            public IList<Dog> Dogs { get; }
-        }
-
         protected Realm realm;
 
         [SetUp]

--- a/Shared/Tests.Shared/TestObjects.cs
+++ b/Shared/Tests.Shared/TestObjects.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Realms;
 
@@ -169,5 +170,27 @@ namespace IntegrationTests.Shared
         }
 
         public Person RealmObjectProperty { get; set; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class Dog : RealmObject
+    {
+        public string Name { get; set; }
+
+        public string Color { get; set; }
+
+        public bool Vaccinated { get; set; }
+
+        // Owner Owner { get; set; }  will uncomment when verifying that we have back-links from ToMany relationships
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class Owner : RealmObject
+    {
+        public string Name { get; set; }
+
+        public Dog TopDog { get; set; }
+
+        public IList<Dog> Dogs { get; }
     }
 }

--- a/Shared/Tests.Shared/Tests.Shared.projitems
+++ b/Shared/Tests.Shared/Tests.Shared.projitems
@@ -36,6 +36,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MigrationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AddOrUpdateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GetPrimaryKeyTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReflectableTypeTests.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(ProjectName)' != 'IntegrationTests.Win32' ">
     <Compile Include="$(MSBuildThisFileDirectory)TestRunner.cs" />

--- a/examples/QuickJournal/QuickJournal/EntryMetadata.cs
+++ b/examples/QuickJournal/QuickJournal/EntryMetadata.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.ComponentModel;
+using Realms;
+
+namespace QuickJournal
+{
+    public class EntryMetadata : RealmObject, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public DateTimeOffset Date { get; set; }
+
+        public string Author { get; set; }
+    }
+}

--- a/examples/QuickJournal/QuickJournal/JournalEntry.cs
+++ b/examples/QuickJournal/QuickJournal/JournalEntry.cs
@@ -9,7 +9,11 @@ namespace QuickJournal
         public event PropertyChangedEventHandler PropertyChanged;
 
         public string Title { get; set; }
-        public DateTimeOffset Date { get; set; }
         public string BodyText { get; set; }
+
+        public EntryMetadata Metadata { get; set; }
+
+        // If we remove that and use Metadata.Date in the binding, exception is thrown when deleting item. See #883.
+        public DateTimeOffset Date => Metadata.Date;
     }
 }

--- a/examples/QuickJournal/QuickJournal/QuickJournal.csproj
+++ b/examples/QuickJournal/QuickJournal/QuickJournal.csproj
@@ -41,6 +41,7 @@
       <DependentUpon>JournalEntryDetailsPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="ViewModels\JournalEntryDetailsViewModel.cs" />
+    <Compile Include="EntryMetadata.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.1.3.5.6335\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.3.5.6335\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/examples/QuickJournal/QuickJournal/ViewModels/JournalEntriesViewModel.cs
+++ b/examples/QuickJournal/QuickJournal/ViewModels/JournalEntriesViewModel.cs
@@ -8,6 +8,9 @@ namespace QuickJournal
 {
     public class JournalEntriesViewModel
     {
+        // TODO: add UI for changing that.
+        private const string AuthorName = "Me";
+
         private Realm _realm;
 
         public IEnumerable<JournalEntry> Entries { get; private set; }
@@ -37,7 +40,10 @@ namespace QuickJournal
         {
             var transaction = _realm.BeginWrite();
             var entry = _realm.CreateObject<JournalEntry>();
-            entry.Date = DateTimeOffset.Now;
+            var metadata = _realm.CreateObject<EntryMetadata>();
+            metadata.Date = DateTimeOffset.Now;
+            metadata.Author = AuthorName;
+            entry.Metadata = metadata;
 
             var page = new JournalEntryDetailsPage(new JournalEntryDetailsViewModel(entry, transaction));
 

--- a/examples/QuickJournal/QuickJournal/Views/JournalEntriesPage.xaml
+++ b/examples/QuickJournal/QuickJournal/Views/JournalEntriesPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		x:Class="QuickJournal.JournalEntriesPage"
@@ -10,7 +10,7 @@
 		<ListView ItemsSource="{Binding Entries}" x:Name="EntriesListView" ItemTapped="OnItemTapped" ItemSelected="OnItemSelected">
 			<ListView.ItemTemplate>
 				<DataTemplate>
-					<TextCell Text="{Binding Title}" Detail="{Binding Date, StringFormat='{0:dddd, MMMM d yyyy}'}">
+					<TextCell Text="{Binding Title}" Detail="{Binding Metadata.Date, StringFormat='{0:dddd, MMMM d yyyy}'}">
 						<TextCell.ContextActions>
 							<MenuItem Text="Delete" IsDestructive="true" 
 									  Command="{Binding BindingContext.DeleteEntryCommand, Source={x:Reference EntriesListView}" 


### PR DESCRIPTION
The problem stems from the fact that Xamarin.Forms tries to apply the binding, even after an object is removed. This causes our RealmObject to try query core about the relationship, which obviously fails. While our behavior is semantically correct - you shouldn't try to get properties of a detached object, we should play nicer with Forms.

The proposed solution is to implement `IReflectableType` which Forms [respects](https://github.com/xamarin/Xamarin.Forms/blob/f252238fec90d8f71b49e35212275b9e588964e3/Xamarin.Forms.Core/BindingExpression.cs#L125). Then, replace the getter of the property info with a custom one, that will check if the object is valid and if it's not, return the default value.

The methods we should overrider are [`TypeInfo.GetDeclaredProperty`](https://github.com/xamarin/Xamarin.Forms/blob/f252238fec90d8f71b49e35212275b9e588964e3/Xamarin.Forms.Core/BindingExpression.cs#L319), [`PropertyInfo.GetGetMethod`](https://github.com/xamarin/Xamarin.Forms/blob/f252238fec90d8f71b49e35212275b9e588964e3/Xamarin.Forms.Core/BindingExpression.cs#L326), and obviously, [`MethodInfo.Invoke`](https://github.com/xamarin/Xamarin.Forms/blob/f252238fec90d8f71b49e35212275b9e588964e3/Xamarin.Forms.Core/BindingExpression.cs#L555). 

To verify that the solution works, I modified the QuickJournal example, to contain an artificial related object. When referencing the Realm Nuget package, it will crash with an `InvalidObjectException` after deleting an object, but when referencing Realm built from source, it will work as expected.

This resolves #883 