### PR TITLE
Apply [UnmanagedFunctionPointer] to EventLoopPostHandler to fix JIT crash

### DIFF
--- a/Shared/Realm.Shared/native/SynchronizationContextEventLoopSignal.cs
+++ b/Shared/Realm.Shared/native/SynchronizationContextEventLoopSignal.cs
@@ -34,6 +34,7 @@ namespace Realms
 
         private delegate void release_eventloop(IntPtr eventloop);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void EventLoopPostHandler(IntPtr user_data);
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_install_eventloop_callbacks", CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Happens on device where no-JIT policy is enforced by the OS.