### PR TITLE
Remove references to CreateObject from our tests

### DIFF
--- a/Platform.XamarinIOS/Tests.XamarinIOS/RunLoopTests.cs
+++ b/Platform.XamarinIOS/Tests.XamarinIOS/RunLoopTests.cs
@@ -52,15 +52,15 @@ namespace IntegrationTests.XamarinIOS
         [Test]
         public void QueriesShouldAutomaticallyRefreshInRunLoop()
         {
-            Person p1, p2;
-
             var thread = new Thread(() =>
             {
                 var r = Realm.GetInstance(_databasePath);
                 r.Write(() =>
                 {
-                    p1 = r.CreateObject<Person>();
-                    p1.FullName = "Person 1";
+                    r.Add(new Person
+                    {
+                        FullName = "Person 1"
+                    });
                 });
 
                 var q = r.All<Person>();
@@ -68,8 +68,10 @@ namespace IntegrationTests.XamarinIOS
 
                 WriteOnDifferentThread(newRealm =>
                 {
-                    p2 = newRealm.CreateObject<Person>();
-                    p2.FullName = "Person 2";
+                    newRealm.Add(new Person
+                    {
+                        FullName = "Person 2"
+                    });
                 });
 
                 // Instead of r.Refresh(), initiate the runloop which should trigger auto refresh

--- a/Shared/Realm.Shared/Realm.cs
+++ b/Shared/Realm.Shared/Realm.cs
@@ -541,7 +541,11 @@ namespace Realms
                 throw new RealmObjectManagedByAnotherRealmException("Cannot start to manage an object with a realm when it's already managed by another realm");
             }
 
-            var metadata = Metadata[objectType.Name];
+            RealmObject.Metadata metadata;
+            if (!Metadata.TryGetValue(objectType.Name, out metadata))
+            {
+                throw new ArgumentException($"The class {objectType.Name} is not in the limited set of classes for this realm");
+            }
 
             var objectPtr = IntPtr.Zero;
 

--- a/Shared/Tests.Shared/AccessTests.cs
+++ b/Shared/Tests.Shared/AccessTests.cs
@@ -17,10 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 using Realms;
 
 namespace IntegrationTests
@@ -31,14 +28,13 @@ namespace IntegrationTests
         [TestCaseSource(nameof(SetAndGetValueCases))]
         public void SetAndGetValue(string propertyName, object propertyValue)
         {
-            AllTypesObject ato;
-            using (var transaction = _realm.BeginWrite())
+            AllTypesObject ato = null;
+            _realm.Write(() =>
             {
-                ato = _realm.CreateObject<AllTypesObject>();
+                ato = _realm.Add(new AllTypesObject { RequiredStringProperty = string.Empty });
 
                 TestHelpers.SetPropertyValue(ato, propertyName, propertyValue);
-                transaction.Commit();
-            }
+            });
 
             Assert.That(TestHelpers.GetPropertyValue(ato, propertyName), Is.EqualTo(propertyValue));
         }
@@ -62,22 +58,20 @@ namespace IntegrationTests
         [TestCaseSource(nameof(SetAndReplaceWithNullCases))]
         public void SetValueAndReplaceWithNull(string propertyName, object propertyValue)
         {
-            AllTypesObject ato;
-            using (var transaction = _realm.BeginWrite())
+            AllTypesObject ato = null;
+            _realm.Write(() =>
             {
-                ato = _realm.CreateObject<AllTypesObject>();
+                ato = _realm.Add(new AllTypesObject { RequiredStringProperty = string.Empty });
 
                 TestHelpers.SetPropertyValue(ato, propertyName, propertyValue);
-                transaction.Commit();
-            }
+            });
 
             Assert.That(TestHelpers.GetPropertyValue(ato, propertyName), Is.EqualTo(propertyValue));
 
-            using (var transaction = _realm.BeginWrite())
+            _realm.Write(() =>
             {
                 TestHelpers.SetPropertyValue(ato, propertyName, null);
-                transaction.Commit();
-            }
+            });
 
             Assert.That(TestHelpers.GetPropertyValue(ato, propertyName), Is.EqualTo(null));
         }
@@ -106,10 +100,10 @@ namespace IntegrationTests
             Person p1 = null;
             _realm.Write(() =>
             {
-                p1 = _realm.CreateObject<Person>();
+                p1 = _realm.Add(new Person());
 
                 // Create another object to ensure there is a row in the db after deleting p1.
-                _realm.CreateObject<Person>();
+                _realm.Add(new Person());
 
                 _realm.Remove(p1);
             });
@@ -126,7 +120,7 @@ namespace IntegrationTests
         {
             // Arrange
             Person p1 = null;
-            _realm.Write(() => p1 = _realm.CreateObject<Person>());
+            _realm.Write(() => p1 = _realm.Add(new Person()));
             _realm.Dispose();
 
             // Act and assert
@@ -140,7 +134,7 @@ namespace IntegrationTests
         public void RealmObjectProperties_WhenNotSet_ShouldHaveDefaultValues()
         {
             AllTypesObject obj = null;
-            _realm.Write(() => obj = _realm.CreateObject<AllTypesObject>());
+            _realm.Write(() => obj = _realm.Add(new AllTypesObject { RequiredStringProperty = string.Empty }));
 
             Assert.That(obj.ByteArrayProperty, Is.EqualTo(default(byte[])));
             Assert.That(obj.StringProperty, Is.EqualTo(default(string)));
@@ -167,10 +161,7 @@ namespace IntegrationTests
         [Test]
         public void RealmObjectProperties_WhenNotSetAfterManage_ShouldHaveDefaultValues()
         {
-            var obj = new AllTypesObject
-            {
-                RequiredStringProperty = string.Empty
-            };
+            var obj = new AllTypesObject { RequiredStringProperty = string.Empty };
             _realm.Write(() => _realm.Add(obj));
 
             Assert.That(obj.ByteArrayProperty, Is.EqualTo(default(byte[])));

--- a/Shared/Tests.Shared/AsyncTests.cs
+++ b/Shared/Tests.Shared/AsyncTests.cs
@@ -65,7 +65,7 @@ namespace IntegrationTests
                 await _realm.WriteAsync(realm =>
                 {
                     otherThreadId = Thread.CurrentThread.ManagedThreadId;
-                    realm.CreateObject<Person>();
+                    realm.Add(new Person());
                 });
 
                 await Task.Yield();
@@ -92,8 +92,7 @@ namespace IntegrationTests
                 MyDataObject obj = null;
                 _realm.Write(() =>
                 {
-                    obj = _realm.CreateObject<MyDataObject>();
-                    obj.Path = path;
+                    obj = _realm.Add(new MyDataObject { Path = path });
                 });
 
                 await _realm.WriteAsync(realm =>

--- a/Shared/Tests.Shared/ConfigurationTests.cs
+++ b/Shared/Tests.Shared/ConfigurationTests.cs
@@ -260,7 +260,7 @@ namespace IntegrationTests
             {
                 openToCreate.Write(() =>
                 {
-                    var anObject = openToCreate.CreateObject<Person>();
+                    openToCreate.Add(new Person());
                 });
             }
 
@@ -273,7 +273,7 @@ namespace IntegrationTests
                 {
                     openedReadonly.Write(() =>
                     {
-                        var neverMade = openedReadonly.CreateObject<Person>();
+                        openedReadonly.Add(new Person());
                     });
                 });
             }

--- a/Shared/Tests.Shared/DateTimeTests.cs
+++ b/Shared/Tests.Shared/DateTimeTests.cs
@@ -36,15 +36,15 @@ namespace IntegrationTests
         {
             var turingsBirthday = new DateTimeOffset(1912, 6, 23, hour, mins, secs, ms, TimeSpan.Zero);
 
-            Person turing;
-            using (var transaction = _realm.BeginWrite())
+            _realm.Write(() =>
             {
-                turing = _realm.CreateObject<Person>();
-                turing.FirstName = "Alan";
-                turing.LastName = "Turing";
-                turing.Birthday = turingsBirthday;
-                transaction.Commit();
-            }
+                _realm.Add(new Person
+                {
+                    FirstName = "Alan",
+                    LastName = "Turing",
+                    Birthday = turingsBirthday
+                });
+            });
 
             // perform a db fetch
             var turingAgain = _realm.All<Person>().First();
@@ -57,13 +57,12 @@ namespace IntegrationTests
         {
             using (var transaction = _realm.BeginWrite())
             {
-                foreach (var ms in new List<int> { 10, 999, 998, 42 })
+                foreach (var ms in new int[] { 10, 999, 998, 42 })
                 {
                     var birthday = new DateTimeOffset(1912, 6, 23, 23, 59, 59, ms, TimeSpan.Zero);
-                    foreach (var addMs in new List<double> { -2000.0, 1.0, -1.0, 1000.0, 100.0 })
+                    foreach (var addMs in new double[] { -2000.0, 1.0, -1.0, 1000.0, 100.0 })
                     {
-                        Person turing = _realm.CreateObject<Person>();
-                        turing.Birthday = birthday.AddMilliseconds(addMs);
+                        _realm.Add(new Person { Birthday = birthday.AddMilliseconds(addMs) });
                     }
                 }
 
@@ -86,10 +85,9 @@ namespace IntegrationTests
             var birthday = new DateTimeOffset(1912, 6, 23, 23, 59, 59, 0, TimeSpan.Zero);
             using (var transaction = _realm.BeginWrite())
             {
-                foreach (var addMs in new List<double> { 0.0, 1.0, -1.0 })
+                foreach (var addMs in new double[] { 0.0, 1.0, -1.0 })
                 {
-                    Person turing = _realm.CreateObject<Person>();
-                    turing.Birthday = birthday.AddMilliseconds(addMs);
+                    _realm.Add(new Person { Birthday = birthday.AddMilliseconds(addMs) });
                 }
 
                 transaction.Commit();

--- a/Shared/Tests.Shared/InstanceTests.cs
+++ b/Shared/Tests.Shared/InstanceTests.cs
@@ -182,8 +182,10 @@ namespace IntegrationTests
             {
                 lonelyRealm.Write(() =>
                 {
-                    var p = lonelyRealm.CreateObject<LoneClass>();
-                    p.Name = "The Singular";
+                    lonelyRealm.Add(new LoneClass
+                    {
+                        Name = "The Singular"
+                    });
                 });
 
                 // Assert
@@ -202,14 +204,11 @@ namespace IntegrationTests
             // Act and assert
             using (var lonelyRealm = Realm.GetInstance(config))
             {
-                using (var trans = lonelyRealm.BeginWrite())
+                // Can't create an object with a class not included in this Realm
+                lonelyRealm.Write(() =>
                 {
-                    Assert.Throws<ArgumentException>(() =>
-                        {
-                            lonelyRealm.CreateObject<Person>();
-                        },
-                        "Can't create an object with a class not included in this Realm");
-                }
+                    Assert.That(() => lonelyRealm.Add(new Person()), Throws.TypeOf<ArgumentException>());
+                });
             }
         }
 
@@ -222,11 +221,8 @@ namespace IntegrationTests
             config.ObjectClasses = new Type[] { typeof(LoneClass), typeof(object) };
 
             // Act and assert
-            Assert.Throws<ArgumentException>(() =>
-            {
-                Realm.GetInstance(config);
-            },
-            "Can't have classes in the list which are not RealmObjects");
+            // Can't have classes in the list which are not RealmObjects
+            Assert.That(() => Realm.GetInstance(config), Throws.TypeOf<ArgumentException>());
         }
 
         [TestCase(false, true)]

--- a/Shared/Tests.Shared/LifetimeTests.cs
+++ b/Shared/Tests.Shared/LifetimeTests.cs
@@ -48,7 +48,10 @@ namespace IntegrationTests
             // Arrange
             var realm = GetWeakRealm();
             Person person = null;
-            ((Realm)realm.Target).Write(() => { person = ((Realm)realm.Target).CreateObject<Person>(); });
+            ((Realm)realm.Target).Write(() => 
+            { 
+                person = ((Realm)realm.Target).Add(new Person()); 
+            });
 
             // Act
             GC.Collect();
@@ -73,7 +76,10 @@ namespace IntegrationTests
             var realm = Realm.GetInstance("LifetimeTests.realm");
             var realmThatWillBeFinalized = GetWeakRealm();
             Person person = null;
-            realm.Write(() => { person = realm.CreateObject<Person>(); });
+            realm.Write(() => 
+            { 
+                person = realm.Add(new Person());
+            });
 
             // Act
             GC.Collect();

--- a/Shared/Tests.Shared/NotificationTests.cs
+++ b/Shared/Tests.Shared/NotificationTests.cs
@@ -84,7 +84,7 @@ namespace IntegrationTests
             _realm.RealmChanged += (sender, e) => { wasNotified = true; };
 
             // Act
-            _realm.Write(() => _realm.CreateObject<Person>());
+            _realm.Write(() => _realm.Add(new Person()));
 
             // Assert
             Assert.That(wasNotified, "RealmChanged notification was not triggered");
@@ -115,7 +115,7 @@ namespace IntegrationTests
 
                 using (query.SubscribeForNotifications(cb))
                 {
-                    _realm.Write(() => _realm.CreateObject<Person>());
+                    _realm.Write(() => _realm.Add(new Person()));
 
                     await Task.Delay(MillisecondsToWaitForCollectionNotification);
                     Assert.That(changes, Is.Not.Null);
@@ -136,7 +136,7 @@ namespace IntegrationTests
 
                 using (container.Items.SubscribeForNotifications(cb))
                 {
-                    _realm.Write(() => container.Items.Add(_realm.CreateObject<OrderedObject>()));
+                    _realm.Write(() => container.Items.Add(new OrderedObject()));
 
                     await Task.Delay(MillisecondsToWaitForCollectionNotification);
                     Assert.That(changes, Is.Not.Null);
@@ -162,7 +162,7 @@ namespace IntegrationTests
 
                 for (int i = 0; i < 2; i++)
                 {
-                    _realm.Write(() => _realm.CreateObject<Person>());
+                    _realm.Write(() => _realm.Add(new Person()));
                     await Task.Delay(MillisecondsToWaitForCollectionNotification);
                     Assert.That(notificationCount, Is.EqualTo(1));
                 }
@@ -589,14 +589,16 @@ namespace IntegrationTests
             AsyncContext.Run(async delegate
             {
                 _realm.Write(() =>
-            {
-                foreach (var value in initial)
                 {
-                    var obj = _realm.CreateObject<OrderedObject>();
-                    obj.Order = value;
-                    obj.IsPartOfResults = true;
-                }
-            });
+                    foreach (var value in initial)
+                    {
+                        _realm.Add(new OrderedObject
+                        {
+                            Order = value,
+                            IsPartOfResults = true
+                        });
+                    }
+                });
 
                 Exception error = null;
                 _realm.Error += (sender, e) =>
@@ -622,9 +624,11 @@ namespace IntegrationTests
                     {
                         foreach (var value in change)
                         {
-                            var obj = _realm.CreateObject<OrderedObject>();
-                            obj.Order = value;
-                            obj.IsPartOfResults = true;
+                            _realm.Add(new OrderedObject
+                            {
+                                Order = value,
+                                IsPartOfResults = true
+                            });
                         }
                     }
                     else if (action == NotifyCollectionChangedAction.Remove)

--- a/Shared/Tests.Shared/ObjectIntegrationTests.cs
+++ b/Shared/Tests.Shared/ObjectIntegrationTests.cs
@@ -17,11 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Realms;
 
@@ -59,7 +56,7 @@ namespace IntegrationTests
         public void CreateObjectTest()
         {
             // Arrange and act
-            _realm.Write(() => _realm.CreateObject<Person>());
+            _realm.Write(() => _realm.Add(new Person()));
 
             // Assert
             Assert.That(_realm.All<Person>().Count(), Is.EqualTo(1));
@@ -92,13 +89,12 @@ namespace IntegrationTests
             Assert.That(p1.Equals(p2));
 
             // Act
-            using (var transaction = _realm.BeginWrite())
+            _realm.Write(() =>
             {
                 p1.Score = 99.0f;
-                Assert.That(p2.Score, Is.EqualTo(99.0f));  // value propagates despite transaction not finished
-                Assert.That(p1.Equals(p2));  // identity-based comparison holds
-                transaction.Commit();
-            }
+                Assert.That(p2.Score, Is.EqualTo(99.0f)); // value propagates despite transaction not finished
+                Assert.That(p1.Equals(p2)); // identity-based comparison holds
+            });
 
             // Assert
             Assert.That(p2.Score, Is.EqualTo(99.0f));  // value still holds after transaction finished
@@ -109,9 +105,9 @@ namespace IntegrationTests
         public void SetAndGetPropertyTest()
         {
             // Arrange
-            using (var transaction = _realm.BeginWrite())
+            _realm.Write(() =>
             {
-                Person p = _realm.CreateObject<Person>();
+                var p = _realm.Add(new Person());
 
                 // Act
                 p.FirstName = "John";
@@ -119,11 +115,10 @@ namespace IntegrationTests
                 p.Score = -0.9907f;
                 p.Latitude = 51.508530;
                 p.Longitude = 0.076132;
-                transaction.Commit();
-            }
+            });
 
             var allPeople = _realm.All<Person>().ToList();
-            Person p2 = allPeople[0];  // pull it back out of the database otherwise can't tell if just a dumb property
+            var p2 = allPeople[0];  // pull it back out of the database otherwise can't tell if just a dumb property
             var receivedFirstName = p2.FirstName;
             var receivedIsInteresting = p2.IsInteresting;
             var receivedScore = p2.Score;
@@ -140,16 +135,14 @@ namespace IntegrationTests
         public void SetRemappedPropertyTest()
         {
             // Arrange
-            Person p;
-            using (var transaction = _realm.BeginWrite())
+            Person p = null;
+            _realm.Write(() =>
             {
-                p = _realm.CreateObject<Person>();
+                p = _realm.Add(new Person());
 
                 // Act
                 p.Email = "John@a.com";
-
-                transaction.Commit();
-            }
+            });
 
             var receivedEmail = p.Email;
 
@@ -161,37 +154,33 @@ namespace IntegrationTests
         public void CreateObjectOutsideTransactionShouldFail()
         {
             // Arrange, act and assert
-            Assert.Throws<RealmInvalidTransactionException>(() => _realm.CreateObject<Person>());
+            Assert.That(() => _realm.Add(new Person()), Throws.TypeOf<RealmInvalidTransactionException>());
         }
 
         [Test]
         public void AddOutsideTransactionShouldFail()
         {
             var obj = new Person();
-            Assert.Throws<RealmInvalidTransactionException>(() => _realm.Add(obj));
+            Assert.That(() => _realm.Add(obj), Throws.TypeOf<RealmInvalidTransactionException>());
         }
 
         [Test]
         public void AddNullObjectShouldFail()
         {
-            Assert.Throws<ArgumentNullException>(() => _realm.Add(null as Person));
+            Assert.That(() => _realm.Add(null as Person), Throws.TypeOf<ArgumentNullException>());
         }
 
         [Test]
         public void AddAnObjectFromAnotherRealmShouldFail()
         {
-            Person p;
-            using (var transaction = _realm.BeginWrite())
-            {
-                p = _realm.CreateObject<Person>();
-                transaction.Commit();
-            }
+            Person p = null;
+            _realm.Write(() => p = _realm.Add(new Person()));
 
             var secondaryConfig = new RealmConfiguration("AddAnObjectFromAnotherRealmShouldFail");
             Realm.DeleteRealm(secondaryConfig);
             using (var otherRealm = Realm.GetInstance(secondaryConfig))
             {
-                Assert.Throws<RealmObjectManagedByAnotherRealmException>(() => otherRealm.Add(p));
+                Assert.That(() => otherRealm.Add(p), Throws.TypeOf<RealmObjectManagedByAnotherRealmException>());
             }
         }
 
@@ -199,15 +188,11 @@ namespace IntegrationTests
         public void SetPropertyOutsideTransactionShouldFail()
         {
             // Arrange
-            Person p;
-            using (var transaction = _realm.BeginWrite())
-            {
-                p = _realm.CreateObject<Person>();
-                transaction.Commit();
-            }
+            Person p = null;
+            _realm.Write(() => p = _realm.Add(new Person()));
 
             // Act and assert
-            Assert.Throws<RealmInvalidTransactionException>(() => p.FirstName = "John");
+            Assert.That(() => p.FirstName = "John", Throws.TypeOf<RealmInvalidTransactionException>());
         }
 
 #if ENABLE_INTERNAL_NON_PCL_TESTS
@@ -222,14 +207,15 @@ namespace IntegrationTests
         [Test]
         public void NonAutomaticPropertiesShouldBeIgnored()
         {
-            using (var trans = _realm.BeginWrite())
+            _realm.Write(() =>
             {
-                var p = _realm.CreateObject<Person>();
-                p.FirstName = "Vincent";
-                p.LastName = "Adultman";
-                p.Nickname = "Vinnie";
-                trans.Commit();
-            }
+                _realm.Add(new Person
+                {
+                    FirstName = "Vincent",
+                    LastName = "Adultman",
+                    Nickname = "Vinnie"
+                });
+            });
 
             var vinnie = _realm.All<Person>().ToList().Single();
             Assert.That(vinnie.FullName, Is.EqualTo("Vincent Adultman"));
@@ -265,7 +251,7 @@ namespace IntegrationTests
         {
             _realm.Write(() =>
             {
-                var p1 = _realm.CreateObject<Person>();
+                var p1 = _realm.Add(new Person());
                 Assert.That(p1.IsValid);
 
                 _realm.Remove(p1);

--- a/Shared/Tests.Shared/PeopleTestsBase.cs
+++ b/Shared/Tests.Shared/PeopleTestsBase.cs
@@ -17,10 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Diagnostics;
-using System.IO;
-using NUnit.Framework;
-using Realms;
 
 namespace IntegrationTests
 {
@@ -28,55 +24,57 @@ namespace IntegrationTests
     {
         protected void MakeThreePeople()
         {
-            Person p1, p2, p3;
-            using (var transaction = _realm.BeginWrite())
+            _realm.Write(() =>
             {
-                p1 = _realm.CreateObject<Person>();
-                p1.FirstName = "John";
-                p1.LastName = "Smith";
-                p1.IsInteresting = true;
-                p1.Email = "john@smith.com";
-                p1.Salary = 30000;
-                p1.Score = -0.9907f;
-                p1.Latitude = 51.508530;
-                p1.Longitude = 0.076132;
-                p1.Birthday = new DateTimeOffset(1959, 3, 13, 0, 0, 0, TimeSpan.Zero);
-                p1.PublicCertificateBytes = new byte[] { 0xca, 0xfe, 0xba, 0xbe };
-                p1.OptionalAddress = "12 Cosgrove St.";
-                p1.IsAmbivalent = true; 
-                transaction.Commit();
-            }
+                _realm.Add(new Person
+                {
+                    FirstName = "John",
+                    LastName = "Smith",
+                    IsInteresting = true,
+                    Email = "john@smith.com",
+                    Salary = 30000,
+                    Score = -0.9907f,
+                    Latitude = 51.508530,
+                    Longitude = 0.076132,
+                    Birthday = new DateTimeOffset(1959, 3, 13, 0, 0, 0, TimeSpan.Zero),
+                    PublicCertificateBytes = new byte[] { 0xca, 0xfe, 0xba, 0xbe },
+                    OptionalAddress = "12 Cosgrove St.",
+                    IsAmbivalent = true
+                });
+            });
 
-            using (var transaction = _realm.BeginWrite())
+            _realm.Write(() =>
             {
-                p2 = _realm.CreateObject<Person>();
-                p2.FullName = "John Doe"; // uses our setter whcih splits and maps to First/Lastname
-                p2.IsInteresting = false;
-                p2.Email = "john@doe.com";
-                p2.Salary = 60000;
-                p2.Score = 100;
-                p2.Latitude = 40.7637286;
-                p2.Longitude = -73.9748113;
-                p2.Birthday = new DateTimeOffset(1963, 4, 14, 0, 0, 0, TimeSpan.Zero);
-                p2.PublicCertificateBytes = new byte[] { 0xde, 0xad, 0xbe, 0xef };
-                p2.OptionalAddress = string.Empty;
-                p2.IsAmbivalent = false; 
-                transaction.Commit();
-            }
+                _realm.Add(new Person
+                {
+                    FullName = "John Doe", // uses our setter which splits and maps to First/Lastname
+                    IsInteresting = false,
+                    Email = "john@doe.com",
+                    Salary = 60000,
+                    Score = 100,
+                    Latitude = 40.7637286,
+                    Longitude = -73.9748113,
+                    Birthday = new DateTimeOffset(1963, 4, 14, 0, 0, 0, TimeSpan.Zero),
+                    PublicCertificateBytes = new byte[] { 0xde, 0xad, 0xbe, 0xef },
+                    OptionalAddress = string.Empty,
+                    IsAmbivalent = false
+                });
+            });
 
-            using (var transaction = _realm.BeginWrite())
+            _realm.Write(() =>
             {
-                p3 = _realm.CreateObject<Person>();
-                p3.FullName = "Peter Jameson";
-                p3.Email = "peter@jameson.net";
-                p3.Salary = 87000;
-                p3.IsInteresting = true;
-                p3.Score = 42.42f;
-                p3.Latitude = 37.7798657;
-                p3.Longitude = -122.394179;
-                p3.Birthday = new DateTimeOffset(1989, 2, 25, 0, 0, 0, TimeSpan.Zero);
-                transaction.Commit();
-            }
+                _realm.Add(new Person
+                {
+                    FullName = "Peter Jameson",
+                    Email = "peter@jameson.net",
+                    Salary = 87000,
+                    IsInteresting = true,
+                    Score = 42.42f,
+                    Latitude = 37.7798657,
+                    Longitude = -122.394179,
+                    Birthday = new DateTimeOffset(1989, 2, 25, 0, 0, 0, TimeSpan.Zero)
+                });
+            });
         }
     }
 }

--- a/Shared/Tests.Shared/PerformanceTests.cs
+++ b/Shared/Tests.Shared/PerformanceTests.cs
@@ -46,9 +46,11 @@ namespace IntegrationTests
                     var hangOntoObjectsUntilCommit = new List<RealmObject>();
                     for (var iTrans = 0; iTrans < recsPerTrans; ++iTrans)
                     {
-                        var p = _realm.CreateObject<Person>();
-                        p.FirstName = s;
-                        p.IsInteresting = true;
+                        var p = _realm.Add(new Person
+                        {
+                            FirstName = s,
+                            IsInteresting = true
+                        });
                         hangOntoObjectsUntilCommit.Add(p);
                     }
 
@@ -76,7 +78,7 @@ namespace IntegrationTests
                     var hangOntoObjectsUntilCommit = new List<RealmObject>();
                     for (var iTrans = 0; iTrans < recsPerTrans; ++iTrans)
                     {
-                        var p = _realm.CreateObject<Person>();
+                        var p = _realm.Add(new Person());
                         hangOntoObjectsUntilCommit.Add(p);
                     }
 
@@ -100,7 +102,7 @@ namespace IntegrationTests
             var sw = Stopwatch.StartNew();
             using (var trans = _realm.BeginWrite())
             {
-                var p = _realm.CreateObject<Person>();
+                var p = _realm.Add(new Person());
 
                 // inner loop this time to rewrite the value many times without committing
                 for (var rowIndex = 0; rowIndex < count; rowIndex++)
@@ -149,9 +151,11 @@ namespace IntegrationTests
             {
                 for (var i = 0; i < count; i++)
                 {
-                    var newObject = _realm.CreateObject<MiniPerson>();
-                    newObject.Name = objects[i].Name;
-                    newObject.IsInteresting = objects[i].IsInteresting;
+                    _realm.Add(new MiniPerson
+                    {
+                        Name = objects[i].Name,
+                        IsInteresting = objects[i].IsInteresting
+                    });
                 }
             });
 
@@ -189,9 +193,11 @@ namespace IntegrationTests
             {
                 for (var i = 0; i < count; i++)
                 {
-                    var newObject = _realm.CreateObject<Person>();
-                    newObject.FirstName = objects[i].FirstName;
-                    newObject.IsInteresting = objects[i].IsInteresting;
+                    _realm.Add(new Person
+                    {
+                        FirstName = objects[i].FirstName,
+                        IsInteresting = objects[i].IsInteresting
+                    });
                 }
             });
 

--- a/Shared/Tests.Shared/PrimaryKeyTests.cs
+++ b/Shared/Tests.Shared/PrimaryKeyTests.cs
@@ -256,19 +256,13 @@ namespace IntegrationTests
         [Test]
         public void ExceptionIfNoPrimaryKeyDeclared()
         {
-            Assert.Throws<RealmClassLacksPrimaryKeyException>(() =>
-            {
-                var foundObj = _realm.Find<Person>("Zaphod");
-            });
+            Assert.That(() => _realm.Find<Person>("Zaphod"), Throws.TypeOf<RealmClassLacksPrimaryKeyException>());
         }
 
         [Test]
         public void ExceptionIfNoDynamicPrimaryKeyDeclared()
         {
-            Assert.Throws<RealmClassLacksPrimaryKeyException>(() =>
-            {
-                var foundObj = _realm.Find("Person", "Zaphod");
-            });
+            Assert.That(() => _realm.Find("Person", "Zaphod"), Throws.TypeOf<RealmClassLacksPrimaryKeyException>());
         }
 
         [Test]
@@ -276,8 +270,7 @@ namespace IntegrationTests
         {
             _realm.Write(() =>
             {
-                var obj = _realm.CreateObject<PrimaryKeyInt64Object>();
-                obj.Int64Property = 42000042;
+                _realm.Add(new PrimaryKeyInt64Object { Int64Property = 42000042 });
             });
 
             long foundValue = 0;
@@ -302,31 +295,28 @@ namespace IntegrationTests
         {
             _realm.Write(() =>
             {
-                var o1 = _realm.CreateObject<PrimaryKeyStringObject>();
-                o1.StringProperty = "Zaphod";
+                _realm.Add(new PrimaryKeyStringObject { StringProperty = "Zaphod" });
             });
 
-            Assert.Throws<RealmDuplicatePrimaryKeyValueException>(() =>
+            Assert.That(() =>
             {
                 _realm.Write(() =>
                 {
-                    var o2 = _realm.CreateObject<PrimaryKeyStringObject>();
-                    o2.StringProperty = "Zaphod"; // deliberately reuse id
+                    _realm.Add(new PrimaryKeyStringObject { StringProperty = "Zaphod" }); // deliberately reuse id
                 });
-            });
+            }, Throws.TypeOf<RealmDuplicatePrimaryKeyValueException>());
         }
 
         [Test]
         public void NullPrimaryKeyStringObjectThrows()
         {
-            Assert.Throws<ArgumentNullException>(() =>
+            Assert.That(() =>
             {
                 _realm.Write(() =>
                 {
-                    var o2 = _realm.CreateObject<PrimaryKeyStringObject>();
-                    o2.StringProperty = null;
+                    _realm.Add(new PrimaryKeyStringObject { StringProperty = null });
                 });
-            });
+            }, Throws.TypeOf<ArgumentNullException>());
         }
 
         [Test]
@@ -334,10 +324,8 @@ namespace IntegrationTests
         {
             _realm.Write(() =>
             {
-                var o1 = _realm.CreateObject<PrimaryKeyNullableInt64Object>();
-                o1.Int64Property = null;
-                var o2 = _realm.CreateObject<PrimaryKeyNullableInt64Object>();
-                o2.Int64Property = 123;
+                _realm.Add(new PrimaryKeyNullableInt64Object { Int64Property = null });
+                _realm.Add(new PrimaryKeyNullableInt64Object { Int64Property = 123 });
             });
 
             Assert.That(_realm.All<PrimaryKeyNullableInt64Object>().Count, Is.EqualTo(2));
@@ -349,10 +337,7 @@ namespace IntegrationTests
             var conf = RealmConfiguration.DefaultConfiguration.ConfigWithPath("Skinny");
             conf.ObjectClasses = new[] { typeof(Person) };
             var skinny = Realm.GetInstance(conf);
-            Assert.Throws<KeyNotFoundException>(() =>
-            {
-                var obj = skinny.Find<PrimaryKeyInt64Object>(42);
-            });
+            Assert.That(() => skinny.Find<PrimaryKeyInt64Object>(42), Throws.TypeOf<KeyNotFoundException>());
         }
     }
 }

--- a/Shared/Tests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Shared/Tests.Shared/RealmResults/SimpleLINQtests.cs
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NUnit.Framework;
 using Realms;
@@ -299,14 +298,10 @@ namespace IntegrationTests
         {
             _realm.Write(() =>
             {
-                var c1 = _realm.CreateObject<PrimaryKeyCharObject>();
-                c1.CharProperty = 'A';
-                var c2 = _realm.CreateObject<PrimaryKeyCharObject>();
-                c2.CharProperty = 'B';
-                var c3 = _realm.CreateObject<PrimaryKeyCharObject>();
-                c3.CharProperty = 'c';
-                var c4 = _realm.CreateObject<PrimaryKeyCharObject>();
-                c4.CharProperty = 'a';
+                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'A' });
+                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'B' });
+                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'c' });
+                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'a' });
             });
             var equality = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty == 'A').ToArray();
             Assert.That(equality.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A' }));

--- a/Shared/Tests.Shared/RealmResults/SortingTests.cs
+++ b/Shared/Tests.Shared/RealmResults/SortingTests.cs
@@ -17,10 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using Realms;
 
@@ -44,13 +42,15 @@ namespace IntegrationTests
             _realm.Write(() =>
             {
                 // add an entry like John Doe but interesting
-                var jd = _realm.CreateObject<Person>();
-                jd.FullName = "John Jamez";
-                jd.IsInteresting = true;
-                jd.Email = "john@doe.com";
-                jd.Score = 100;
-                jd.Latitude = 40.7637286;
-                jd.Longitude = -73.9748113;
+                _realm.Add(new Person
+                {
+                    FullName = "John Jamez",
+                    IsInteresting = true,
+                    Email = "john@doe.com",
+                    Score = 100,
+                    Latitude = 40.7637286,
+                    Longitude = -73.9748113
+                });
             });
         }
 
@@ -243,8 +243,7 @@ namespace IntegrationTests
             {
                 foreach (var city in new[] { "Santo Domingo", "Åby", "Sydney", "São Paulo", "Shanghai", "A-Place", "A Place" })
                 {
-                    var co = _realm.CreateObject<Cities>();
-                    co.Name = city;
+                    _realm.Add(new Cities { Name = city });
                 }
             });
             var sortedCities = _realm.All<Cities>().OrderBy(c => c.Name).ToList().Select(c => c.Name);

--- a/Shared/Tests.Shared/RefreshTests.cs
+++ b/Shared/Tests.Shared/RefreshTests.cs
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
@@ -43,15 +42,12 @@ namespace IntegrationTests
         [Test]
         public void CommittingAWriteTransactionShouldRefreshQueries()
         {
-            Person p1 = null, p2, p3;
+            Person p1 = null;
 
             _realm.Write(() =>
             {
-                p1 = _realm.CreateObject<Person>();
-                p1.FullName = "Person 1";
-
-                p2 = _realm.CreateObject<Person>();
-                p2.FullName = "Person 2";
+                p1 = _realm.Add(new Person { FullName = "Person 1" });
+                _realm.Add(new Person { FullName = "Person 2" });
             });
 
             var q = _realm.All<Person>();
@@ -61,9 +57,7 @@ namespace IntegrationTests
             _realm.Write(() =>
             {
                 p1.FullName = "Modified Person";
-
-                p3 = _realm.CreateObject<Person>();
-                p3.FullName = "Person 3";
+                _realm.Add(new Person { FullName = "Person 3" });
             });
 
             var ql2 = q.ToList().Select(p => p.FullName);
@@ -73,12 +67,9 @@ namespace IntegrationTests
         [Test]
         public void CallingRefreshShouldRefreshQueriesAfterModificationsOnDifferentThreads()
         {
-            Person p1, p2;
-
             _realm.Write(() =>
             {
-                p1 = _realm.CreateObject<Person>();
-                p1.FullName = "Person 1";
+                _realm.Add(new Person { FullName = "Person 1" });
             });
 
             var q = _realm.All<Person>();
@@ -86,8 +77,7 @@ namespace IntegrationTests
 
             WriteOnDifferentThread(newRealm =>
             {
-                p2 = newRealm.CreateObject<Person>();
-                p2.FullName = "Person 2";
+                newRealm.Add(new Person { FullName = "Person 2" });
             });
 
             _realm.Refresh();

--- a/Shared/Tests.Shared/RemoveTests.cs
+++ b/Shared/Tests.Shared/RemoveTests.cs
@@ -35,17 +35,15 @@ namespace IntegrationTests
             Person p1 = null, p2 = null, p3 = null;
             _realm.Write(() =>
             {
-                p1 = _realm.CreateObject<Person>(); p1.FirstName = "A";
-                p2 = _realm.CreateObject<Person>(); p2.FirstName = "B";
-                p3 = _realm.CreateObject<Person>(); p3.FirstName = "C";
+                p1 = _realm.Add(new Person { FirstName = "A" });
+                p2 = _realm.Add(new Person { FirstName = "B" });
+                p3 = _realm.Add(new Person { FirstName = "C" });
             });
 
             // Act
             _realm.Write(() => _realm.Remove(p2));
 
             // Assert
-            // Assert.That(!p2.InRealm);
-
             var allPeople = _realm.All<Person>().ToList();
             Assert.That(allPeople, Is.EquivalentTo(new List<Person> { p1, p3 }));
         }
@@ -55,10 +53,10 @@ namespace IntegrationTests
         {
             // Arrange
             Person p = null;
-            _realm.Write(() => p = _realm.CreateObject<Person>());
+            _realm.Write(() => p = _realm.Add(new Person()));
 
             // Act and assert
-            Assert.Throws<RealmInvalidTransactionException>(() => _realm.Remove(p));
+            Assert.That(() => _realm.Remove(p), Throws.TypeOf<RealmInvalidTransactionException>());
         }
 
         [Test]
@@ -67,21 +65,27 @@ namespace IntegrationTests
             // Arrange
             _realm.Write(() =>
             {
-                var p1 = _realm.CreateObject<Person>();
-                p1.FirstName = "deletable person #1";
-                p1.IsInteresting = false;
+                _realm.Add(new Person
+                {
+                    FirstName = "deletable person #1",
+                    IsInteresting = false
+                });
 
-                var p2 = _realm.CreateObject<Person>();
-                p2.FirstName = "person to keep";
-                p2.IsInteresting = true;
+                _realm.Add(new Person
+                {
+                    FirstName = "person to keep",
+                    IsInteresting = true
+                });
 
-                var p3 = _realm.CreateObject<Person>();
-                p3.FirstName = "deletable person #2";
-                p3.IsInteresting = false;
+                _realm.Add(new Person
+                {
+                    FirstName = "deletable person #2",
+                    IsInteresting = false
+                });
             });
 
             // Act
-            _realm.Write(() => _realm.RemoveRange<Person>(_realm.All<Person>().Where(p => !p.IsInteresting)));
+            _realm.Write(() => _realm.RemoveRange(_realm.All<Person>().Where(p => !p.IsInteresting)));
 
             // Assert
             Assert.That(_realm.All<Person>().ToList().Select(p => p.FirstName).ToArray(),
@@ -94,9 +98,9 @@ namespace IntegrationTests
             // Arrange
             _realm.Write(() =>
             {
-                _realm.CreateObject<Person>();
-                _realm.CreateObject<Person>();
-                _realm.CreateObject<Person>();
+                _realm.Add(new Person());
+                _realm.Add(new Person());
+                _realm.Add(new Person());
 
                 Assert.That(_realm.All<Person>().Count(), Is.EqualTo(3));
             });
@@ -114,9 +118,9 @@ namespace IntegrationTests
             // Arrange
             _realm.Write(() =>
             {
-                _realm.CreateObject<Person>();
-                _realm.CreateObject<Person>();
-                _realm.CreateObject<AllTypesObject>();
+                _realm.Add(new Person());
+                _realm.Add(new Person());
+                _realm.Add(new AllTypesObject { RequiredStringProperty = string.Empty });
 
                 Assert.That(_realm.All<Person>().Count(), Is.EqualTo(2));
                 Assert.That(_realm.All<AllTypesObject>().Count(), Is.EqualTo(1));
@@ -138,13 +142,11 @@ namespace IntegrationTests
                 Person otherPerson = null;
                 other.Write(() =>
                 {
-                    otherPerson = other.CreateObject<Person>();
+                    otherPerson = other.Add(new Person());
                 });
 
-                Assert.That(() =>
-                {
-                    _realm.Write(() => _realm.Remove(otherPerson));
-                }, Throws.TypeOf<RealmObjectManagedByAnotherRealmException>());
+                Assert.That(() => _realm.Write(() => _realm.Remove(otherPerson)),
+                            Throws.TypeOf<RealmObjectManagedByAnotherRealmException>());
             });
         }
 
@@ -153,14 +155,12 @@ namespace IntegrationTests
         {
             PerformWithOtherRealm(null, other =>
             {
-                other.Write(() => other.CreateObject<Person>());
+                other.Write(() => other.Add(new Person()));
 
                 var people = other.All<Person>();
 
-                Assert.That(() =>
-                {
-                    _realm.Write(() => _realm.RemoveRange(people));
-                }, Throws.TypeOf<RealmObjectManagedByAnotherRealmException>());
+                Assert.That(() => _realm.Write(() => _realm.RemoveRange(people)), 
+                            Throws.TypeOf<RealmObjectManagedByAnotherRealmException>());
             });
         }
 
@@ -169,10 +169,7 @@ namespace IntegrationTests
         {
             var person = new Person();
 
-            Assert.That(() =>
-            {
-                _realm.Write(() => _realm.Remove(person));
-            }, Throws.TypeOf<ArgumentException>());
+            Assert.That(() => _realm.Write(() => _realm.Remove(person)), Throws.TypeOf<ArgumentException>());
         }
 
         [Test]
@@ -183,13 +180,10 @@ namespace IntegrationTests
                 Person otherPerson = null;
                 other.Write(() =>
                 {
-                    otherPerson = other.CreateObject<Person>();
+                    otherPerson = other.Add(new Person());
                 });
 
-                Assert.That(() =>
-                {
-                    _realm.Write(() => _realm.Remove(otherPerson));
-                }, Throws.Nothing);
+                Assert.That(() => _realm.Write(() => _realm.Remove(otherPerson)), Throws.Nothing);
             });
         }
 
@@ -198,14 +192,11 @@ namespace IntegrationTests
         {
             PerformWithOtherRealm(_realm.Config.DatabasePath, other =>
             {
-                other.Write(() => other.CreateObject<Person>());
+                other.Write(() => other.Add(new Person()));
 
                 var people = other.All<Person>();
 
-                Assert.That(() =>
-                {
-                    _realm.Write(() => _realm.RemoveRange(people));
-                }, Throws.Nothing);
+                Assert.That(() => _realm.Write(() => _realm.RemoveRange(people)), Throws.Nothing);
             });
         }
 


### PR DESCRIPTION
One nice side effect is that it helped catch a bug with `Realm.Add` when supplying an object that is not part of the schema - it threw an obscure `KeyNotFoundException` which is not the case anymore.

Resolves #1077 