### PR TITLE
Properly return null for session's user when the session is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ If you encounter any issues after the upgrade, we recommend clearing the `bin` a
 
 ### Bug fixes
 - Fixes the `RemoveAll(string)` overload to work correctly. (#1288)
+- Resolved an issue that would lead to crashes when refreshing the token for an invalid session. (#1289)
 
 ### Enhancements
 

--- a/Realm/Realm.Sync/Handles/SessionHandle.cs
+++ b/Realm/Realm.Sync/Handles/SessionHandle.cs
@@ -69,12 +69,17 @@ namespace Realms.Sync
             public static extern void report_error_for_testing(SessionHandle session, int error_code, [MarshalAs(UnmanagedType.LPWStr)] string message, IntPtr message_len, [MarshalAs(UnmanagedType.I1)] bool is_fatal);
         }
 
-        public SyncUserHandle GetUser()
+        public User GetUser()
         {
-            var handle = new SyncUserHandle();
             var ptr = NativeMethods.get_user(this);
+            if (ptr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var handle = new SyncUserHandle();
             handle.SetHandle(ptr);
-            return handle;
+            return new User(handle);
         }
 
         public string GetServerUri()

--- a/Realm/Realm.Sync/Helpers/AuthenticationHelper.cs
+++ b/Realm/Realm.Sync/Helpers/AuthenticationHelper.cs
@@ -53,6 +53,11 @@ namespace Realms.Sync
         public static async Task RefreshAccessToken(Session session, bool reportErrors = true)
         {
             var user = session.User;
+            if (user == null || session.State == SessionState.Invalid)
+            {
+                return;
+            }
+
             try
             {
                 var json = new Dictionary<string, object>

--- a/Realm/Realm.Sync/Session.cs
+++ b/Realm/Realm.Sync/Session.cs
@@ -47,7 +47,7 @@ namespace Realms.Sync
         /// Gets the <see cref="User"/> defined by the <see cref="SyncConfiguration"/> that is used to connect to the Realm Object Server.
         /// </summary>
         /// <value>The <see cref="User"/> that was used to create the <see cref="Realm"/>'s <see cref="SyncConfiguration"/>.</value>
-        public User User => new User(Handle.GetUser());
+        public User User => Handle.GetUser();
 
         /// <summary>
         /// Gets the on-disk path of the Realm file backing the <see cref="Realm"/> this Session represents.

--- a/Tests/Tests.Sync.Shared/SessionTests.cs
+++ b/Tests/Tests.Sync.Shared/SessionTests.cs
@@ -126,6 +126,24 @@ namespace Tests.Sync
             });
         }
 
+        [Test]
+        public void Session_GetUser_WhenInvalidSession_ShouldNotThrow()
+        {
+            AsyncContext.Run(async () =>
+            {
+                var realm = await SyncTestHelpers.GetFakeRealm(isUserAdmin: false);
+                var session = realm.GetSession();
+                session.SimulateError(ErrorCode.BadUserAuthentication, "some error", isFatal: true);
+
+                while (session.State != SessionState.Invalid)
+                {
+                    await Task.Delay(100);
+                }
+
+                Assert.That(() => session.User, Is.Null);
+            });
+        }
+
         [Explicit("Fails with obscure error.")]
         [Test, Timeout(1000)]
         public void Session_Error_WhenInvalidRefreshToken()

--- a/wrappers/src/sync_session_cs.cpp
+++ b/wrappers/src/sync_session_cs.cpp
@@ -77,6 +77,10 @@ REALM_EXPORT SharedSyncSession* realm_syncsession_get_from_path(const uint16_t* 
 
 REALM_EXPORT std::shared_ptr<SyncUser>* realm_syncsession_get_user(const SharedSyncSession& session)
 {
+    if (session->user() == nullptr) {
+        return nullptr;
+    }
+    
     return new std::shared_ptr<SyncUser>(session->user());
 }
 


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes #1244

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
