### PR TITLE
Added more testing and idiom to show how to get the single Boss

### DIFF
--- a/Shared/Realm.Shared/Linq/RealmResultsVisitor.cs
+++ b/Shared/Realm.Shared/Linq/RealmResultsVisitor.cs
@@ -92,7 +92,7 @@ namespace Realms
         /*
             Expressions will typically be in a form:
             - with embedded Lambda `Count(p => !p.IsInteresting)`
-            - at the end of a Where `Where(p => !p.IsInteresting).Where()`
+            - at the end of a Where `Where(p => !p.IsInteresting).Count()`
 
             The latter form is handled by recursion where evaluation of Visit will 
             take us back into VisitMethodCall to evaluate the Where call.

--- a/Shared/Realm.Shared/RealmObject.cs
+++ b/Shared/Realm.Shared/RealmObject.cs
@@ -354,6 +354,9 @@ namespace Realms
             _metadata.Schema.TryFindProperty(propertyName, out property);
             var relatedMeta = _realm.Metadata[property.ObjectType];
 
+            // Although this retrns a new RealmResults each time it is called,
+            // the woven code in ModuleWeaver.ReplaceBacklinksGetter caches this in the backing field
+            // so it should not be invoked repeaatedly when user code gets the backlinks multiple times.
             return new RealmResults<T>(_realm, resultsHandle, relatedMeta);
         }
 

--- a/Shared/Tests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Shared/Tests.Shared/RealmResults/SimpleLINQtests.cs
@@ -770,6 +770,21 @@ namespace IntegrationTests
             Assert.That(s3.FirstName, Is.EqualTo("Peter"));
         }
 
+        // test added to prove with breakpoints that we rebuild query multiple times calling ElementAt
+        [Test]
+        public void ElementAtRepeatedOnResults()
+        {
+            var twoPeeps = _realm.All<Person>().Where(p => p.Score > 10.0f); 
+            var peepsList = twoPeeps.ToList();
+            Assert.That(peepsList.Count, Is.EqualTo(2));
+
+            var p1 = twoPeeps.ElementAt(0);
+            Assert.That(p1.Email, Is.EqualTo("john@doe.com"));
+
+            var p2 = twoPeeps.ElementAt(1);
+            Assert.That(p2.FirstName, Is.EqualTo("Peter"));
+        }
+
         [Test]
         public void ElementAtOrDefaultInRange()
         {
@@ -852,6 +867,27 @@ namespace IntegrationTests
             var moderateScorers = _realm.All<Person>().Where(p => p.Score >= 20.0f && p.Score <= 100.0f);
             var hasJohn = moderateScorers.Any(p => p.FirstName == "John");
             Assert.That(hasJohn, Is.True);
+        }
+
+        // test that you can add a clause to a RealmResults after instantiating the query
+        [Test]
+        public void ChainedWithIterationBefore2ndClause()
+        {
+            var moderateScorers = _realm.All<Person>().Where(p => p.Score >= 20.0f && p.Score <= 100.0f);
+            var listScorers = moderateScorers.ToList();  // query will be evaluated to iterate making the list
+            Assert.That(listScorers.Count, Is.EqualTo(2));
+            var hasJohn = moderateScorers.Any(p => p.FirstName == "John");  // now 2nd predicate applied
+            Assert.That(hasJohn, Is.True);
+        }
+
+        [Test]
+        public void ChainedWithIterationBeforeFirst()
+        {
+            var moderateScorers = _realm.All<Person>().Where(p => p.Score >= 20.0f && p.Score <= 100.0f);
+            var listScorers = moderateScorers.ToList();  // query will be evaluated to iterate making the list
+            Assert.That(listScorers.Count, Is.EqualTo(2));
+            var firstAfterIter = moderateScorers.First();  // if debugging, query should not be evaulated again
+            Assert.That(firstAfterIter, Is.Not.Null);
         }
 
         [Test]

--- a/Shared/Tests.Shared/RelationshipTests.cs
+++ b/Shared/Tests.Shared/RelationshipTests.cs
@@ -438,7 +438,7 @@ namespace IntegrationTests
         }
 
         [Test]
-        public void RecursiveBacklinksBossTestOnly()
+        public void RecursiveBacklinkWorksViaOneToManyProperty()
         {
             realm.Write(() =>
             {
@@ -460,9 +460,9 @@ namespace IntegrationTests
             Assert.That(bossesBoss, Is.Null);
         }
 
-        // Demonstrate the bug reported in issue 1177
+        // Test is named assuming it succeeds. Currently fails and demonstrates the bug reported in issue 1177
         [Test, NUnit.Framework.Explicit("Demonstrates issue 1177 so disable from auto run")]
-        public void RecursiveBacklinksQueryFailures()
+        public void RecursiveBacklinksQueriesOnlySeeRelatedItems()
         {
             realm.Write(() =>
             {

--- a/Shared/Tests.Shared/RelationshipTests.cs
+++ b/Shared/Tests.Shared/RelationshipTests.cs
@@ -460,8 +460,7 @@ namespace IntegrationTests
             Assert.That(bossesBoss, Is.Null);
         }
 
-        // Test is named assuming it succeeds. Currently fails and demonstrates the bug reported in issue 1177
-        [Test, NUnit.Framework.Explicit("Demonstrates issue 1177 so disable from auto run")]
+        [Test]
         public void RecursiveBacklinksQueriesOnlySeeRelatedItems()
         {
             realm.Write(() =>

--- a/Shared/Tests.Shared/RelationshipTests.cs
+++ b/Shared/Tests.Shared/RelationshipTests.cs
@@ -421,12 +421,12 @@ namespace IntegrationTests
         }
 
         [Test]
-        public void Backlinks()
+        public void BacklinksBetweenTwoClasses()
         {
             var tim = realm.All<Owner>().Single(o => o.Name == "Tim");
             foreach (var dog in tim.Dogs)
             {
-                Assert.That(dog.Owners, Is.EquivalentTo(new[] { tim })); 
+                Assert.That(dog.Owners, Is.EquivalentTo(new[] { tim }));
             }
 
             var dani = realm.All<Owner>().Single(o => o.Name == "Dani");
@@ -435,6 +435,56 @@ namespace IntegrationTests
 
             realm.Write(() => dani.Dogs.Add(maggie));
             Assert.That(maggie.Owners, Is.EquivalentTo(new[] { dani }));
+        }
+
+        [Test]
+        public void RecursiveBacklinksBossTestOnly()
+        {
+            realm.Write(() =>
+            {
+                realm.Add(new Employee
+                {
+                    Name = "Sally",
+                    Reports =
+                    {
+                        new Employee { Name = "Sree" },
+                        new Employee { Name = "Jake" }
+                    }
+                });
+            });
+
+            // simple query of immediate Boss 
+            var jake = realm.All<Employee>().Single(p => p.Name == "Jake");
+            Assert.That(jake.Boss?.Name, Is.EqualTo("Sally"));
+            var bossesBoss = jake.Boss?.Boss;
+            Assert.That(bossesBoss, Is.Null);
+        }
+
+        // Demonstrate the bug reported in issue 1177
+        [Test, NUnit.Framework.Explicit("Demonstrates issue 1177 so disable from auto run")]
+        public void RecursiveBacklinksQueryFailures()
+        {
+            realm.Write(() =>
+            {
+                realm.Add(new Employee
+                {
+                    Name = "Sally",
+                    Reports =
+                    {
+                        new Employee { Name = "Sree" },
+                        new Employee { Name = "Jake" }
+                    }
+                });
+            });
+
+            // simple query of immediate Boss 
+            var jake = realm.All<Employee>().Single(p => p.Name == "Jake");
+            var jakeBossCount = jake.Bosses.Count();
+            Assert.That(jakeBossCount, Is.EqualTo(1));
+
+            var sally = realm.All<Employee>().Single(p => p.Name == "Sally");
+            var sallyBossCount = sally.Bosses.Count();
+            Assert.That(sallyBossCount, Is.EqualTo(0));
         }
 
         #region DeleteRelated

--- a/Shared/Tests.Shared/TestObjects.cs
+++ b/Shared/Tests.Shared/TestObjects.cs
@@ -223,9 +223,12 @@ namespace IntegrationTests
         {
             get
             {
-                // NOTE the ToList() in here is needed because of issue 1177
-                // it is shown as a workaround
-                return Bosses.ToList().SingleOrDefault();
+                // Alternative implementation here to get faster release performance avoiding 2nd search to ensure only one.
+                #if DEBUG
+                return Bosses.SingleOrDefault();
+                #else
+                return Bosses.FirstOrDefault();
+                #endif
             }
         }
     }

--- a/Shared/Tests.Shared/TestObjects.cs
+++ b/Shared/Tests.Shared/TestObjects.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Linq.Expressions;
 using Realms;
 
 namespace IntegrationTests
@@ -206,6 +207,25 @@ namespace IntegrationTests
         public Dog TopDog { get; set; }
 
         public IList<Dog> Dogs { get; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class Employee : RealmObject
+    {
+        public string Name { get; set; }
+
+        public IList<Employee> Reports { get; }
+
+        [Backlink(nameof(Employee.Reports))]
+        public IQueryable<Employee> Bosses { get; }
+
+        public Employee Boss
+        {
+            get
+            {
+                return Bosses.ToList().SingleOrDefault();
+            }
+        }
     }
 
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]

--- a/Shared/Tests.Shared/TestObjects.cs
+++ b/Shared/Tests.Shared/TestObjects.cs
@@ -223,6 +223,8 @@ namespace IntegrationTests
         {
             get
             {
+                // NOTE the ToList() in here is needed because of issue 1177
+                // it is shown as a workaround
                 return Bosses.ToList().SingleOrDefault();
             }
         }


### PR DESCRIPTION
Want to merge these tests in, with `RecursiveBacklinksQueryFailures` disabled as Explicit, so that can be just enabled for the fix later.