### PR TITLE
Designate ids as PK for permission objects

### DIFF
--- a/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/PermissionChange.cs
@@ -40,7 +40,7 @@ namespace Realms.Sync
     public class PermissionChange : RealmObject, IPermissionObject
     {
         /// <inheritdoc />
-        [Required]
+        [PrimaryKey, Required]
         [MapTo("id")]
         public string Id { get; private set; } = Guid.NewGuid().ToString();
 

--- a/Shared/Realm.Sync.Shared/Permissions/PermissionOffer.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/PermissionOffer.cs
@@ -41,7 +41,7 @@ namespace Realms.Sync
     public class PermissionOffer : RealmObject, IPermissionObject
     {
         /// <inheritdoc />
-        [Required]
+        [PrimaryKey, Required]
         [MapTo("id")]
         public string Id { get; private set; } = Guid.NewGuid().ToString();
 

--- a/Shared/Realm.Sync.Shared/Permissions/PermissionOfferResponse.cs
+++ b/Shared/Realm.Sync.Shared/Permissions/PermissionOfferResponse.cs
@@ -40,7 +40,7 @@ namespace Realms.Sync
     public class PermissionOfferResponse : RealmObject, IPermissionObject
     {
         /// <inheritdoc />
-        [Required]
+        [PrimaryKey, Required]
         [MapTo("id")]
         public string Id { get; private set; } = Guid.NewGuid().ToString();
 

--- a/Shared/Tests.Sync.Shared/PermissionsTests.cs
+++ b/Shared/Tests.Sync.Shared/PermissionsTests.cs
@@ -132,7 +132,7 @@ namespace Tests.Sync.Shared
                 var user = await GetUser();
                 var permissionResponse = await CreateResponse(user, "Some string");
                 Assert.That(permissionResponse.Status, Is.EqualTo(ManagementObjectStatus.Error));
-                Assert.That(permissionResponse.ErrorCode, Is.Not.Null.And.GreaterThan(0));
+                Assert.That(permissionResponse.ErrorCode, Is.EqualTo(ErrorCode.InvalidParameters));
                 Assert.That(permissionResponse.StatusMessage, Is.Not.Null);
             });
         }


### PR DESCRIPTION
Based on the [ROS release notes](https://github.com/realm/realm-object-server/blob/master/CHANGELOG.md#breaking-changes-1), objects in the management realm have PKs now, so this change is to accommodate that. 