### PR TITLE
Turn off sync metadata encryption on the iOS Simulator

### DIFF
--- a/wrappers/src/sync_manager_cs.cpp
+++ b/wrappers/src/sync_manager_cs.cpp
@@ -66,8 +66,8 @@ REALM_EXPORT void realm_syncmanager_configure_file_system(const uint16_t* base_p
         auto metadata_mode = SyncManager::MetadataMode::NoEncryption;
         if (mode) {
             metadata_mode = *mode;
+#if REALM_PLATFORM_APPLE && !TARGET_OS_SIMULATOR
         } else {
-#if REALM_PLATFORM_APPLE
             metadata_mode = SyncManager::MetadataMode::Encryption;
 #endif
         }


### PR DESCRIPTION
Metadata encryption relies on the Keychain APIs on iOS but those behave erratically on the Simulator when the app is not explicitly signed with a keychain access group entitlement, even those the exact same app works fine on a device.

This causes spurious failures on CI when testing on an iOS Simulator so better turn it off for the time being.