### PR TITLE
Added extra test for case in #1102 to confirm that it is fixed by #1040

### DIFF
--- a/Shared/Tests.Shared/AddOrUpdateTests.cs
+++ b/Shared/Tests.Shared/AddOrUpdateTests.cs
@@ -340,6 +340,43 @@ namespace IntegrationTests
             Assert.That(_realm.Find<PrimaryKeyObject>(1).StringValue, Is.EqualTo("secondChild"));
         }
 
+        // confirm when we do this in a single Write that child objects correctly owned
+        [Test]
+        public void AddOrUpdate_WhenListHasPK_ShouldUpdateListItemsSingleWrite()
+        {
+            PrimaryKeyWithPKList first = null;
+            _realm.Write(() =>
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    first = new PrimaryKeyWithPKList
+                    {
+                        Id = 1,
+                        StringValue = "first"
+                    };
+
+                    first.ListValue.Add(new PrimaryKeyObject
+                    {
+                        Id = 1,
+                        StringValue = "child"
+                    });
+
+                    first.ListValue.Add(new PrimaryKeyObject
+                    {
+                        Id = 2,
+                        StringValue = "secondChild"
+                    });
+
+                    _realm.Add(first, update: true);
+                }
+            });
+
+            Assert.That(first.ListValue.Count(), Is.EqualTo(2));  // did the Add keep adding dups?
+            Assert.That(_realm.Find<PrimaryKeyWithPKList>(1).ListValue.Count(), Is.EqualTo(2));
+            Assert.That(_realm.Find<PrimaryKeyObject>(1).StringValue, Is.EqualTo("child"));
+            Assert.That(_realm.Find<PrimaryKeyObject>(2).StringValue, Is.EqualTo("secondChild"));
+        }
+
         [Test]
         public void AddOrUpdate_WhenListHasNoPK_ShouldAddListItems()
         {


### PR DESCRIPTION
Test scenario confirms that the repeated updates don't add items in the IList. 