### PR TITLE
Fix PCL linq methods lookup

### DIFF
--- a/Weaver/RealmWeaver.Fody/Extensions/AssemblyResolverExtensions.cs
+++ b/Weaver/RealmWeaver.Fody/Extensions/AssemblyResolverExtensions.cs
@@ -1,0 +1,39 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.ComponentModel;
+using Mono.Cecil;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class AssemblyResolverExtensions
+{
+    public static TypeDefinition LookupTypeDefinition(this IAssemblyResolver resolver, string typeName, params string[] assemblyNames)
+    {
+        foreach (var name in assemblyNames)
+        {
+            var result = resolver.Resolve(name).MainModule.GetType(typeName);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        throw new Exception($"{typeName} not found in {string.Join(", ", assemblyNames)}");
+    }
+}

--- a/Weaver/RealmWeaver.Fody/ModuleWeaver.cs
+++ b/Weaver/RealmWeaver.Fody/ModuleWeaver.cs
@@ -224,9 +224,11 @@ public class ModuleWeaver
             _system_IList = ModuleDefinition.ImportReference(listTypeDefinition);
         }
 
-        var system_core = AssemblyResolver.Resolve("System.Core");
-        _system_linq_Enumerable_Empty = ModuleDefinition.ImportReference(system_core.MainModule.GetType("System.Linq.Enumerable").LookupMethodDefinition("Empty"));
-        _system_linq_Queryable_AsQueryable = ModuleDefinition.ImportReference(system_core.MainModule.GetType("System.Linq.Queryable").LookupMethodDefinition("AsQueryable"));
+        var system_linq_enumerable = AssemblyResolver.LookupTypeDefinition("System.Linq.Enumerable", "System.Core", "System.Linq");
+        var system_linq_queryable = AssemblyResolver.LookupTypeDefinition("System.Linq.Queryable", "System.Core", "System.Linq.Queryable");
+
+        _system_linq_Enumerable_Empty = ModuleDefinition.ImportReference(system_linq_enumerable.LookupMethodDefinition("Empty"));
+        _system_linq_Queryable_AsQueryable = ModuleDefinition.ImportReference(system_linq_queryable.LookupMethodDefinition("AsQueryable"));
 
         // If the solution has a reference to PropertyChanged.Fody, let's look up the DoNotNotifyAttribute for use later.
         var usesPropertyChangedFody = ModuleDefinition.AssemblyReferences.Any(X => X.Name == "PropertyChanged");

--- a/Weaver/RealmWeaver.Fody/RealmWeaver.Fody.csproj
+++ b/Weaver/RealmWeaver.Fody/RealmWeaver.Fody.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Analytics.cs" />
     <Compile Include="TypeHelper.cs" />
     <Compile Include="Extensions\TypeDefinitionExtensions.cs" />
+    <Compile Include="Extensions\AssemblyResolverExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">


### PR DESCRIPTION
Build fails on PCL projects because `Enumerable.Empty` and `.AsQueryable` are not found.