### PR TITLE
Use NSBundle for iOS devices

### DIFF
--- a/Shared/Tests.Shared/TestHelpers.cs
+++ b/Shared/Tests.Shared/TestHelpers.cs
@@ -53,7 +53,12 @@ namespace IntegrationTests
             return;
 #endif
 
+#if __IOS__
+            var sourceDir = Foundation.NSBundle.MainBundle.BundlePath;
+#else
             var sourceDir = NUnit.Framework.TestContext.CurrentContext.TestDirectory;
+#endif
+
             File.Copy(Path.Combine(sourceDir, realmName), destPath, overwrite);
         }
     }


### PR DESCRIPTION
`NUnit.Framework.TestContext.CurrentContext.TestDirectory` doesn't produce the correct directory on iOS devices:

This is the returned (incorrect) location:
```
/private/var/containers/Bundle/Application/9FDCAEBE-D0B1-4DA8-8825-6A11239F8D1C/Tests.XamarinIOS.app/.monotouch-64
````

whereas `NSBundle.MainBundle.BundlePath` returns the correct:
```
/var/containers/Bundle/Application/9FDCAEBE-D0B1-4DA8-8825-6A11239F8D1C/Tests.XamarinIOS.app
```

Both return the correct path on simulators, but that doesn't help much when testing on device.