### PR TITLE
Add a virtual OnPropertyChanged method

### DIFF
--- a/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
+++ b/Platform.PCL/Realm.PCL/RealmObjectPCL.cs
@@ -452,6 +452,39 @@ namespace Realms
             RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
         }
 
+        /// <summary>
+        /// Called when a property has changed on this class.
+        /// </summary>
+        /// <param name="propertyName">Property name.</param>
+        /// <remarks>
+        /// For this method to be called, you need to have first subscribed to <see cref="PropertyChanged"/>.
+        /// This can be used to react to changes to the current object, e.g. raising `PropertyChanged` for computed properties.
+        /// </remarks>
+        /// <example>
+        /// <c>
+        /// class MyClass : RealmObject
+        /// {
+        ///     public int StatusCodeRaw { get; set; }
+        /// 
+        ///     public StatusCodeEnum StatusCode => (StatusCodeEnum)StatusCodeRaw;
+        /// 
+        ///     protected override void OnPropertyChanged(string propertyName)
+        ///     {
+        ///         if (propertyName == nameof(StatusCodeRaw))
+        ///         {
+        ///             RaisePropertyChanged(nameof(StatusCode));
+        ///         }
+        ///     }
+        /// }
+        /// </c>
+        /// Here, we have a computed property that depends on a persisted one. In order to notify any <see cref="PropertyChanged"/>
+        /// subscribers that <c>StatusCode</c> has changed, we override <c>OnPropertyChanged</c> and raise <c>PropertyChanged</c>
+        /// manually.
+        /// </example>
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+        }
+
         TypeInfo IReflectableType.GetTypeInfo()
         {
             RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -677,6 +677,40 @@ namespace Realms
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
         {
             _propertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            OnPropertyChanged(propertyName);
+        }
+
+        /// <summary>
+        /// Called when a property has changed on this class.
+        /// </summary>
+        /// <param name="propertyName">Property name.</param>
+        /// <remarks>
+        /// For this method to be called, you need to have first subscribed to <see cref="PropertyChanged"/>.
+        /// This can be used to react to changes to the current object, e.g. raising `PropertyChanged` for computed properties.
+        /// </remarks>
+        /// <example>
+        /// <c>
+        /// class MyClass : RealmObject
+        /// {
+        ///     public int StatusCodeRaw { get; set; }
+        /// 
+        ///     public StatusCodeEnum StatusCode => (StatusCodeEnum)StatusCodeRaw;
+        /// 
+        ///     protected override void OnPropertyChanged(string propertyName)
+        ///     {
+        ///         if (propertyName == nameof(StatusCodeRaw))
+        ///         {
+        ///             RaisePropertyChanged(nameof(StatusCode));
+        ///         }
+        ///     }
+        /// }
+        /// </c>
+        /// Here, we have a computed property that depends on a persisted one. In order to notify any <see cref="PropertyChanged"/>
+        /// subscribers that <c>StatusCode</c> has changed, we override <c>OnPropertyChanged</c> and raise <c>PropertyChanged</c>
+        /// manually.
+        /// </example>
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
         }
 
         TypeInfo IReflectableType.GetTypeInfo()


### PR DESCRIPTION
This allows users to hook into PropertyChanged and plug their own logic there. I designed it mostly for raising `PropertyChanged` on computed properties. This came up while working on #1046 - we have a `StatusCode` and we want to proxy it to a more human-readable enum and have it raise `PropertyChanged`.