### PR TITLE
Win32 wrappers path should not be dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+x.y.z (TBD)
+------------------
+
+### Bug fixes
+
+- The `Realm` NuGet package no longer clobbers the path to Win32 native binaries in `Realm.Database`. (#1239)
+
 1.0.3 (2017-02-14)
 ------------------
 # Out of Beta!

--- a/NuGet/Realm.Database/Realm.Database.targets
+++ b/NuGet/Realm.Database/Realm.Database.targets
@@ -50,11 +50,11 @@
     </AndroidNativeLibrary>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <None Include="$(_RealmNugetNativePath)win32\x86\realm-wrappers.dll">
+    <None Include="$(MSBuildThisFileDirectory)..\native\win32\x86\realm-wrappers.dll">
         <Link>lib\win32\x86\realm-wrappers.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
-      <None Include="$(_RealmNugetNativePath)win32\x64\realm-wrappers.dll">
+      <None Include="$(MSBuildThisFileDirectory)..\native\win32\x64\realm-wrappers.dll">
         <Link>lib\win32\x64\realm-wrappers.dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>


### PR DESCRIPTION
The path should always point to the location of the `Realm.Database` package and should not be affected by the presence of the `Realm` package like the iOS and Android wrappers because `Realm` doesn't provide Win32 wrappers.

Fixes #1239