### PR TITLE
Make PermissionChange immutable

### DIFF
--- a/Platform.PCL/Realm.Sync.PCL/Permissions/PermissionChangePCL.cs
+++ b/Platform.PCL/Realm.Sync.PCL/Permissions/PermissionChangePCL.cs
@@ -52,7 +52,7 @@ namespace Realms.Sync
         public string StatusMessage { get; }
 
         /// <inheritdoc />
-        public ManagementObjectStatus ObjectStatus { get; }
+        public ManagementObjectStatus Status { get; }
 
         /// <summary>
         /// Gets the user or users to effect.

--- a/Platform.PCL/Realm.Sync.PCL/Permissions/PermissionChangePCL.cs
+++ b/Platform.PCL/Realm.Sync.PCL/Permissions/PermissionChangePCL.cs
@@ -18,7 +18,7 @@
 
 using System;
 
-namespace Realms.Sync.Permissions
+namespace Realms.Sync
 {
     /// <summary>
     /// Objects of this class allow to change permissions of owned Realms.
@@ -36,48 +36,78 @@ namespace Realms.Sync.Permissions
     public class PermissionChange : RealmObject, IPermissionObject
     {
         /// <inheritdoc />
-        public string Id { get; set; }
+        [PrimaryKey, Required]
+        public string Id { get; }
 
         /// <inheritdoc />
-        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset CreatedAt { get; }
 
         /// <inheritdoc />
-        public DateTimeOffset UpdatedAt { get; set; }
+        public DateTimeOffset UpdatedAt { get; }
 
         /// <inheritdoc />
-        public int? StatusCode { get; set; }
+        public int? StatusCode { get; }
 
         /// <inheritdoc />
-        public string StatusMessage { get; set; }
+        public string StatusMessage { get; }
+
+        /// <inheritdoc />
+        public ManagementObjectStatus ObjectStatus { get; }
 
         /// <summary>
-        /// Gets or sets the user or users to effect.
+        /// Gets the user or users to effect.
         /// </summary>
         /// <value><c>*</c> to change the permissions for all users.</value>
-        public string UserId { get; set; }
+        [Required]
+        public string UserId { get; }
 
         /// <summary>
-        /// Gets or sets the Realm to change permissions for.
+        /// Gets the Realm to change permissions for.
         /// </summary>
         /// <value><c>*</c> to change the permissions of all Realms.</value>
-        public string RealmUrl { get; set; }
+        [Required]
+        public string RealmUrl { get; }
 
         /// <summary>
-        /// Gets or sets read access.
+        /// Gets a value indicating whether the user(s) have read access to the specified Realm(s).
         /// </summary>
         /// <value><c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</value>
-        public bool? MayRead { get; set; }
+        public bool? MayRead { get; }
 
         /// <summary>
-        /// Gets or sets write access.
+        /// Gets a value indicating whether the user(s) have write access to the specified Realm(s).
         /// </summary>
         /// <value><c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</value>
-        public bool? MayWrite { get; set; }
+        public bool? MayWrite { get; }
 
         /// <summary>
-        /// Gets or sets manage access.
+        /// Gets a value indicating whether the user(s) have manage access to the specified Realm(s).
         /// </summary>
         /// <value><c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</value>
-        public bool? MayManage { get; set; }
+        public bool? MayManage { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermissionChange"/> class.
+        /// </summary>
+        /// <param name="userId">The user or users who should be granted these permission changes. Use * to change permissions for all users.</param>
+        /// <param name="realmUrl">The Realm URL whose permissions settings should be changed. Use `*` to change the permissions of all Realms managed by the management Realm's <see cref="User"/>.</param>
+        /// <param name="mayRead">Define read access. <c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</param>
+        /// <param name="mayWrite">Define write access. <c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</param>
+        /// <param name="mayManage">Define manage access. <c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</param>
+        public PermissionChange(string userId, string realmUrl, bool? mayRead = null, bool? mayWrite = null, bool? mayManage = null)
+        {
+            RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermissionChange"/> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is used by Realm to create a new instance from C++. You should use the constructor that accepts parameters instead.
+        /// </remarks>
+        public PermissionChange()
+        {
+            RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
+        }
     }
 }

--- a/Platform.PCL/Realm.Sync.PCL/Permissions/PermissionChangePCL.cs
+++ b/Platform.PCL/Realm.Sync.PCL/Permissions/PermissionChangePCL.cs
@@ -98,16 +98,5 @@ namespace Realms.Sync
         {
             RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
         }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PermissionChange"/> class.
-        /// </summary>
-        /// <remarks>
-        /// This constructor is used by Realm to create a new instance from C++. You should use the constructor that accepts parameters instead.
-        /// </remarks>
-        public PermissionChange()
-        {
-            RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
-        }
     }
 }

--- a/Platform.PCL/Realm.Sync.PCL/Permissions/UserPermissionsExtensionsPCL.cs
+++ b/Platform.PCL/Realm.Sync.PCL/Permissions/UserPermissionsExtensionsPCL.cs
@@ -18,7 +18,7 @@
 
 using System.ComponentModel;
 
-namespace Realms.Sync.Permissions
+namespace Realms.Sync
 {
     /// <summary>
     /// A set of extensions methods over the <see cref="User"/> class that expose functionality for managing synchronized Realm permissions.

--- a/Platform.PCL/Realm.Sync.PCL/Realm.Sync.PCL.csproj
+++ b/Platform.PCL/Realm.Sync.PCL/Realm.Sync.PCL.csproj
@@ -68,6 +68,9 @@
     <Compile Include="..\..\Shared\Realm.Sync.Shared\UserPersistenceMode.cs">
       <Link>UserPersistencyMode.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\Realm.Sync.Shared\Permissions\ManagementObjectStatus.cs">
+      <Link>Permissions\ManagementObjectStatus.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Realm.PCL\Realm.PCL.csproj">

--- a/Shared/Realm.Sync.Shared/Permissions/IPermissionObject.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/IPermissionObject.cs
@@ -80,6 +80,6 @@ namespace Realms.Sync
         /// <summary>
         /// Gets the <see cref="ManagementObjectStatus"/> as set by the server.
         /// </summary>
-        ManagementObjectStatus ObjectStatus { get; }
+        ManagementObjectStatus Status { get; }
     }
 }

--- a/Shared/Realm.Sync.Shared/Permissions/IPermissionObject.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/IPermissionObject.cs
@@ -18,7 +18,7 @@
 
 using System;
 
-namespace Realms.Sync.Permissions
+namespace Realms.Sync
 {
     /// <summary>
     /// Interface that describes the shared base model of all Permission classes.
@@ -26,26 +26,26 @@ namespace Realms.Sync.Permissions
     public interface IPermissionObject
     {
         /// <summary>
-        /// Gets or sets the unique identifier of this object in the Management realm.
+        /// Gets the unique identifier of this object in the Management realm.
         /// </summary>
-        string Id { get; set; }
+        string Id { get; }
 
         /// <summary>
-        /// Gets or sets the creation time of this object.
+        /// Gets the creation time of this object.
         /// </summary>
-        DateTimeOffset CreatedAt { get; set; }
+        DateTimeOffset CreatedAt { get; }
 
         /// <summary>
-        /// Gets or sets when the object was updated the last time.
+        /// Gets when the object was updated the last time.
         /// </summary>
         /// <remarks>
         /// This should be filled by the client with the <see cref="CreatedAt"/>
         /// date and is updated by the server with the current object when the object is processed.
         /// </remarks>
-        DateTimeOffset UpdatedAt { get; set; }
+        DateTimeOffset UpdatedAt { get; }
 
         /// <summary>
-        /// Gets or sets the status code.
+        /// Gets the status code.
         /// </summary>
         /// <remarks>
         /// Filled by the server after an object was processed indicating the status
@@ -66,15 +66,20 @@ namespace Realms.Sync.Permissions
         /// </listheader>
         /// </list>
         /// </remarks>
-        int? StatusCode { get; set; }
+        int? StatusCode { get; }
 
         /// <summary>
-        /// Gets or sets the status message.
+        /// Gets the status message.
         /// </summary>
         /// <remarks>
         /// Filled by the server after an object was processed with additional info
         /// explaining the status if necessary.
         /// </remarks>
-        string StatusMessage { get; set; }
+        string StatusMessage { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ManagementObjectStatus"/> as set by the server.
+        /// </summary>
+        ManagementObjectStatus ObjectStatus { get; }
     }
 }

--- a/Shared/Realm.Sync.Shared/Permissions/ManagementObjectStatus.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/ManagementObjectStatus.cs
@@ -1,0 +1,41 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Realms.Sync
+{
+    /// <summary>
+    /// The status of the management object as set by the server.
+    /// </summary>
+    public enum ManagementObjectStatus
+    {
+        /// <summary>
+        /// The server hasn't yet processed the request.
+        /// </summary>
+        NotProcessed,
+
+        /// <summary>
+        /// The server has processed the request successfully.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// There was an error while processing the request. See <see cref="IPermissionObject.StatusMessage"/> for more details.
+        /// </summary>
+        Error
+    }
+}

--- a/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
@@ -17,9 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
-namespace Realms.Sync.Permissions
+namespace Realms.Sync
 {
     /// <summary>
     /// Objects of this class allow to change permissions of owned Realms.
@@ -40,59 +39,114 @@ namespace Realms.Sync.Permissions
         /// <inheritdoc />
         [PrimaryKey, Required]
         [MapTo("id")]
-        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string Id { get; private set; } = Guid.NewGuid().ToString();
 
         /// <inheritdoc />
         [MapTo("createdAt")]
-        public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset CreatedAt { get; private set; } = DateTimeOffset.UtcNow;
 
         /// <inheritdoc />
         [MapTo("updatedAt")]
-        public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset UpdatedAt { get; private set; } = DateTimeOffset.UtcNow;
 
         /// <inheritdoc />
         [MapTo("statusCode")]
-        public int? StatusCode { get; set; }
+        public int? StatusCode { get; private set; }
 
         /// <inheritdoc />
         [MapTo("statusMessage")]
-        public string StatusMessage { get; set; }
+        public string StatusMessage { get; private set; }
+
+        /// <inheritdoc />
+        public ManagementObjectStatus ObjectStatus
+        {
+            get
+            {
+                switch (StatusCode)
+                {
+                    case null:
+                        return ManagementObjectStatus.NotProcessed;
+                    case 0:
+                        return ManagementObjectStatus.Success;
+                    default:
+                        return ManagementObjectStatus.Error;
+                }
+            }
+        }
 
         /// <summary>
-        /// Gets or sets the user or users to effect.
+        /// Gets the user or users to effect.
         /// </summary>
         /// <value><c>*</c> to change the permissions for all users.</value>
         [Required]
         [MapTo("userId")]
-        public string UserId { get; set; }
+        public string UserId { get; private set; }
 
         /// <summary>
-        /// Gets or sets the Realm to change permissions for.
+        /// Gets the Realm to change permissions for.
         /// </summary>
         /// <value><c>*</c> to change the permissions of all Realms.</value>
         [Required]
         [MapTo("realmUrl")]
-        public string RealmUrl { get; set; }
+        public string RealmUrl { get; private set; }
 
         /// <summary>
-        /// Gets or sets read access.
+        /// Gets a value indicating whether the user(s) have read access to the specified Realm(s).
         /// </summary>
         /// <value><c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</value>
         [MapTo("mayRead")]
-        public bool? MayRead { get; set; }
+        public bool? MayRead { get; private set; }
 
         /// <summary>
-        /// Gets or sets write access.
+        /// Gets a value indicating whether the user(s) have write access to the specified Realm(s).
         /// </summary>
         /// <value><c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</value>
         [MapTo("mayWrite")]
-        public bool? MayWrite { get; set; }
+        public bool? MayWrite { get; private set; }
 
         /// <summary>
-        /// Gets or sets manage access.
+        /// Gets a value indicating whether the user(s) have manage access to the specified Realm(s).
         /// </summary>
         /// <value><c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</value>
         [MapTo("mayManage")]
-        public bool? MayManage { get; set; }
+        public bool? MayManage { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermissionChange"/> class.
+        /// </summary>
+        /// <param name="userId">The user or users who should be granted these permission changes. Use * to change permissions for all users.</param>
+        /// <param name="realmUrl">The Realm URL whose permissions settings should be changed. Use `*` to change the permissions of all Realms managed by the management Realm's <see cref="User"/>.</param>
+        /// <param name="mayRead">Define read access. <c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</param>
+        /// <param name="mayWrite">Define write access. <c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</param>
+        /// <param name="mayManage">Define manage access. <c>true</c> or <c>false</c> to request this new value. <c>null</c> to keep current value.</param>
+        public PermissionChange(string userId, string realmUrl, bool? mayRead = null, bool? mayWrite = null, bool? mayManage = null)
+        {
+            UserId = userId;
+            RealmUrl = realmUrl;
+            MayRead = mayRead;
+            MayWrite = mayWrite;
+            MayManage = mayManage;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermissionChange"/> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is used by Realm to create a new instance from C++. You should use the constructor that accepts parameters instead.
+        /// </remarks>
+        public PermissionChange()
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void OnPropertyChanged(string propertyName)
+        {
+            base.OnPropertyChanged(propertyName);
+
+            if (propertyName == nameof(StatusCode))
+            {
+                RaisePropertyChanged(nameof(ObjectStatus));
+            }
+        }
     }
 }

--- a/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
@@ -58,7 +58,7 @@ namespace Realms.Sync
         public string StatusMessage { get; private set; }
 
         /// <inheritdoc />
-        public ManagementObjectStatus ObjectStatus
+        public ManagementObjectStatus Status
         {
             get
             {
@@ -139,7 +139,7 @@ namespace Realms.Sync
 
             if (propertyName == nameof(StatusCode))
             {
-                RaisePropertyChanged(nameof(ObjectStatus));
+                RaisePropertyChanged(nameof(Status));
             }
         }
     }

--- a/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
@@ -128,13 +128,7 @@ namespace Realms.Sync
             MayManage = mayManage;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PermissionChange"/> class.
-        /// </summary>
-        /// <remarks>
-        /// This constructor is used by Realm to create a new instance from C++. You should use the constructor that accepts parameters instead.
-        /// </remarks>
-        public PermissionChange()
+        private PermissionChange()
         {
         }
 

--- a/Shared/Realm.Sync.Shared/Permissions/UserPermissionsExtensions.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/UserPermissionsExtensions.cs
@@ -19,7 +19,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Realms.Sync.Permissions
+namespace Realms.Sync
 {
     /// <summary>
     /// A set of extensions methods over the <see cref="User"/> class that expose functionality for managing synchronized Realm permissions.

--- a/Shared/Realm.Sync.Shared/Realm.Sync.Shared.projitems
+++ b/Shared/Realm.Sync.Shared/Realm.Sync.Shared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Exceptions\SessionErrorException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Exceptions\SessionErrorKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UserPersistenceMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Permissions\ManagementObjectStatus.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Handles\" />

--- a/Shared/Tests.Sync.Shared/Constants.cs
+++ b/Shared/Tests.Sync.Shared/Constants.cs
@@ -22,8 +22,11 @@ namespace Tests.Sync
     {
         public static class Credentials
         {
+            // Credentials of an existing user
             public const string Username = "z@z";
             public const string Password = "z";
+
+            // The server url as visible from the testing device
             public const string ServerUrl = "localhost:9080";
         }
     }

--- a/Shared/Tests.Sync.Shared/Constants.cs
+++ b/Shared/Tests.Sync.Shared/Constants.cs
@@ -1,0 +1,30 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Tests.Sync
+{
+    public static class Constants
+    {
+        public static class Credentials
+        {
+            public const string Username = "z@z";
+            public const string Password = "z";
+            public const string ServerUrl = "localhost:9080";
+        }
+    }
+}

--- a/Shared/Tests.Sync.Shared/PermissionsTests.cs
+++ b/Shared/Tests.Sync.Shared/PermissionsTests.cs
@@ -51,7 +51,7 @@ namespace Tests.Sync.Shared
             Assert.That(RealmSchema.Default.Find(nameof(PermissionChange)), Is.Null);
         }
 
-        [Test, Explicit]
+        [Test, Explicit("Update Constants.Credentials with values that work on your setup.")]
         public async void PermissionChange_IsProcessedByServer()
         {
             var credentials = Credentials.UsernamePassword(Constants.Credentials.Username, Constants.Credentials.Password, createUser: false);

--- a/Shared/Tests.Sync.Shared/PermissionsTests.cs
+++ b/Shared/Tests.Sync.Shared/PermissionsTests.cs
@@ -17,10 +17,13 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Realms;
 using Realms.Sync;
-using Realms.Sync.Permissions;
+
+using ExplicitAttribute = NUnit.Framework.ExplicitAttribute;
 
 namespace Tests.Sync.Shared
 {
@@ -46,6 +49,36 @@ namespace Tests.Sync.Shared
         public void PermissionChange_ShouldNotBeInDefaultSchema()
         {
             Assert.That(RealmSchema.Default.Find(nameof(PermissionChange)), Is.Null);
+        }
+
+        [Test, Explicit]
+        public async void PermissionChange_IsProcessedByServer()
+        {
+            var credentials = Credentials.UsernamePassword(Constants.Credentials.Username, Constants.Credentials.Password, createUser: false);
+            var user = await User.LoginAsync(credentials, new Uri($"http://{Constants.Credentials.ServerUrl}"));
+
+            using (var realm = user.GetManagementRealm())
+            {
+                var permissionChange = new PermissionChange("*", "*", mayRead: true);
+                realm.Write(() => realm.Add(permissionChange));
+                var tcs = new TaskCompletionSource<object>();
+
+                permissionChange.PropertyChanged += (sender, e) =>
+                {
+                    if (e.PropertyName == nameof(PermissionChange.ObjectStatus))
+                    {
+                        tcs.TrySetResult(null);
+                    }
+                };
+
+                var completedProcessingTask = await Task.WhenAny(tcs.Task, Task.Delay(10000));
+
+                Assert.That(completedProcessingTask, Is.EqualTo(tcs.Task));
+
+                await tcs.Task;
+
+                Assert.That(permissionChange.ObjectStatus, Is.EqualTo(ManagementObjectStatus.Success));
+            }
         }
     }
 }

--- a/Shared/Tests.Sync.Shared/PermissionsTests.cs
+++ b/Shared/Tests.Sync.Shared/PermissionsTests.cs
@@ -65,7 +65,7 @@ namespace Tests.Sync.Shared
 
                 permissionChange.PropertyChanged += (sender, e) =>
                 {
-                    if (e.PropertyName == nameof(PermissionChange.ObjectStatus))
+                    if (e.PropertyName == nameof(PermissionChange.Status))
                     {
                         tcs.TrySetResult(null);
                     }
@@ -77,7 +77,7 @@ namespace Tests.Sync.Shared
 
                 await tcs.Task;
 
-                Assert.That(permissionChange.ObjectStatus, Is.EqualTo(ManagementObjectStatus.Success));
+                Assert.That(permissionChange.Status, Is.EqualTo(ManagementObjectStatus.Success));
             }
         }
     }

--- a/Shared/Tests.Sync.Shared/Tests.Sync.Shared.projitems
+++ b/Shared/Tests.Sync.Shared/Tests.Sync.Shared.projitems
@@ -17,5 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)SyncConfigurationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SynchronizedInstanceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MergeByPKTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
   </ItemGroup>
 </Project>

--- a/Weaver/RealmWeaver.Fody/ModuleWeaver.cs
+++ b/Weaver/RealmWeaver.Fody/ModuleWeaver.cs
@@ -317,7 +317,7 @@ public class ModuleWeaver
         }
 
         var objectConstructor = type.GetConstructors()
-            .SingleOrDefault(c => c.Parameters.Count == 0 && c.IsPublic && !c.IsStatic);
+            .SingleOrDefault(c => c.Parameters.Count == 0 && !c.IsStatic);
         if (objectConstructor == null)
         {
             var nonDefaultConstructor = type.GetConstructors().First();


### PR DESCRIPTION
Previously, it was wrongly implied you could modify a PermissionChange after adding it to the Realm. That is not the case, so I've made all setters private and exposed a constructor similar to what we have in Cocoa.

Additionally, I've exposed a `ManagementObjectStatus` enum to make it friendlier to check the status of the request.

Finally, I've created an explicit unit test to verify that permissions are actually processed and we get notified about it.