### PR TITLE
Handle change notifications originating from Core

### DIFF
--- a/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
+++ b/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
@@ -20,16 +20,31 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Realms
 {
     /// <summary>
     /// Base for any object that can be persisted in a Realm.
     /// </summary>
-    public class RealmObject : IReflectableType
+    public class RealmObject : IReflectableType, INotifyPropertyChanged
     {
         private Realm _realm;  // may not be used but wanted it included in definition of IsManaged below.
+
+        public event PropertyChangedEventHandler PropertyChanged
+        {
+            add
+            {
+                RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
+            }
+
+            remove
+            {
+                RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
+            }
+        }
 
         /// <summary>
         /// Allows you to check if the object has been associated with a Realm, either at creation or via Realm.Add.
@@ -334,6 +349,11 @@ namespace Realms
         {
             RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
             return false;
+        }
+
+        protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
         }
 
         TypeInfo IReflectableType.GetTypeInfo()

--- a/Shared/Realm.Shared/Handles/SharedRealmHandle.cs
+++ b/Shared/Realm.Shared/Handles/SharedRealmHandle.cs
@@ -77,6 +77,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_schema_version",
                 CallingConvention = CallingConvention.Cdecl)]
             public static extern UInt64 get_schema_version(SharedRealmHandle sharedRealm, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_add_observed_object", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void add_observed_object(SharedRealmHandle sharedRealm, IntPtr managedRealmHandle, ObjectHandle objectHandle, out NativeException ex);
         }
 
         [Preserve]
@@ -110,6 +113,13 @@ namespace Realms
         {
             NativeException nativeException;
             NativeMethods.bind_to_managed_realm_handle(this, managedRealmHandle, out nativeException);
+            nativeException.ThrowIfNecessary();
+        }
+
+        public void AddObservedObject(IntPtr managedRealmHandle, ObjectHandle objectHandle)
+        {
+            NativeException nativeException;
+            NativeMethods.add_observed_object(this, managedRealmHandle, objectHandle, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Shared/Realm.Shared/Handles/SharedRealmHandle.cs
+++ b/Shared/Realm.Shared/Handles/SharedRealmHandle.cs
@@ -80,6 +80,9 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_add_observed_object", CallingConvention = CallingConvention.Cdecl)]
             public static extern void add_observed_object(SharedRealmHandle sharedRealm, IntPtr managedRealmHandle, ObjectHandle objectHandle, IntPtr managedRealmObjectHandle, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_remove_observed_object", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void remove_observed_object(SharedRealmHandle sharedRealm, IntPtr managedRealmObjectHandle, out NativeException ex);
         }
 
         [Preserve]
@@ -120,6 +123,13 @@ namespace Realms
         {
             NativeException nativeException;
             NativeMethods.add_observed_object(this, managedRealmHandle, objectHandle, managedRealmObjectHandle, out nativeException);
+            nativeException.ThrowIfNecessary();
+        }
+
+        public void RemoveObservedObject(IntPtr managedRealmObjectHandle)
+        {
+            NativeException nativeException;
+            NativeMethods.remove_observed_object(this, managedRealmObjectHandle, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Shared/Realm.Shared/Handles/SharedRealmHandle.cs
+++ b/Shared/Realm.Shared/Handles/SharedRealmHandle.cs
@@ -79,7 +79,7 @@ namespace Realms
             public static extern UInt64 get_schema_version(SharedRealmHandle sharedRealm, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_add_observed_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_observed_object(SharedRealmHandle sharedRealm, IntPtr managedRealmHandle, ObjectHandle objectHandle, out NativeException ex);
+            public static extern void add_observed_object(SharedRealmHandle sharedRealm, IntPtr managedRealmHandle, ObjectHandle objectHandle, IntPtr managedRealmObjectHandle, out NativeException ex);
         }
 
         [Preserve]
@@ -116,10 +116,10 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public void AddObservedObject(IntPtr managedRealmHandle, ObjectHandle objectHandle)
+        public void AddObservedObject(IntPtr managedRealmHandle, ObjectHandle objectHandle, IntPtr managedRealmObjectHandle)
         {
             NativeException nativeException;
-            NativeMethods.add_observed_object(this, managedRealmHandle, objectHandle, out nativeException);
+            NativeMethods.add_observed_object(this, managedRealmHandle, objectHandle, managedRealmObjectHandle, out nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Shared/Realm.Shared/Linq/RealmResults.cs
+++ b/Shared/Realm.Shared/Linq/RealmResults.cs
@@ -239,9 +239,8 @@ namespace Realms
 
         internal void RemoveCallback(NotificationCallbackDelegate callback)
         {
-            _callbacks.Remove(callback);
-
-            if (_callbacks.Count == 0)
+            if (_callbacks.Remove(callback) &&
+                _callbacks.Count == 0)
             {
                 UnsubscribeFromNotifications();
             }
@@ -271,7 +270,7 @@ namespace Realms
         {
             Debug.Assert(_notificationToken != null, "_notificationToken must not be null to unsubscribe.");
 
-            _notificationToken.Dispose();
+            _notificationToken?.Dispose();
             _notificationToken = null;
         }
 

--- a/Shared/Realm.Shared/Realm.cs
+++ b/Shared/Realm.Shared/Realm.cs
@@ -46,6 +46,7 @@ namespace Realms
         {
             NativeCommon.Initialize();
             NativeCommon.register_notify_realm_changed(NotifyRealmChanged);
+            NativeCommon.register_notify_realm_object_changed(RealmObject.NotifyRealmObjectPropertyChanged);
         }
 
         #if __IOS__

--- a/Shared/Realm.Shared/Realm.cs
+++ b/Shared/Realm.Shared/Realm.cs
@@ -792,7 +792,7 @@ namespace Realms
                 throw new ArgumentException("Object is not managed by Realm, so it cannot be removed.", nameof(obj));
             }
 
-            obj.RemoveFromRealm(this);
+            obj.ObjectHandle.RemoveFromRealm(SharedRealmHandle);
         }
 
         /// <summary>

--- a/Shared/Realm.Shared/Realm.cs
+++ b/Shared/Realm.Shared/Realm.cs
@@ -433,6 +433,13 @@ namespace Realms
             return new SortDescriptorBuilder(metadata);
         }
 
+        internal void SubscribeForNotifications(RealmObject @object)
+        {
+            // TODO: add objects to a local collection as well
+            var managedRealmHandle = GCHandle.Alloc(this, GCHandleType.Weak);
+            this.SharedRealmHandle.AddObservedObject(GCHandle.ToIntPtr(managedRealmHandle), @object.ObjectHandle);
+        }
+
         /// <summary>
         /// This realm will start managing a RealmObject which has been created as a standalone object.
         /// </summary>

--- a/Shared/Realm.Shared/Realm.cs
+++ b/Shared/Realm.Shared/Realm.cs
@@ -48,19 +48,14 @@ namespace Realms
             NativeCommon.register_notify_realm_changed(NotifyRealmChanged);
         }
 
-#if __IOS__
+        #if __IOS__
         [MonoPInvokeCallback(typeof(NativeCommon.NotifyRealmCallback))]
-#endif
+        #endif
         private static void NotifyRealmChanged(IntPtr realmHandle)
         {
             var gch = GCHandle.FromIntPtr(realmHandle);
             ((Realm)gch.Target).NotifyChanged(EventArgs.Empty);
         }
-
-        /// <summary>
-        /// Gets the <see cref="RealmConfiguration"/> that controls this realm's path and other settings.
-        /// </summary>
-        public RealmConfiguration Config { get; private set; }
 
         /// <summary>
         /// Factory for a Realm instance for this thread.
@@ -127,6 +122,11 @@ namespace Realms
         /// Gets the <see cref="RealmSchema"/> instance that describes all the types that can be stored in this <see cref="Realm"/>.
         /// </summary>
         public RealmSchema Schema { get; }
+
+        /// <summary>
+        /// Gets the <see cref="RealmConfiguration"/> that controls this realm's path and other settings.
+        /// </summary>
+        public RealmConfiguration Config { get; private set; }
 
         internal Realm(SharedRealmHandle sharedRealmHandle, RealmConfiguration config, RealmSchema schema)
         {
@@ -435,9 +435,9 @@ namespace Realms
 
         internal void SubscribeForNotifications(RealmObject @object)
         {
-            // TODO: add objects to a local collection as well
             var managedRealmHandle = GCHandle.Alloc(this, GCHandleType.Weak);
-            this.SharedRealmHandle.AddObservedObject(GCHandle.ToIntPtr(managedRealmHandle), @object.ObjectHandle);
+            var managedRealmObjectHandle = GCHandle.Alloc(@object, GCHandleType.Weak);
+            this.SharedRealmHandle.AddObservedObject(GCHandle.ToIntPtr(managedRealmHandle), @object.ObjectHandle, GCHandle.ToIntPtr(managedRealmObjectHandle));
         }
 
         /// <summary>

--- a/Shared/Realm.Shared/Realm.cs
+++ b/Shared/Realm.Shared/Realm.cs
@@ -792,7 +792,7 @@ namespace Realms
                 throw new ArgumentException("Object is not managed by Realm, so it cannot be removed.", nameof(obj));
             }
 
-            obj.RemoveFromRealm();
+            obj.RemoveFromRealm(this);
         }
 
         /// <summary>

--- a/Shared/Realm.Shared/Realm.cs
+++ b/Shared/Realm.Shared/Realm.cs
@@ -433,13 +433,6 @@ namespace Realms
             return new SortDescriptorBuilder(metadata);
         }
 
-        internal void SubscribeForNotifications(RealmObject @object)
-        {
-            var managedRealmHandle = GCHandle.Alloc(this, GCHandleType.Weak);
-            var managedRealmObjectHandle = GCHandle.Alloc(@object, GCHandleType.Weak);
-            this.SharedRealmHandle.AddObservedObject(GCHandle.ToIntPtr(managedRealmHandle), @object.ObjectHandle, GCHandle.ToIntPtr(managedRealmObjectHandle));
-        }
-
         /// <summary>
         /// This realm will start managing a RealmObject which has been created as a standalone object.
         /// </summary>
@@ -799,7 +792,7 @@ namespace Realms
                 throw new ArgumentException("Object is not managed by Realm, so it cannot be removed.", nameof(obj));
             }
 
-            obj.ObjectHandle.RemoveFromRealm(SharedRealmHandle);
+            obj.RemoveFromRealm();
         }
 
         /// <summary>

--- a/Shared/Realm.Shared/RealmConfiguration.cs
+++ b/Shared/Realm.Shared/RealmConfiguration.cs
@@ -242,7 +242,7 @@ namespace Realms
             var configuration = new Native.Configuration
             {
                 Path = DatabasePath,
-                read_only = ReadOnly,
+                read_only = IsReadOnly,
                 delete_if_migration_needed = ShouldDeleteIfMigrationNeeded,
                 schema_version = SchemaVersion
             };

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -53,7 +53,7 @@ namespace Realms
         {
             var gch = GCHandle.FromIntPtr(realmObjectHandle);
             var realmObject = (RealmObject)gch.Target;
-            var propertyName = realmObject.ObjectSchema.ElementAtOrDefault((int)propertyIndex).Name;
+            var propertyName = realmObject.ObjectSchema.ElementAtOrDefault((int)propertyIndex).PropertyInfo.Name;
             realmObject.RaisePropertyChanged(propertyName);
         }
 
@@ -127,16 +127,6 @@ namespace Realms
             {
                 SubscribeForNotifications();
             }
-        }
-
-        internal void RemoveFromRealm(Realm realm)
-        {
-            if (_propertyChanged != null)
-            {
-                UnsubscribeFromNotifications();
-            }
-
-            ObjectHandle.RemoveFromRealm(realm.SharedRealmHandle);
         }
 
         internal class Metadata

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -41,15 +41,10 @@ namespace Realms
     {
         #region static
 
-        static RealmObject()
-        {
-            NativeCommon.register_notify_realm_object_changed(NotifyRealmObjectPropertyChanged);
-        }
-
         #if __IOS__
         [MonoPInvokeCallback(typeof(NativeCommon.NotifyRealmCallback))]
         #endif
-        private static void NotifyRealmObjectPropertyChanged(IntPtr realmObjectHandle, IntPtr propertyIndex)
+        public static void NotifyRealmObjectPropertyChanged(IntPtr realmObjectHandle, IntPtr propertyIndex)
         {
             var gch = GCHandle.FromIntPtr(realmObjectHandle);
             var realmObject = (RealmObject)gch.Target;

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -129,14 +129,14 @@ namespace Realms
             }
         }
 
-        internal void RemoveFromRealm()
+        internal void RemoveFromRealm(Realm realm)
         {
             if (_propertyChanged != null)
             {
                 UnsubscribeFromNotifications();
             }
 
-            ObjectHandle.RemoveFromRealm(_realm.SharedRealmHandle);
+            ObjectHandle.RemoveFromRealm(realm.SharedRealmHandle);
         }
 
         internal class Metadata

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -38,7 +38,31 @@ namespace Realms
         private ObjectHandle _objectHandle;
         private Metadata _metadata;
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        private event PropertyChangedEventHandler _propertyChanged;
+
+        public event PropertyChangedEventHandler PropertyChanged
+        {
+            add
+            {
+                if (IsManaged && _propertyChanged == null)
+                {
+                    // TODO: Subscribe
+                }
+
+                _propertyChanged += value;
+            }
+
+            remove
+            {
+                _propertyChanged -= value;
+
+                if (IsManaged &&
+                    _propertyChanged == null)
+                {
+                    // TODO: Unsubscribe
+                }
+            }
+        }
 
         internal ObjectHandle ObjectHandle => _objectHandle;
 
@@ -72,6 +96,19 @@ namespace Realms
             _realm = realm;
             _objectHandle = objectHandle;
             _metadata = metadata;
+
+            if (_propertyChanged != null)
+            {
+                // TODO: subscribe
+            }
+        }
+
+        internal void RemoveFromRealm()
+        {
+            if (_propertyChanged != null)
+            {
+                // TODO: unsubscribe
+            }
         }
 
         internal class Metadata
@@ -539,7 +576,7 @@ namespace Realms
 
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            _propertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         TypeInfo IReflectableType.GetTypeInfo()

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -46,7 +46,7 @@ namespace Realms
             {
                 if (IsManaged && _propertyChanged == null)
                 {
-                    // TODO: Subscribe
+                    _realm.SubscribeForNotifications(this);
                 }
 
                 _propertyChanged += value;
@@ -99,7 +99,7 @@ namespace Realms
 
             if (_propertyChanged != null)
             {
-                // TODO: subscribe
+                realm.SubscribeForNotifications(this);
             }
         }
 

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -18,10 +18,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Realms
 {
@@ -32,11 +32,13 @@ namespace Realms
     /// Has a Preserve attribute to attempt to preserve all subtypes without having to weave.
     /// </remarks>
     [Preserve(AllMembers = true, Conditional = false)]
-    public class RealmObject : IReflectableType
+    public class RealmObject : IReflectableType, INotifyPropertyChanged
     {
         private Realm _realm;
         private ObjectHandle _objectHandle;
         private Metadata _metadata;
+
+        public event PropertyChangedEventHandler PropertyChanged;
 
         internal ObjectHandle ObjectHandle => _objectHandle;
 
@@ -533,6 +535,11 @@ namespace Realms
             // Note that the base class is not invoked because it is 
             // System.Object, which defines Equals as reference equality. 
             return ObjectHandle.Equals(((RealmObject)obj).ObjectHandle);
+        }
+
+        protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         TypeInfo IReflectableType.GetTypeInfo()

--- a/Shared/Realm.Shared/native/NativeCommon.cs
+++ b/Shared/Realm.Shared/native/NativeCommon.cs
@@ -35,6 +35,8 @@ namespace Realms
     {
         public delegate void NotifyRealmCallback(IntPtr realmHandle);
 
+        public delegate void NotifyRealmObjectCallback(IntPtr realmObjectHandle, IntPtr propertyIndex);
+
 #if DEBUG
         public delegate void DebugLoggerCallback(IntPtr utf8String, IntPtr stringLen);
 
@@ -56,6 +58,9 @@ namespace Realms
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "delete_pointer", CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe void delete_pointer(void* pointer);
+
+        [DllImport(InteropConfig.DLL_NAME, EntryPoint = "register_notify_realm_object_changed", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void register_notify_realm_object_changed(NotifyRealmObjectCallback callback);
 
         public static void Initialize()
         {

--- a/Shared/Tests.Shared/NotificationTests.cs
+++ b/Shared/Tests.Shared/NotificationTests.cs
@@ -81,6 +81,23 @@ namespace IntegrationTests.Shared
         }
 
         [Test]
+        public void ShouldTriggerObjectPropertyChangedEvent()
+        {
+            var wasNotified = false;
+            var person = new Person();
+            _realm.Write(() => 
+            {
+                _realm.Add(person);
+            });
+
+            person.PropertyChanged += (sender, e) => { wasNotified = true; };
+
+            _realm.Write(() => person.FirstName = "Peter");
+
+            Assert.That(wasNotified, Is.True);
+        }
+
+        [Test]
         public void ResultsShouldSendNotifications()
         {
             var query = _realm.All<Person>();

--- a/Shared/Tests.Shared/NotificationTests.cs
+++ b/Shared/Tests.Shared/NotificationTests.cs
@@ -81,36 +81,6 @@ namespace IntegrationTests.Shared
         }
 
         [Test]
-        public void ShouldTriggerObjectPropertyChangedEvent()
-        {
-            string notifiedPropertyName = null;
-            var person = new Person();
-            _realm.Write(() => 
-            {
-                _realm.Add(person);
-            });
-
-            person.PropertyChanged += (sender, e) => 
-            { 
-                notifiedPropertyName = e.PropertyName;
-            };
-
-            Task.Run(() =>
-            {
-                var realm = Realm.GetInstance(_databasePath);
-                var p = realm.All<Person>().First();
-                realm.Write(() =>
-                {
-                    p.FirstName = "Peter";
-                });
-            }).Wait();
-
-            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
-
-            Assert.That(notifiedPropertyName, Is.EqualTo(nameof(Person.FirstName)));
-        }
-
-        [Test]
         public void ResultsShouldSendNotifications()
         {
             var query = _realm.All<Person>();

--- a/Shared/Tests.Shared/PropertyChangedTests.cs
+++ b/Shared/Tests.Shared/PropertyChangedTests.cs
@@ -1,0 +1,81 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Realms;
+
+namespace IntegrationTests.Shared
+{
+    [TestFixture, Preserve(AllMembers = true)]
+    public class PropertyChangedTests
+    {
+        private string _databasePath;
+        private Realm _realm;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _databasePath = Path.GetTempFileName();
+            _realm = Realm.GetInstance(_databasePath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _realm.Dispose();
+            Realm.DeleteRealm(_realm.Config);
+        }
+
+        [Test]
+        public void ShouldTriggerObjectPropertyChangedEvent()
+        {
+            string notifiedPropertyName = null;
+            var person = new Person();
+            _realm.Write(() =>
+            {
+                _realm.Add(person);
+            });
+
+            var handler = new PropertyChangedEventHandler((sender, e) => 
+            {
+                notifiedPropertyName = e.PropertyName;
+            });
+
+            person.PropertyChanged += handler;
+
+            Task.Run(() =>
+            {
+                var realm = Realm.GetInstance(_databasePath);
+                var p = realm.All<Person>().First();
+                realm.Write(() =>
+                {
+                    p.FirstName = "Peter";
+                });
+            }).Wait();
+
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+
+            Assert.That(notifiedPropertyName, Is.EqualTo(nameof(Person.FirstName)));
+        }
+    }
+}

--- a/Shared/Tests.Shared/PropertyChangedTests.cs
+++ b/Shared/Tests.Shared/PropertyChangedTests.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -47,35 +48,225 @@ namespace IntegrationTests.Shared
         }
 
         [Test]
-        public void ShouldTriggerObjectPropertyChangedEvent()
+        public void UnmanagedObject()
         {
             string notifiedPropertyName = null;
+            var person = new Person();
+
+            var handler = new PropertyChangedEventHandler((sender, e) =>
+            {
+                notifiedPropertyName = e.PropertyName;
+            });
+            person.PropertyChanged += handler;
+
+            // Subscribed - should trigger
+            person.FirstName = "Peter";
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifiedPropertyName, Is.EqualTo(nameof(Person.FirstName)));
+
+            notifiedPropertyName = null;
+            person.PropertyChanged -= handler;
+
+            // Unsubscribed - should not trigger
+            person.FirstName = "George";
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifiedPropertyName, Is.Null);
+        }
+
+        [Test]
+        public void UnmanagedObject_AfterAdd_ShouldContinueTriggering()
+        {
+            var notifications = 0;
+            var person = new SomeClass();
+
+            person.PropertyChanged += (sender, e) =>
+            {
+                Assert.That(e.PropertyName, Is.EqualTo(nameof(SomeClass.StringValue)));
+                notifications++;
+            };
+
+            person.StringValue = "Peter";
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifications, Is.EqualTo(1));
+
+            _realm.Write(() =>
+            {
+                _realm.Add(person);
+            });
+
+            // When calling Realm.Add, all properties are persisted, which causes a notification to be sent out.
+            // We're using SomeClass because Person has nullable properties, which are set always, so it interferes with the test.
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifications, Is.EqualTo(2));
+
+            _realm.Write(() =>
+            {
+                person.StringValue = "George";
+            });
+
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifications, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void ManagedObject_WhenSameInstanceChanged()
+        {
+            TestManaged((person, name) =>
+            {
+                _realm.Write(() =>
+                {
+                    person.FirstName = name;
+                });
+            });
+        }
+
+        [Test]
+        public void ManagedObject_WhenAnotherInstanceChanged()
+        {
+            TestManaged((_, name) =>
+            {
+                _realm.Write(() =>
+                {
+                    var otherPersonInstance = _realm.All<Person>().First();
+                    otherPersonInstance.FirstName = name;
+                });
+            });
+        }
+
+        [Test]
+        public void ManagedObject_WhenAnotherThreadInstanceChanged()
+        {
+            TestManaged((_, name) =>
+            {
+                _realm.WriteAsync(otherRealm =>
+                {
+                    var otherPersonInstance = otherRealm.All<Person>().First();
+                    otherPersonInstance.FirstName = name;
+                }).Wait();
+            });
+        }
+
+        [Test]
+        public void ManagedObject_WhenSameInstanceTransactionRollback()
+        {
+            TestManagedRollback((person, name) =>
+            {
+                person.FirstName = name;
+            }, _realm.BeginWrite);
+        }
+
+        [Test]
+        public void ManagedObject_WhenAnotherInstaceTransactionRollback()
+        {
+            TestManagedRollback((_, name) =>
+            {
+                var otherInstance = _realm.All<Person>().First();
+                otherInstance.FirstName = name;
+            }, _realm.BeginWrite);
+        }
+
+        [Test]
+        public void ManagedObject_WhenAnotherThreadInstanceTransactionRollback()
+        {
+            var notifiedPropertyNames = new List<string>();
             var person = new Person();
             _realm.Write(() =>
             {
                 _realm.Add(person);
             });
 
-            var handler = new PropertyChangedEventHandler((sender, e) => 
+            person.PropertyChanged += (sender, e) =>
             {
-                notifiedPropertyName = e.PropertyName;
-            });
-
-            person.PropertyChanged += handler;
+                notifiedPropertyNames.Add(e.PropertyName);
+            };
 
             Task.Run(() =>
             {
-                var realm = Realm.GetInstance(_databasePath);
-                var p = realm.All<Person>().First();
-                realm.Write(() =>
+                var otherRealm = Realm.GetInstance(_databasePath);
+                using (var transaction = otherRealm.BeginWrite())
                 {
-                    p.FirstName = "Peter";
-                });
+                    var otherInstance = otherRealm.All<Person>().First();
+                    otherInstance.FirstName = "Peter";
+
+                    TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+                    Assert.That(notifiedPropertyNames, Is.Empty);
+
+                    transaction.Rollback();
+                }
             }).Wait();
 
             TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifiedPropertyNames, Is.Empty);
+        }
 
-            Assert.That(notifiedPropertyName, Is.EqualTo(nameof(Person.FirstName)));
+        private void TestManaged(Action<Person, string> writeFirstNameAction)
+        {
+            var notifiedPropertyNames = new List<string>();
+            var person = new Person();
+            _realm.Write(() =>
+            {
+                _realm.Add(person);
+            });
+            var handler = new PropertyChangedEventHandler((sender, e) =>
+            {
+                notifiedPropertyNames.Add(e.PropertyName);
+            });
+            person.PropertyChanged += handler;
+
+            // Subscribed - regular set should trigger
+            writeFirstNameAction(person, "Peter");
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifiedPropertyNames, Is.EquivalentTo(new[] { nameof(Person.FirstName) }));
+
+            // Subscribed - setting the same value for the property should trigger again
+            // This is different from .NET's usual behavior, but is a limitation due to the fact that we don't
+            // check the previous value of the property before setting it.
+            writeFirstNameAction(person, "Peter");
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifiedPropertyNames, Is.EquivalentTo(new[] { nameof(Person.FirstName), nameof(Person.FirstName) }));
+
+            notifiedPropertyNames.Clear();
+            person.PropertyChanged -= handler;
+
+            // Unsubscribed - should not trigger
+            writeFirstNameAction(person, "George");
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifiedPropertyNames, Is.Empty);
+        }
+
+        private void TestManagedRollback(Action<Person, string> writeFirstNameAction, Func<Transaction> transactionFactory)
+        {
+            var notifiedPropertyNames = new List<string>();
+            var person = new Person();
+            _realm.Write(() =>
+            {
+                _realm.Add(person);
+            });
+
+            person.PropertyChanged += (sender, e) =>
+            {
+                notifiedPropertyNames.Add(e.PropertyName);
+            };
+
+            using (var transaction = transactionFactory())
+            {
+                writeFirstNameAction(person, "Peter");
+
+                TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+                Assert.That(notifiedPropertyNames, Is.EquivalentTo(new[] { nameof(Person.FirstName) }));
+
+                transaction.Rollback();
+            }
+
+            TestHelpers.RunEventLoop(TimeSpan.FromMilliseconds(1));
+            Assert.That(notifiedPropertyNames, Is.EquivalentTo(new[] { nameof(Person.FirstName), nameof(Person.FirstName) }));
+        }
+
+        private class SomeClass : RealmObject
+        {
+            public string StringValue { get; set; }
+
+            public int IntValue { get; set; }
         }
     }
 }

--- a/Shared/Tests.Shared/Tests.Shared.projitems
+++ b/Shared/Tests.Shared/Tests.Shared.projitems
@@ -38,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GetPrimaryKeyTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReflectableTypeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ObjectSchemaTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PropertyChangedTests.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(ProjectName)' != 'IntegrationTests.Win32' ">
     <Compile Include="$(MSBuildThisFileDirectory)TestRunner.cs" />

--- a/Weaver/WeaverTests/AssemblyToProcess/TestObjects.cs
+++ b/Weaver/WeaverTests/AssemblyToProcess/TestObjects.cs
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Realms;
 
@@ -63,48 +62,6 @@ namespace AssemblyToProcess
         public bool? NullableBooleanProperty { get; set; }
 
         public DateTimeOffset? NullableDateTimeOffsetProperty { get; set; }
-    }
-
-    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
-    public class AllTypesObjectPropertyChanged : RealmObject, INotifyPropertyChanged
-    {
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        public char CharProperty { get; set; }
-
-        public byte ByteProperty { get; set; }
-
-        public short Int16Property { get; set; }
-
-        public int Int32Property { get; set; }
-
-        public long Int64Property { get; set; }
-
-        public float SingleProperty { get; set; }
-
-        public double DoubleProperty { get; set; }
-
-        public bool BooleanProperty { get; set; }
-
-        public string StringProperty { get; set; }
-
-        public DateTimeOffset DateTimeOffsetProperty { get; set; }
-
-        public char? NullableCharProperty { get; set; }
-
-        public byte? NullableByteProperty { get; set; }
-
-        public short? NullableInt16Property { get; set; }
-
-        public int? NullableInt32Property { get; set; }
-
-        public long? NullableInt64Property { get; set; }
-
-        public float? NullableSingleProperty { get; set; }
-
-        public double? NullableDoubleProperty { get; set; }
-
-        public bool? NullableBooleanProperty { get; set; }
     }
 
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]

--- a/Weaver/WeaverTests/Realm.FakeForWeaverTests/RealmObject.cs
+++ b/Weaver/WeaverTests/Realm.FakeForWeaverTests/RealmObject.cs
@@ -18,14 +18,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace Realms
 {
-    public class RealmObject
+    public class RealmObject : INotifyPropertyChanged
     {
         public List<string> LogList = new List<string>();
 
+        public event PropertyChangedEventHandler PropertyChanged;
+        
         private void LogString(string s)
         {
             LogList.Add(s);
@@ -358,6 +361,11 @@ namespace Realms
         protected void SetByteArrayValue(string propertyName, byte[] value)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
+        }
+
+        protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Weaver/WeaverTests/RealmWeaver.Tests/WeaverTests.cs
+++ b/Weaver/WeaverTests/RealmWeaver.Tests/WeaverTests.cs
@@ -82,6 +82,13 @@ namespace RealmWeaver
 
         private void WeavePropertyChanged(ModuleDefinition moduleDefinition)
         {
+            // Disable CheckForEquality, because this will rewrite all our properties and some tests will
+            // behave differently based on whether PropertyChanged is weaved or not.
+            // Those differences will be unlikely to affect real world scenarios, but affect the tests:
+            //   WovenCopyToRealm_ShouldAlwaysSetNullableProperties -> does not call native methods
+            //   ShouldFollowMapToAttribute -> checks for (value != this.Email_) which adds two extra entries in the LogList
+            // Additionally, the tests don't test the exact behavior of Realm + PropertyChanged, because the check for
+            // Fody.PropertyChanged will always return 'false' (ModuleWeaver.cs@214).
             var config = new XElement("PropertyChanged");
             config.SetAttributeValue("CheckForEquality", false);
             new propertychanged::ModuleWeaver
@@ -310,6 +317,27 @@ namespace RealmWeaver
             }));
             Assert.That(GetAutoPropertyBackingFieldValue(o, propertyName), Is.EqualTo(defaultPropertyValue));
             Assert.That(eventRaised, Is.False);
+        }
+
+        [TestCaseSource(nameof(RandomValues))]
+        public void SetValueUnmanagedShouldRaisePropertyChanged(string typeName, object propertyValue)
+        {
+            // Arrange
+            var propertyName = typeName + "Property";
+            var o = (dynamic)Activator.CreateInstance(_assembly.GetType("AssemblyToProcess.AllTypesObject"));
+
+            var eventRaised = false;
+            o.PropertyChanged += new PropertyChangedEventHandler((s, e) =>
+            {
+                eventRaised |= e.PropertyName == propertyName;
+            });
+
+            // Act
+            SetPropertyValue(o, propertyName, propertyValue);
+
+            // Assert
+            Assert.That(GetAutoPropertyBackingFieldValue(o, propertyName), Is.EqualTo(propertyValue));
+            Assert.That(eventRaised, Is.True);
         }
 
         [TestCase("Char", '0', char.MinValue)]

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -250,6 +250,8 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_link(column_ndx, target_object.row().get_index());
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -260,6 +262,8 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().nullify_link(column_ndx);
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -273,6 +277,8 @@ extern "C" {
                 throw std::invalid_argument("Column is not nullable");
             
             object.row().set_null(column_ndx);
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -295,6 +301,8 @@ extern "C" {
                 }
                 
                 object.row().set_null_unique(column_ndx);
+                
+                notify_changes(object, property_ndx);
             }
         });
     }
@@ -303,9 +311,10 @@ extern "C" {
     {
         return handle_errors(ex, [&]() {
             verify_can_set(object);
-            
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_bool(column_ndx, size_t_to_bool(value));
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -316,6 +325,8 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_int(column_ndx, value);
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -336,6 +347,8 @@ extern "C" {
                 }
                 
                 object.row().set_int_unique(column_ndx, value);
+                
+                notify_changes(object, property_ndx);
             }
         });
     }
@@ -347,6 +360,8 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_float(column_ndx, value);
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -356,6 +371,8 @@ extern "C" {
             verify_can_set(object);
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_double(column_ndx, value);
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -367,6 +384,8 @@ extern "C" {
             const size_t column_ndx = get_column_index(object, property_ndx);
             Utf16StringAccessor str(value, value_len);
             object.row().set_string(column_ndx, str);
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -388,6 +407,8 @@ extern "C" {
                 }
                 
                 object.row().set_string_unique(column_ndx, str);
+                
+                notify_changes(object, property_ndx);
             }
         });
     }
@@ -399,6 +420,8 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_binary(column_ndx, BinaryData(value, value_len));
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -409,6 +432,8 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_timestamp(column_ndx, from_ticks(value));
+            
+            notify_changes(object, property_ndx);
         });
     }
     
@@ -422,6 +447,8 @@ extern "C" {
             verify_can_set(object);
             
             object.row().get_table()->move_last_over(object.row().get_index());
+            
+            notify_removed(object);
         });
     }
     

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -446,9 +446,14 @@ extern "C" {
             
             verify_can_set(object);
             
-            object.row().get_table()->move_last_over(object.row().get_index());
+            auto const row_index = object.row().get_index();
+            auto const table_index = object.row().get_table()->get_index_in_group();
+            object.row().get_table()->move_last_over(row_index);
             
-            notify_removed(object);
+            if (realm->m_binding_context != nullptr) {
+                auto const& csharp_context = static_cast<binding::CSharpBindingContext*>(object.realm()->m_binding_context.get());
+                csharp_context->notify_removed(row_index, table_index);
+            }
         });
     }
     

--- a/wrappers/src/object_cs.hpp
+++ b/wrappers/src/object_cs.hpp
@@ -53,11 +53,4 @@ namespace realm {
             csharp_context->notify_change(object.row().get_index(), object.row().get_table()->get_index_in_group(), property_index);
         }
     }
-    
-    inline void notify_removed(const Object& object) {
-        if (object.realm()->m_binding_context != nullptr) {
-            auto const& csharp_context = static_cast<binding::CSharpBindingContext*>(object.realm()->m_binding_context.get());
-            csharp_context->notify_removed(object.row().get_index(), object.row().get_table()->get_index_in_group());
-        }
-    }
 }

--- a/wrappers/src/object_cs.hpp
+++ b/wrappers/src/object_cs.hpp
@@ -17,6 +17,10 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "object_accessor.hpp"
+#include "shared_realm_cs.hpp"
+
+using namespace realm;
+using namespace realm::binding;
 
 namespace realm {
     inline void verify_can_get(const Object& object) {
@@ -39,7 +43,21 @@ namespace realm {
         object.realm()->verify_in_write();
     }
     
-    inline size_t get_column_index(const Object& object, size_t property_index) {
+    inline size_t get_column_index(const Object& object, const size_t property_index) {
         return object.get_object_schema().persisted_properties[property_index].table_column;
+    }
+    
+    inline void notify_changes(const Object& object, const size_t property_index) {
+        if (object.realm()->m_binding_context != nullptr) {
+            auto const& csharp_context = static_cast<binding::CSharpBindingContext*>(object.realm()->m_binding_context.get());
+            csharp_context->notify_change(object.row().get_index(), object.row().get_table()->get_index_in_group(), property_index);
+        }
+    }
+    
+    inline void notify_removed(const Object& object) {
+        if (object.realm()->m_binding_context != nullptr) {
+            auto const& csharp_context = static_cast<binding::CSharpBindingContext*>(object.realm()->m_binding_context.get());
+            csharp_context->notify_removed(object.row().get_index(), object.row().get_table()->get_index_in_group());
+        }
     }
 }

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -114,7 +114,7 @@ REALM_EXPORT void shared_realm_add_observed_object(SharedRealm& realm, void* man
 {
     handle_errors(ex, [&]() {
         auto const& csharp_context = get_or_set_managed_context(realm, managed_realm_handle);
-        csharp_context->add_observed_row(object.row().get_index(), object.row().get_table()->get_index_in_group(), managed_realm_object_handle);
+        csharp_context->add_observed_row(object, managed_realm_object_handle);
     });
 }
     

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -59,10 +59,7 @@ namespace binding {
         return static_cast<CSharpBindingContext*>(realm->m_binding_context.get());
     }
 
-    CSharpBindingContext::CSharpBindingContext(void* managed_realm_handle) : m_managed_realm_handle(managed_realm_handle)
-    {
-        m_observed_rows = std::vector<ObserverState>();
-    }
+    CSharpBindingContext::CSharpBindingContext(void* managed_realm_handle) : m_managed_realm_handle(managed_realm_handle) {}
     
     void CSharpBindingContext::did_change(std::vector<CSharpBindingContext::ObserverState> const& observed, std::vector<void*> const& invalidated)
     {
@@ -80,11 +77,6 @@ namespace binding {
         }
         
         notify_realm_changed(m_managed_realm_handle);
-    }
-    
-    std::vector<CSharpBindingContext::ObserverState> CSharpBindingContext::get_observed_rows()
-    {
-        return m_observed_rows;
     }
     
     void CSharpBindingContext::add_observed_row(const Object& object, void* managed_object_handle)

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -21,6 +21,7 @@
 
 #include "shared_realm.hpp"
 #include "schema_cs.hpp"
+#include "object-store/src/binding_context.hpp"
 
 class ManagedExceptionDuringMigration : public std::runtime_error
 {
@@ -45,5 +46,81 @@ struct Configuration
     bool (*migration_callback)(realm::SharedRealm* old_realm, realm::SharedRealm* new_realm, SchemaForMarshaling, uint64_t schema_version, void* managed_migration_handle);
     void* managed_migration_handle;
 };
+
+using NotifyRealmChangedT = void(*)(void* managed_realm_handle);
+NotifyRealmChangedT notify_realm_changed = nullptr;
+
+using NotifyRealmObjectChangedT = void(*)(void* managed_realm_object_handle, size_t property_ndx);
+NotifyRealmObjectChangedT notify_realm_object_changed = nullptr;
+
+namespace realm {
+namespace binding {
+    
+    class CSharpBindingContext: public BindingContext {
+    public:
+        CSharpBindingContext(void* managed_realm_handle) : m_managed_realm_handle(managed_realm_handle) {}
+        
+        void did_change(std::vector<ObserverState> const& observed, std::vector<void*> const& invalidated) override
+        {
+            for (auto const& o : observed) {
+                for (auto const& change : o.changes) {
+                    if (change.kind == ColumnInfo::Kind::Set) {
+                        // TODO: get property index from column_index
+                        notify_realm_object_changed(o.info, change.initial_column_index);
+                    }
+                }
+            }
+            
+            for (auto const& o : invalidated) {
+                remove_observed_row(o);
+            }
+            
+            notify_realm_changed(m_managed_realm_handle);
+        }
+        
+        std::vector<ObserverState> get_observed_rows() override
+        {
+            return observed_rows;
+        }
+        
+        void add_observed_row(const size_t row_ndx, const size_t table_ndx, void* info)
+        {
+            auto observer_state = BindingContext::ObserverState();
+            observer_state.row_ndx = row_ndx;
+            observer_state.table_ndx = table_ndx;
+            observer_state.info = info;
+            observed_rows.push_back(observer_state);
+        }
+        
+        void remove_observed_row(void* info)
+        {
+            observed_rows.erase(std::remove_if(observed_rows.begin(), observed_rows.end(), [&](auto const& row) { return row.info == info; }));
+        }
+        
+        void* get_managed_realm_handle() const {
+            return m_managed_realm_handle;
+        }
+        
+        void notify_change(const size_t row_ndx, const size_t table_ndx, const size_t property_index) const
+        {
+            for (auto const& o : observed_rows) {
+                if (o.row_ndx == row_ndx && o.table_ndx == table_ndx) {
+                    notify_realm_object_changed(o.info, property_index);
+                }
+            }
+        }
+        
+        void notify_removed(const size_t row_ndx, const size_t table_ndx)
+        {
+            observed_rows.erase(std::remove_if(observed_rows.begin(), observed_rows.end(),
+                                               [&](auto const& row) { return row.row_ndx == row_ndx && row.table_ndx == table_ndx; }));
+        }
+    private:
+        void* m_managed_realm_handle;
+        std::vector<BindingContext::ObserverState> observed_rows;
+    };
+}
+    
+}
 
 #endif /* defined(SHARED_REALM_CS_HPP) */

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -48,103 +48,29 @@ struct Configuration
     void* managed_migration_handle;
 };
 
-using NotifyRealmChangedT = void(*)(void* managed_realm_handle);
-NotifyRealmChangedT notify_realm_changed = nullptr;
-
-using NotifyRealmObjectChangedT = void(*)(void* managed_realm_object_handle, size_t property_ndx);
-NotifyRealmObjectChangedT notify_realm_object_changed = nullptr;
-
 namespace realm {
 namespace binding {
     
     struct ObservedObjectDetails {
         ObservedObjectDetails(const ObjectSchema& schema, void* managed_object_handle) : schema(schema), managed_object_handle(managed_object_handle) {}
-        
+
         const ObjectSchema& schema;
         void* managed_object_handle;
     };
     
     class CSharpBindingContext: public BindingContext {
     public:
-        CSharpBindingContext(void* managed_realm_handle) : m_managed_realm_handle(managed_realm_handle) {}
-        
-        void did_change(std::vector<ObserverState> const& observed, std::vector<void*> const& invalidated) override
-        {
-            for (auto const& o : observed) {
-                for (auto const& change : o.changes) {
-                    if (change.kind == ColumnInfo::Kind::Set) {
-                        auto const& observed_object_details = static_cast<ObservedObjectDetails*>(o.info);
-                        notify_realm_object_changed(observed_object_details->managed_object_handle, get_property_index(observed_object_details->schema, change.initial_column_index));
-                    }
-                }
-            }
-            
-            for (auto const& o : invalidated) {
-                remove_observed_row(o);
-            }
-            
-            notify_realm_changed(m_managed_realm_handle);
-        }
-        
-        std::vector<ObserverState> get_observed_rows() override
-        {
-            return observed_rows;
-        }
-        
-        void add_observed_row(const Object& object, void* managed_object_handle)
-        {
-            auto observer_state = BindingContext::ObserverState();
-            observer_state.row_ndx = object.row().get_index();
-            observer_state.table_ndx = object.row().get_table()->get_index_in_group();
-            observer_state.info = new ObservedObjectDetails(object.get_object_schema(), managed_object_handle);
-            observed_rows.push_back(observer_state);
-        }
-        
-        void remove_observed_row(void* managed_object_handle)
-        {
-            if (!observed_rows.empty()) {
-                observed_rows.erase(std::remove_if(observed_rows.begin(), observed_rows.end(), [&](auto const& row) { return get_managed_object_handle(row.info) == managed_object_handle; }));
-            }
-        }
-        
-        void* get_managed_realm_handle() const {
-            return m_managed_realm_handle;
-        }
-        
-        void notify_change(const size_t row_ndx, const size_t table_ndx, const size_t property_index) const
-        {
-            for (auto const& o : observed_rows) {
-                if (o.row_ndx == row_ndx && o.table_ndx == table_ndx) {
-                    notify_realm_object_changed(get_managed_object_handle(o.info), property_index);
-                }
-            }
-        }
-        
-        void notify_removed(const size_t row_ndx, const size_t table_ndx)
-        {
-            if (!observed_rows.empty()) {
-                observed_rows.erase(std::remove_if(observed_rows.begin(), observed_rows.end(),
-                                                   [&](auto const& row) { return row.row_ndx == row_ndx && row.table_ndx == table_ndx; }));
-            }
-        }
+        CSharpBindingContext(void* managed_realm_handle);
+        void did_change(std::vector<CSharpBindingContext::ObserverState> const& observed, std::vector<void*> const& invalidated) override;
+        std::vector<ObserverState> get_observed_rows() override;
+        void add_observed_row(const Object& object, void* managed_object_handle);
+        void remove_observed_row(void* managed_object_handle);
+        void* get_managed_realm_handle();
+        void notify_change(const size_t row_ndx, const size_t table_ndx, const size_t property_index);
+        void notify_removed(const size_t row_ndx, const size_t table_ndx);
     private:
         void* m_managed_realm_handle;
         std::vector<BindingContext::ObserverState> observed_rows;
-        
-        inline size_t get_property_index(const ObjectSchema& schema, const size_t column_index) {
-            auto const& props = schema.persisted_properties;
-            for (size_t i = 0; i < props.size(); ++i) {
-                if (props[i].table_column == column_index) {
-                    return i;
-                }
-            }
-            
-            return -1;
-        }
-        
-        inline void* get_managed_object_handle(void* info) const {
-            return static_cast<ObservedObjectDetails*>(info)->managed_object_handle;
-        }
     };
 }
     

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -62,7 +62,6 @@ namespace binding {
     public:
         CSharpBindingContext(void* managed_realm_handle);
         void did_change(std::vector<CSharpBindingContext::ObserverState> const& observed, std::vector<void*> const& invalidated) override;
-        std::vector<ObserverState> get_observed_rows() override;
         void add_observed_row(const Object& object, void* managed_object_handle);
         void remove_observed_row(void* managed_object_handle);
         void notify_change(const size_t row_ndx, const size_t table_ndx, const size_t property_index);
@@ -71,6 +70,11 @@ namespace binding {
         void* get_managed_realm_handle()
         {
             return m_managed_realm_handle;
+        }
+        
+        std::vector<CSharpBindingContext::ObserverState> get_observed_rows() override
+        {
+            return m_observed_rows;
         }
     private:
         void* m_managed_realm_handle;

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -65,12 +65,32 @@ namespace binding {
         std::vector<ObserverState> get_observed_rows() override;
         void add_observed_row(const Object& object, void* managed_object_handle);
         void remove_observed_row(void* managed_object_handle);
-        void* get_managed_realm_handle();
         void notify_change(const size_t row_ndx, const size_t table_ndx, const size_t property_index);
         void notify_removed(const size_t row_ndx, const size_t table_ndx);
+        
+        void* get_managed_realm_handle()
+        {
+            return m_managed_realm_handle;
+        }
     private:
         void* m_managed_realm_handle;
-        std::vector<BindingContext::ObserverState> observed_rows;
+        std::vector<BindingContext::ObserverState> m_observed_rows;
+
+        inline void remove_observed_rows(std::function<bool (const BindingContext::ObserverState*, const ObservedObjectDetails*)> filter)
+        {
+            if (!m_observed_rows.empty()) {
+                for (auto it = m_observed_rows.begin(); it != m_observed_rows.end();) {
+                    auto const& details = static_cast<ObservedObjectDetails*>(it->info);
+                    if (filter(&*it, details)) {
+                        delete(details);
+                        it = m_observed_rows.erase(it);
+                    } else {
+                        ++it;
+                    }
+                    
+                }
+            }
+        }
     };
 }
     


### PR DESCRIPTION
TODO:
- [x] Unregister observed items (event unsubscribe, remove object)
- [x] Unregister observed items on deletion (`invalidated` vector)
- [x] Handle changes for same-thread realms (I'm thinking of adding `NotifyChanges()` at the end of each `set_xxx` method)
- [x] Lookup property index, instead of using the column index
- [x] Decide whether we want to support `[MapTo]`
- [x] Moar unit tests 👺
- [x] Tests for object deletion

Resolves https://github.com/realm/realm-dotnet/issues/886