### PR TITLE
Cleanup NuGet targets files

### DIFF
--- a/NuGet/Realm.Database/Realm.Database.targets
+++ b/NuGet/Realm.Database/Realm.Database.targets
@@ -6,13 +6,13 @@
     <Error 
       Text="Solution directory was not set. If you are building via xbuild, specify by adding a /p:SolutionDir=/path/to/solution/folder argument. See github.com/realm/realm-dotnet/issues/656"
       Condition="'$(SolutionDir)' == ''" />
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)../tools/RealmWeaver.Fody.dll" DestinationFolder="$(SolutionDir)/Tools" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\tools\RealmWeaver.Fody.dll" DestinationFolder="$(SolutionDir)Tools" />
   </Target>
   <ItemGroup>
     <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' AND '$(_RealmSyncPackagePath)' == ''">
-    <NativeReference Include="$(MSBuildThisFileDirectory)../native/ios/universal/librealm-wrappers.a">
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios\universal\librealm-wrappers.a">
       <Kind>Static</Kind>
       <SmartLink>True</SmartLink>
       <IsCxx>True</IsCxx>
@@ -20,26 +20,26 @@
     </NativeReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' AND '$(_RealmSyncPackagePath)' == ''">
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../native/android/armeabi-v7a/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../native/android/armeabi-v7a/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../native/android/x86/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../native/android/x86/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\native\android\x86\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
     <!-- 64bit -->
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../native/android/arm64-v8a/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../native/android/arm64-v8a/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../native/android/x86_64/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../native/android/x86_64/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\native\android\x86_64\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <None Include="$(MSBuildThisFileDirectory)../native/win32/x86/realm-wrappers.dll">
+    <None Include="$(MSBuildThisFileDirectory)..\native\win32\x86\realm-wrappers.dll">
         <Link>lib\win32\x86\realm-wrappers.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)../native/win32/x64/realm-wrappers.dll">
+      <None Include="$(MSBuildThisFileDirectory)..\native\win32\x64\realm-wrappers.dll">
         <Link>lib\win32\x64\realm-wrappers.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/NuGet/Realm.Database/Realm.Database.targets
+++ b/NuGet/Realm.Database/Realm.Database.targets
@@ -11,35 +11,38 @@
   <ItemGroup>
     <None Include="FodyWeavers.xml" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' AND '$(_RealmSyncPackagePath)' == ''">
-    <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios\universal\librealm-wrappers.a">
+  <PropertyGroup>
+    <_RealmNugetNativePath Condition="'$(_RealmNugetNativePath)' == ''">$(MSBuildThisFileDirectory)..\native\</_RealmNugetNativePath>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
+    <NativeReference Include="$(_RealmNugetNativePath)ios\universal\librealm-wrappers.a">
       <Kind>Static</Kind>
       <SmartLink>True</SmartLink>
       <IsCxx>True</IsCxx>
       <LinkerFlags>-lz</LinkerFlags>
     </NativeReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' AND '$(_RealmSyncPackagePath)' == ''">
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\librealm-wrappers.so</Link>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid'">
+    <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\armeabi-v7a\librealm-wrappers.so">
+      <Link>$(_RealmNugetNativePath)android\armeabi-v7a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\native\android\x86\librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\x86\librealm-wrappers.so">
+      <Link>$(_RealmNugetNativePath)android\x86\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
     <!-- 64bit -->
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\arm64-v8a\librealm-wrappers.so">
+      <Link>$(_RealmNugetNativePath)android\arm64-v8a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\native\android\x86_64\librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\x86_64\librealm-wrappers.so">
+      <Link>$(_RealmNugetNativePath)android\x86_64\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <None Include="$(MSBuildThisFileDirectory)..\native\win32\x86\realm-wrappers.dll">
+    <None Include="$(_RealmNugetNativePath)win32\x86\realm-wrappers.dll">
         <Link>lib\win32\x86\realm-wrappers.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)..\native\win32\x64\realm-wrappers.dll">
+      <None Include="$(_RealmNugetNativePath)win32\x64\realm-wrappers.dll">
         <Link>lib\win32\x64\realm-wrappers.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/NuGet/Realm/Realm.nuspec
+++ b/NuGet/Realm/Realm.nuspec
@@ -24,14 +24,14 @@
     <file src="../../Platform.PCL/Realm.Sync.PCL/bin/$Configuration$/Realm.Sync.*" target="lib/portable-net45+sl5+wp8+wpa81+win8+monoandroid+Xamarin.iOS10+monotouch+Xamarin.Mac" />
 <!-- IOS file -->
     <file src="../../Platform.XamarinIOS/Realm.Sync.XamarinIOS/bin/iPhoneSimulator/$Configuration$/Realm.Sync.*" target="lib/Xamarin.iOS10" />
-    <file src="../../wrappers/build/$Configuration$-ios-universal/librealm-wrappers.a" target="lib/Xamarin.iOS10" />
+    <file src="../../wrappers/build/$Configuration$-ios-universal/librealm-wrappers.a" target="native/ios/universal" />
 <!-- Targets file adds adds references to native libs -->
     <file src="Realm.targets" target="build" />
 <!-- Android files -->
     <file src="../../Platform.XamarinAndroid/Realm.Sync.XamarinAndroid/bin/$Configuration$/Realm.Sync.*" target="lib/MonoAndroid44" />
-    <file src="../../wrappers/build/$Configuration$-android/armeabi-v7a/librealm-wrappers.so" target="lib/MonoAndroid44/armeabi-v7a" />
-    <file src="../../wrappers/build/$Configuration$-android/arm64-v8a/librealm-wrappers.so" target="lib/MonoAndroid44/arm64-v8a" />
-    <file src="../../wrappers/build/$Configuration$-android/x86/librealm-wrappers.so" target="lib/MonoAndroid44/x86" />
-    <file src="../../wrappers/build/$Configuration$-android/x86_64/librealm-wrappers.so" target="lib/MonoAndroid44/x86_64" />
+    <file src="../../wrappers/build/$Configuration$-android/armeabi-v7a/librealm-wrappers.so" target="native/android/armeabi-v7a" />
+    <file src="../../wrappers/build/$Configuration$-android/arm64-v8a/librealm-wrappers.so" target="native/android/arm64-v8a" />
+    <file src="../../wrappers/build/$Configuration$-android/x86/librealm-wrappers.so" target="native/android/x86" />
+    <file src="../../wrappers/build/$Configuration$-android/x86_64/librealm-wrappers.so" target="native/android/x86_64" />
   </files>
 </package>

--- a/NuGet/Realm/Realm.targets
+++ b/NuGet/Realm/Realm.targets
@@ -4,7 +4,7 @@
     <_RealmSyncPackagePath>$(MSBuildThisFileDirectory)..</_RealmSyncPackagePath>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
-    <NativeReference Include="$(MSBuildThisFileDirectory)../lib/Xamarin.iOS10/librealm-wrappers.a">
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\lib\Xamarin.iOS10\librealm-wrappers.a">
       <Kind>Static</Kind>
       <SmartLink>True</SmartLink>
       <IsCxx>True</IsCxx>
@@ -12,18 +12,18 @@
     </NativeReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid'">
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../lib/MonoAndroid44/armeabi-v7a/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../lib/MonoAndroid44/armeabi-v7a/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\armeabi-v7a\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\armeabi-v7a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../lib/MonoAndroid44/x86/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../lib/MonoAndroid44/x86/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
     <!-- 64bit -->
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../lib/MonoAndroid44/arm64-v8a/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../lib/MonoAndroid44/arm64-v8a/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\arm64-v8a\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\arm64-v8a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)../lib/MonoAndroid44/x86_64/librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)../lib/MonoAndroid44/x86_64/librealm-wrappers.so</Link>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86_64\librealm-wrappers.so">
+      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86_64\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
   </ItemGroup>
 </Project>

--- a/NuGet/Realm/Realm.targets
+++ b/NuGet/Realm/Realm.targets
@@ -1,29 +1,6 @@
 <?xml version="1.0"  encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_RealmSyncPackagePath>$(MSBuildThisFileDirectory)..</_RealmSyncPackagePath>
+    <_RealmNugetNativePath>$(MSBuildThisFileDirectory)..\native\</_RealmNugetNativePath>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
-    <NativeReference Include="$(MSBuildThisFileDirectory)..\lib\Xamarin.iOS10\librealm-wrappers.a">
-      <Kind>Static</Kind>
-      <SmartLink>True</SmartLink>
-      <IsCxx>True</IsCxx>
-      <LinkerFlags>-lz</LinkerFlags>
-    </NativeReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid'">
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\armeabi-v7a\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\armeabi-v7a\librealm-wrappers.so</Link>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86\librealm-wrappers.so</Link>
-    </AndroidNativeLibrary>
-    <!-- 64bit -->
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\arm64-v8a\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\arm64-v8a\librealm-wrappers.so</Link>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86_64\librealm-wrappers.so">
-      <Link>$(MSBuildThisFileDirectory)..\lib\MonoAndroid44\x86_64\librealm-wrappers.so</Link>
-    </AndroidNativeLibrary>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Make sure we always use forward slashes, because Windows (fixes #1169).

Refactor the MSBuild code that includes realm-wrappers in user projects.