### PR TITLE
More fixes related to BuildTasks

### DIFF
--- a/Weaver/Realm.BuildTasks/Realm.BuildTasks.csproj
+++ b/Weaver/Realm.BuildTasks/Realm.BuildTasks.csproj
@@ -31,7 +31,16 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Fody.1.29.4\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Weaver/Realm.BuildTasks/packages.config
+++ b/Weaver/Realm.BuildTasks/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Make skipping logic more robust

<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

- Uses Cecil from Nuget - means we're compatible with XF's version of Cecil, which may get loaded into the appdomain before ours, so that caused a very obscure build error.
- Ensures we're not falsely skipping weaving - if the user project references but doesn't use realm, we would incorrectly ignore it.
