### PR TITLE
API to control user persistence

### DIFF
--- a/Platform.PCL/Realm.Sync.PCL/Realm.Sync.PCL.csproj
+++ b/Platform.PCL/Realm.Sync.PCL/Realm.Sync.PCL.csproj
@@ -65,6 +65,9 @@
     <Compile Include="..\..\Shared\Realm.Sync.Shared\Exceptions\SessionErrorKind.cs">
       <Link>Exceptions\SessionErrorKind.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\Realm.Sync.Shared\UserPersistenceMode.cs">
+      <Link>UserPersistencyMode.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Realm.PCL\Realm.PCL.csproj">

--- a/Platform.PCL/Realm.Sync.PCL/UserPCL.cs
+++ b/Platform.PCL/Realm.Sync.PCL/UserPCL.cs
@@ -66,6 +66,26 @@ namespace Realms.Sync
             return null;
         }
 
+        /// <summary>
+        /// Configures user persistence. If you need to call this, be sure to do so before accessing any other Realm API.
+        /// </summary>
+        /// <param name="mode">The persistence mode.</param>
+        /// <param name="encryptionKey">The key to encrypt the persistent user store with.</param>
+        /// <param name="resetOnError">If set to <c>true</c> reset the persistent user store on error.</param>
+        /// <remarks>
+        /// Users are persisted in a realm file within the application's sandbox.
+        /// <para>
+        /// By default <see cref="User"/> objects are persisted and are additionaly protected with an encryption key stored
+        /// in the iOS Keychain when running on an iOS device (but not on a Simulator).
+        /// On Android users are persisted in plaintext, because the AndroidKeyStore API is only supported on API level 18 and up.
+        /// You might want to provide your own encryption key on Android or disable persistence for security reasons.
+        /// </para>
+        /// </remarks>
+        public static void ConfigurePersistence(UserPersistenceMode mode, byte[] encryptionKey = null, bool resetOnError = false)
+        {
+            RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
+        }
+
         #endregion
 
         /// <summary>

--- a/Shared/Realm.Sync.Shared/Realm.Sync.Shared.projitems
+++ b/Shared/Realm.Sync.Shared/Realm.Sync.Shared.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UserState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Exceptions\SessionErrorException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Exceptions\SessionErrorKind.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UserPersistenceMode.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Handles\" />

--- a/Shared/Realm.Sync.Shared/UserPersistenceMode.cs
+++ b/Shared/Realm.Sync.Shared/UserPersistenceMode.cs
@@ -1,0 +1,42 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Realms.Sync
+{
+    /// <summary>
+    /// Enumeration that specifies how and if logged-in <see cref="User"/> objects are persisted
+    /// across application launches.
+    /// </summary>
+    public enum UserPersistenceMode
+    {
+        /// <summary>
+        /// Persist <see cref="User"/> objects, but do not encrypt them.
+        /// </summary>
+        NotEncrypted = 0,
+
+        /// <summary>
+        /// Persist <see cref="User"/> objects in an encrypted store.
+        /// </summary>
+        Encrypted,
+
+        /// <summary>
+        /// Do not persist <see cref="User"/> objects.
+        /// </summary>
+        Disabled
+    }
+}


### PR DESCRIPTION
which allows a custom encryption key for the sync metadata realm to be provided on Android since we cannot use the AndroidKeyStore because of its version requirements

Closes #975 