### PR TITLE
Add support for .Equals/.StartsWith/.EndsWith ignore case queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
     var peter = realm.All<Person>().FirstOrDefault(d => d.Name == "Peter");
     var petersDogs = realm.All<Dog>().Where(d => d.Owner == peter);
     ```
-* Added support for `StarsWith(string, StringComparison)`, `EndsWith(string, StringComparison)`, and `Equals(string, StringComparison)` filtering in LINQ. (#893)
+* Added support for `StartsWith(string, StringComparison)`, `EndsWith(string, StringComparison)`, and `Equals(string, StringComparison)` filtering in LINQ. (#893)
 
     **NOTE**: Currently only `Ordinal` and `OrdinalIgnoreCase` comparisons are supported. Trying to pass in a different one will result in runtime error. If no argument is supplied, `Ordinal` will be used.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@
     var peter = realm.All<Person>().FirstOrDefault(d => d.Name == "Peter");
     var petersDogs = realm.All<Dog>().Where(d => d.Owner == peter);
     ```
+* Added support for `StarsWith(string, StringComparison)`, `EndsWith(string, StringComparison)`, and `Equals(string, StringComparison)` filtering in LINQ. (#893)
 
+    **NOTE**: Currently only `Ordinal` and `OrdinalIgnoreCase` comparisons are supported. Trying to pass in a different one will result in runtime error. If no argument is supplied, `Ordinal` will be used.
 
 0.78.1 (2016-09-15)
 -------------------

--- a/Shared/Realm.Shared/Handles/QueryHandle.cs
+++ b/Shared/Realm.Shared/Handles/QueryHandle.cs
@@ -29,6 +29,7 @@ namespace Realms
     // so these handles always represent a qeury object that should be released when not used anymore
     // the C# binding methods on query simply return self to add the . nottation again
     // A query will be a child of whatever root its creator has as root (queries are usually created by tableviews and tables)
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1611:ElementParametersMustBeDocumented")]
     internal class QueryHandle : RealmHandle
     {
         // This is a delegate type meant to represent one of the "query operator" methods such as float_less and bool_equal
@@ -229,35 +230,50 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringContains(IntPtr columnIndex, string value, bool caseSensitive = true)
+        /// <summary>
+        /// If the user hasn't specified it, should be caseSensitive=true
+        /// </summary>
+        public void StringContains(IntPtr columnIndex, string value, bool caseSensitive)
         {
             NativeException nativeException;
             NativeMethods.string_contains(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringStartsWith(IntPtr columnIndex, string value, bool caseSensitive = true)
+        /// <summary>
+        /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
+        /// </summary>
+        public void StringStartsWith(IntPtr columnIndex, string value, bool caseSensitive)
         {
             NativeException nativeException;
             NativeMethods.string_starts_with(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringEndsWith(IntPtr columnIndex, string value, bool caseSensitive = true)
+        /// <summary>
+        /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
+        /// </summary>
+        public void StringEndsWith(IntPtr columnIndex, string value, bool caseSensitive)
         {
             NativeException nativeException;
             NativeMethods.string_ends_with(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringEqual(IntPtr columnIndex, string value, bool caseSensitive = true)
+        /// <summary>
+        /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
+        /// </summary>
+        public void StringEqual(IntPtr columnIndex, string value, bool caseSensitive)
         {
             NativeException nativeException;
             NativeMethods.string_equal(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringNotEqual(IntPtr columnIndex, string value, bool caseSensitive = true)
+        /// <summary>
+        /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
+        /// </summary>
+        public void StringNotEqual(IntPtr columnIndex, string value, bool caseSensitive)
         {
             NativeException nativeException;
             NativeMethods.string_not_equal(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);

--- a/Shared/Realm.Shared/Handles/QueryHandle.cs
+++ b/Shared/Realm.Shared/Handles/QueryHandle.cs
@@ -45,23 +45,23 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_contains", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_contains(QueryHandle queryPtr, IntPtr columnIndex,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
+                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.I1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_starts_with", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_starts_with(QueryHandle queryPtr, IntPtr columnIndex,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
+                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.I1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_ends_with", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_ends_with(QueryHandle queryPtr, IntPtr columnIndex,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
+                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.I1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_equal(QueryHandle queryPtr, IntPtr columnIndex,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
+                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.I1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_not_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_not_equal(QueryHandle queryPtr, IntPtr columnIndex,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
+                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.I1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_bool_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void bool_equal(QueryHandle queryPtr, IntPtr columnIndex, IntPtr value, out NativeException ex);
@@ -229,38 +229,38 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringContains(IntPtr columnIndex, string value)
+        public void StringContains(IntPtr columnIndex, string value, bool caseSensitive = true)
         {
             NativeException nativeException;
-            NativeMethods.string_contains(this, columnIndex, value, (IntPtr)value.Length, out nativeException);
+            NativeMethods.string_contains(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringStartsWith(IntPtr columnIndex, string value)
+        public void StringStartsWith(IntPtr columnIndex, string value, bool caseSensitive = true)
         {
             NativeException nativeException;
-            NativeMethods.string_starts_with(this, columnIndex, value, (IntPtr)value.Length, out nativeException);
+            NativeMethods.string_starts_with(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringEndsWith(IntPtr columnIndex, string value)
+        public void StringEndsWith(IntPtr columnIndex, string value, bool caseSensitive = true)
         {
             NativeException nativeException;
-            NativeMethods.string_ends_with(this, columnIndex, value, (IntPtr)value.Length, out nativeException);
+            NativeMethods.string_ends_with(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringEqual(IntPtr columnIndex, string value)
+        public void StringEqual(IntPtr columnIndex, string value, bool caseSensitive = true)
         {
             NativeException nativeException;
-            NativeMethods.string_equal(this, columnIndex, value, (IntPtr)value.Length, out nativeException);
+            NativeMethods.string_equal(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringNotEqual(IntPtr columnIndex, string value)
+        public void StringNotEqual(IntPtr columnIndex, string value, bool caseSensitive = true)
         {
             NativeException nativeException;
-            NativeMethods.string_not_equal(this, columnIndex, value, (IntPtr)value.Length, out nativeException);
+            NativeMethods.string_not_equal(this, columnIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Shared/Realm.Shared/Linq/RealmResultsVisitor.cs
+++ b/Shared/Realm.Shared/Linq/RealmResultsVisitor.cs
@@ -57,9 +57,17 @@ namespace Realms
 
                 internal static readonly LazyMethod StartsWith = Capture<string>(s => s.StartsWith(string.Empty));
 
+                internal static readonly LazyMethod StartsWithStringComparison = Capture<string>(s => s.StartsWith(string.Empty, StringComparison.Ordinal));
+
                 internal static readonly LazyMethod EndsWith = Capture<string>(s => s.EndsWith(string.Empty));
 
+                internal static readonly LazyMethod EndsWithStringComparison = Capture<string>(s => s.EndsWith(string.Empty, StringComparison.Ordinal));
+                
                 internal static readonly LazyMethod IsNullOrEmpty = Capture<string>(s => string.IsNullOrEmpty(s));
+
+                internal static readonly LazyMethod EqualsMethod = Capture<string>(s => s.Equals(string.Empty));
+
+                internal static readonly LazyMethod EqualsStringComparison = Capture<string>(s => s.Equals(string.Empty, StringComparison.Ordinal));
             }
         }
 
@@ -335,9 +343,17 @@ namespace Realms
                 {
                     queryMethod = (q, c, v) => q.StringStartsWith(c, v);
                 }
+                else if (m.Method == Methods.String.StartsWithStringComparison.Value)
+                {
+                    queryMethod = (q, c, v) => q.StringStartsWith(c, v, GetComparisonCaseSensitive(m));
+                }
                 else if (m.Method == Methods.String.EndsWith.Value)
                 {
                     queryMethod = (q, c, v) => q.StringEndsWith(c, v);
+                }
+                else if (m.Method == Methods.String.EndsWithStringComparison.Value)
+                {
+                    queryMethod = (q, c, v) => q.StringEndsWith(c, v, GetComparisonCaseSensitive(m));
                 }
                 else if (m.Method == Methods.String.IsNullOrEmpty.Value)
                 {
@@ -356,6 +372,14 @@ namespace Realms
                     CoreQueryHandle.GroupEnd();
                     return m;
                 }
+                else if (m.Method == Methods.String.EqualsMethod.Value)
+                {
+                    queryMethod = (q, c, v) => q.StringEqual(c, v);
+                }
+                else if (m.Method == Methods.String.EqualsStringComparison.Value)
+                {
+                    queryMethod = (q, c, v) => q.StringEqual(c, v, GetComparisonCaseSensitive(m));
+                }
 
                 if (queryMethod != null)
                 {
@@ -368,7 +392,7 @@ namespace Realms
                     var columnIndex = CoreQueryHandle.GetColumnIndex(member.Member.Name);
 
                     object argument;
-                    if (!TryExtractConstantValue(m.Arguments.SingleOrDefault(), out argument) || argument.GetType() != typeof(string))
+                    if (!TryExtractConstantValue(m.Arguments[0], out argument) || argument.GetType() != typeof(string))
                     {
                         throw new NotSupportedException($"The method '{m.Method}' has to be invoked with a single string constant argument or closure variable");
                     }
@@ -812,6 +836,31 @@ namespace Realms
             {
                 throw new NotImplementedException();
             }
+        }
+
+        private static bool GetComparisonCaseSensitive(MethodCallExpression m)
+        {
+            object argument;
+            if (!TryExtractConstantValue(m.Arguments[1], out argument) || !(argument is StringComparison))
+            {
+                throw new NotSupportedException($"The method '{m.Method}' has to be invoked with a string and StringComparison constant arguments.");
+            }
+
+            var comparison = (StringComparison)argument;
+            bool caseSensitive;
+            switch (comparison)
+            {
+                case StringComparison.Ordinal:
+                    caseSensitive = true;
+                    break;
+                case StringComparison.OrdinalIgnoreCase:
+                    caseSensitive = false;
+                    break;
+                default:
+                    throw new NotSupportedException($"The comparison {comparison} is not yet supported. Use {StringComparison.Ordinal} or {StringComparison.OrdinalIgnoreCase}.");
+            }
+
+            return caseSensitive;
         }
 
         // strange as it may seem, this is also called for the LHS when simply iterating All<T>()

--- a/Shared/Realm.Shared/Linq/RealmResultsVisitor.cs
+++ b/Shared/Realm.Shared/Linq/RealmResultsVisitor.cs
@@ -337,11 +337,11 @@ namespace Realms
 
                 if (m.Method == Methods.String.Contains.Value)
                 {
-                    queryMethod = (q, c, v) => q.StringContains(c, v);
+                    queryMethod = (q, c, v) => q.StringContains(c, v, caseSensitive: true);
                 }
                 else if (m.Method == Methods.String.StartsWith.Value)
                 {
-                    queryMethod = (q, c, v) => q.StringStartsWith(c, v);
+                    queryMethod = (q, c, v) => q.StringStartsWith(c, v, caseSensitive: true);
                 }
                 else if (m.Method == Methods.String.StartsWithStringComparison.Value)
                 {
@@ -349,7 +349,7 @@ namespace Realms
                 }
                 else if (m.Method == Methods.String.EndsWith.Value)
                 {
-                    queryMethod = (q, c, v) => q.StringEndsWith(c, v);
+                    queryMethod = (q, c, v) => q.StringEndsWith(c, v, caseSensitive: true);
                 }
                 else if (m.Method == Methods.String.EndsWithStringComparison.Value)
                 {
@@ -368,13 +368,13 @@ namespace Realms
                     CoreQueryHandle.GroupBegin();
                     CoreQueryHandle.NullEqual(columnIndex);
                     CoreQueryHandle.Or();
-                    CoreQueryHandle.StringEqual(columnIndex, string.Empty);
+                    CoreQueryHandle.StringEqual(columnIndex, string.Empty, caseSensitive: true);
                     CoreQueryHandle.GroupEnd();
                     return m;
                 }
                 else if (m.Method == Methods.String.EqualsMethod.Value)
                 {
-                    queryMethod = (q, c, v) => q.StringEqual(c, v);
+                    queryMethod = (q, c, v) => q.StringEqual(c, v, caseSensitive: true);
                 }
                 else if (m.Method == Methods.String.EqualsStringComparison.Value)
                 {
@@ -559,7 +559,7 @@ namespace Realms
             }
             else if (value is string)
             {
-                queryHandle.StringEqual(columnIndex, (string)value);
+                queryHandle.StringEqual(columnIndex, (string)value, caseSensitive: true);
             }
             else if (value is bool)
             {
@@ -627,7 +627,7 @@ namespace Realms
             }
             else if (value is string)
             {
-                queryHandle.StringNotEqual(columnIndex, (string)value);
+                queryHandle.StringNotEqual(columnIndex, (string)value, caseSensitive: true);
             }
             else if (value is bool)
             {

--- a/Shared/Tests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Shared/Tests.Shared/RealmResults/SimpleLINQtests.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using IntegrationTests.Shared;
 using NUnit.Framework;
@@ -459,6 +460,124 @@ namespace IntegrationTests
         }
 
         [Test]
+        public void StringSearch_Equals_CaseSensitivityTests()
+        {
+            MakeThreePatricks();
+
+            // case sensitive
+            var equalequal_patrick = _realm.All<Person>().Where(p => p.FirstName == "patrick").Count();
+            Assert.That(equalequal_patrick, Is.EqualTo(2));
+
+            // case sensitive
+            var notequal_patrick = _realm.All<Person>().Where(p => p.FirstName != "patrick").Count();
+            Assert.That(notequal_patrick, Is.EqualTo(1));
+
+            // case sensitive
+            var equals_patrick = _realm.All<Person>().Where(p => p.FirstName.Equals("patrick")).Count();
+            Assert.That(equals_patrick, Is.EqualTo(2));
+
+            // case sensitive
+            var notequals_patrick = _realm.All<Person>().Where(p => !p.FirstName.Equals("patrick")).Count();
+            Assert.That(notequals_patrick, Is.EqualTo(1));
+
+            // ignore case
+            var equals_ignorecase_patrick = _realm.All<Person>().Where(p => p.FirstName.Equals("patrick", StringComparison.OrdinalIgnoreCase)).Count();
+            Assert.That(equals_ignorecase_patrick, Is.EqualTo(3));
+
+            // ignore case
+            var notequals_ignorecase_patrick = _realm.All<Person>().Where(p => !p.FirstName.Equals("patrick", StringComparison.OrdinalIgnoreCase)).Count();
+            Assert.That(notequals_ignorecase_patrick, Is.EqualTo(0));
+
+            // case sensitive
+            var equals_ordinal_patrick = _realm.All<Person>().Where(p => p.FirstName.Equals("patrick", StringComparison.Ordinal)).Count();
+            Assert.That(equals_ordinal_patrick, Is.EqualTo(2));
+
+            // case sensitive
+            var equals_ordinal_Patrick = _realm.All<Person>().Where(p => p.FirstName.Equals("Patrick", StringComparison.Ordinal)).Count();
+            Assert.That(equals_ordinal_Patrick, Is.EqualTo(0));
+
+            // case sensitive
+            var equals_ordinal_patRick = _realm.All<Person>().Where(p => p.FirstName.Equals("patRick", StringComparison.Ordinal)).Count();
+            Assert.That(equals_ordinal_patRick, Is.EqualTo(1));
+
+            // case sensitive
+            var notequals_ordinal_patrick = _realm.All<Person>().Where(p => !p.FirstName.Equals("patrick", StringComparison.Ordinal)).Count();
+            Assert.That(notequals_ordinal_patrick, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void StringSearch_StartsWith_CaseSensitivityTests()
+        {
+            MakeThreePatricks();
+
+            // case sensitive
+            var startswith_patr = _realm.All<Person>().Where(p => p.FirstName.StartsWith("patr")).Count();
+            Assert.That(startswith_patr, Is.EqualTo(2));
+
+            // case sensitive
+            var startswith_ordinal_patr = _realm.All<Person>().Where(p => p.FirstName.StartsWith("patr", StringComparison.Ordinal)).Count();
+            Assert.That(startswith_ordinal_patr, Is.EqualTo(2));
+
+            // ignore case
+            var startswith_ignorecase_patr = _realm.All<Person>().Where(p => p.FirstName.StartsWith("patr", StringComparison.OrdinalIgnoreCase)).Count();
+            Assert.That(startswith_ignorecase_patr, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void StringSearch_EndsWith_CaseSensitivityTests()
+        {
+            MakeThreePatricks();
+
+            // case sensitive
+            var endswith_rick = _realm.All<Person>().Where(p => p.FirstName.EndsWith("rick")).Count();
+            Assert.That(endswith_rick, Is.EqualTo(2));
+
+            // case sensitive
+            var endswith_ordinal_rick = _realm.All<Person>().Where(p => p.FirstName.EndsWith("rick", StringComparison.Ordinal)).Count();
+            Assert.That(endswith_ordinal_rick, Is.EqualTo(2));
+
+            // ignore case
+            var endswith_ignorecase_rick = _realm.All<Person>().Where(p => p.FirstName.EndsWith("rick", StringComparison.OrdinalIgnoreCase)).Count();
+            Assert.That(endswith_ignorecase_rick, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void StringSearch_InvalidStringComparisonTests()
+        {
+            MakeThreePatricks();
+
+            Assert.That(() =>
+            {
+                _realm.All<Person>().Where(p => p.FirstName.Equals("patrick", StringComparison.CurrentCulture)).Count();
+            }, Throws.TypeOf<NotSupportedException>());
+
+            Assert.That(() =>
+            {
+                _realm.All<Person>().Where(p => p.FirstName.Equals("patrick", StringComparison.CurrentCultureIgnoreCase)).Count();
+            }, Throws.TypeOf<NotSupportedException>());
+
+            Assert.That(() =>
+            {
+                _realm.All<Person>().Where(p => p.FirstName.Equals("patrick", StringComparison.InvariantCulture)).Count();
+            }, Throws.TypeOf<NotSupportedException>());
+
+            Assert.That(() =>
+            {
+                _realm.All<Person>().Where(p => p.FirstName.Equals("patrick", StringComparison.InvariantCultureIgnoreCase)).Count();
+            }, Throws.TypeOf<NotSupportedException>());
+
+            Assert.That(() =>
+            {
+                _realm.All<Person>().Where(p => p.FirstName.StartsWith("pat", StringComparison.CurrentCulture)).Count();
+            }, Throws.TypeOf<NotSupportedException>());
+
+            Assert.That(() =>
+            {
+                _realm.All<Person>().Where(p => p.FirstName.EndsWith("rick", StringComparison.CurrentCulture)).Count();
+            }, Throws.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
         public void AnySucceeds()
         {
             Assert.That(_realm.All<Person>().Where(p => p.Latitude > 50).Any());
@@ -733,7 +852,30 @@ namespace IntegrationTests
             var hasJohnSmith = moderateScorers.Any(p => p.LastName == "Smith");
             Assert.That(hasJohnSmith, Is.False);
         }
-    
+
+        private void MakeThreePatricks()
+        {
+            _realm.Write(() =>
+            {
+                _realm.RemoveAll<Person>();
+
+                _realm.Manage(new Person
+                {
+                    FirstName = "patRick"
+                });
+
+                _realm.Manage(new Person
+                {
+                    FirstName = "patrick"
+                });
+
+                _realm.Manage(new Person
+                {
+                    FirstName = "patrick"
+                });
+            });
+        }
+
         private static class Constants
         {
             public const long SixtyThousandConstant = 60000;

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -108,43 +108,43 @@ REALM_EXPORT void query_or(Query * query_ptr, NativeException::Marshallable& ex)
     });
 }
 
-REALM_EXPORT void query_string_contains(Query* query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_contains(Query* query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         Utf16StringAccessor str(value, value_len);
-        query_ptr->contains(columnIndex, str);
+        query_ptr->contains(columnIndex, str, case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_starts_with(Query* query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_starts_with(Query* query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         Utf16StringAccessor str(value, value_len);
-        query_ptr->begins_with(columnIndex, str);
+        query_ptr->begins_with(columnIndex, str, case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_ends_with(Query* query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_ends_with(Query* query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         Utf16StringAccessor str(value, value_len);
-        query_ptr->ends_with(columnIndex, str);
+        query_ptr->ends_with(columnIndex, str, case_sensitive);
     });
 }
     
-REALM_EXPORT void query_string_equal(Query * query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_equal(Query * query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         Utf16StringAccessor str(value, value_len);
-        query_ptr->equal(columnIndex, str);
+        query_ptr->equal(columnIndex, str, case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_not_equal(Query * query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_not_equal(Query * query_ptr, size_t columnIndex, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         Utf16StringAccessor str(value, value_len);
-        query_ptr->not_equal(columnIndex, str);
+        query_ptr->not_equal(columnIndex, str, case_sensitive);
     });
 }
 


### PR DESCRIPTION
Theoretically, we support case-insensitive contains as well, but .NET's `.Contains` doesn't 🙄 Perhaps we could provide an extension method that we can use to proxy for our needs? @kristiandupont 

Resolves #794 