### PR TITLE
Reorder pipeline to test sooner rather than later

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,6 +163,14 @@ stage('Build without sync') {
   )
 }
 
+stage('Test without sync') {
+  parallel(
+    'iOS': iOSTest('ios-tests-nosync'),
+    'Android': AndroidTest('android-tests-nosync'),
+    'Win32': Win32Test('win32-tests-nosync')
+  )
+}
+
 stage('Build with sync') {
   parallel(
     'iOS': {
@@ -227,15 +235,6 @@ stage('Build with sync') {
     }
   )
 }
-
-stage('Test without sync') {
-  parallel(
-    'iOS': iOSTest('ios-tests-nosync'),
-    'Android': AndroidTest('android-tests-nosync'),
-    'Win32': Win32Test('win32-tests-nosync')
-  )
-}
-
 
 stage('Test with sync') {
   parallel(


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Just a simple reordering of the steps so we fail sooner if there are issues. It also mitigates congestion of CI a little bit.