### PR TITLE
Attempt to fix sporadically failing test

### DIFF
--- a/Shared/Tests.Shared/PropertyChangedTests.cs
+++ b/Shared/Tests.Shared/PropertyChangedTests.cs
@@ -156,6 +156,8 @@ namespace IntegrationTests
                     var otherPersonInstance = otherRealm.All<Person>().First();
                     otherPersonInstance.FirstName = name;
                 });
+
+                await Task.Delay(50);
             });
         }
 


### PR DESCRIPTION
This adds a slight delay for the `ManagedObject_WhenAnotherThreadInstanceChanged` test case, since it seems to fail every once in a while.