### PR TITLE
Handle crashes in Android tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -249,7 +249,9 @@ def AndroidTest(stashName) {
           }
           archiveLog = false
         } finally {
-          stopLogCatCollector(backgroundPid, archiveLog, stashName)
+          if (backgroundPid != null) {
+            stopLogCatCollector(backgroundPid, archiveLog, stashName)
+          }
         }
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,11 +224,59 @@ def AndroidTest(stashName) {
     node('android-hub') {
       deleteDir()
       unstash stashName
-      sh 'adb devices'
-      sh 'adb devices | grep -v List | grep -v ^$ | awk \'{print $1}\' | parallel \'adb -s {} uninstall io.realm.xamarintests; adb -s {} install io.realm.xamarintests-Signed.apk; adb -s {} shell am instrument -w -r io.realm.xamarintests/.TestRunner; adb -s {} shell run-as io.realm.xamarintests cat /data/data/io.realm.xamarintests/files/TestResults.Android.xml > TestResults.Android_{}.xml\''
+
+      lock("${env.NODE_NAME}-android") {
+        boolean archiveLog = true
+        String backgroundPid
+
+        try {
+          backgroundPid = startLogCatCollector()
+
+          sh '''
+            adb uninstall io.realm.xamarintests
+            adb install io.realm.xamarintests-Signed.apk
+          '''
+
+          def instrumentationOutput = sh script: '''
+            adb shell am instrument -w -r io.realm.xamarintests/.TestRunner
+            adb shell run-as io.realm.xamarintests cat /data/data/io.realm.xamarintests/files/TestResults.Android.xml > TestResults.Android.xml
+          ''', returnStdout: true
+
+          def result = readProperties text: instrumentationOutput.trim().replaceAll(': ', '=')
+          if (result.INSTRUMENTATION_CODE != '-1') {
+            echo instrumentationOutput
+            error result.INSTRUMENTATION_RESULT
+          }
+          archiveLog = false
+        } finally {
+          stopLogCatCollector(backgroundPid, archiveLog, stashName)
+        }
+      }
+
       publishTests()
     }
   }
+}
+
+def String startLogCatCollector() {
+  sh '''
+    adb logcat -c
+    adb logcat -v time > "logcat.txt" &
+    echo $! > pid
+  '''
+  return readFile("pid").trim()
+}
+
+def stopLogCatCollector(String backgroundPid, boolean archiveLog, String archiveName) {
+  sh "kill ${backgroundPid}"
+  if (archiveLog) {
+    zip([
+      'zipFile': "${archiveName}-logcat.zip",
+      'archive': true,
+      'glob' : 'logcat.txt'
+    ])
+  }
+  sh 'rm logcat.txt'
 }
 
 stage('NuGet') {

--- a/Shared/Tests.Shared/TestHelpers.cs
+++ b/Shared/Tests.Shared/TestHelpers.cs
@@ -86,7 +86,7 @@ namespace IntegrationTests
 
         public static void RunEventLoop()
         {
-            RunEventLoop(1);
+            RunEventLoop(100);
         }
 
 #if __ANDROID__


### PR DESCRIPTION
When the instrumented unit test runner crashes, the exit code of `adb shell` is still zero so the build isn't failed.

This checks the `INSTRUMENTATION_RESULT` output of `am instrument` and fails the build if the instrumentation errors out, while archiving the logcat output in case of error.

Fixes #946 