### PR TITLE
Fix notification crash

### DIFF
--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -96,11 +96,17 @@ namespace binding {
     
     void CSharpBindingContext::notify_change(const size_t row_ndx, const size_t table_ndx, const size_t property_index)
     {
+        std::vector<void*> toNotify;
+        
         for (auto const& o : m_observed_rows) {
             if (o.row_ndx == row_ndx && o.table_ndx == table_ndx) {
                 auto const& details = static_cast<ObservedObjectDetails*>(o.info);
-                notify_and_remove_if_needed(this, details->managed_object_handle, property_index);
+                toNotify.push_back(details->managed_object_handle);
             }
+        }
+        
+        for (void* handle : toNotify) {
+            notify_and_remove_if_needed(this, handle, property_index);
         }
     }
     


### PR DESCRIPTION
The current notification implementation has a bug where while iterating, we can delete objects, effectively getting pointers to invalid memory. This was then passed to managed where we attempt to create a GCHandle from the pointer, resulting in a crash. This PR creates a temporary vector to store the pointers.

Fixes #1207