### PR TITLE
Throw exception when accessing an out of range item from RealmResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ If you encounter any issues after the upgrade, we recommend clearing the `bin` a
 
 ### Breaking Changes
 - `DateTimeOffset` properties that are not set will now correctly default to `0001-1-1` instead of `1970-1-1` after the object is passed to `realm.Add`. (#1293)
+- Attempting to get an item at index that is out of range should now correctly throw `ArgumentOutOfRangeException` for all `IRealmCollection` implementations. (#1295)
 
 1.1.1 (2017-03-15)
 ------------------

--- a/Tests/Tests.Shared/CollectionTests.cs
+++ b/Tests/Tests.Shared/CollectionTests.cs
@@ -164,6 +164,23 @@ namespace IntegrationTests
             Assert.That(readonlyContainer.Items.IsReadOnly);
         }
 
+        [Test]
+        public void Results_GetAtIndex_WhenIndexIsOutOfRange_ShouldThrow()
+        {
+            Assert.That(() => _realm.All<IntPropertyObject>().AsRealmCollection()[-1], Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(() => _realm.All<IntPropertyObject>().AsRealmCollection()[0], Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void List_GetAtIndex_WhenIndexIsOutOfRange_ShouldThrow()
+        {
+            var owner = new Owner();
+            _realm.Write(() => _realm.Add(owner));
+
+            Assert.That(() => owner.Dogs.AsRealmCollection()[-1], Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(() => owner.Dogs.AsRealmCollection()[0], Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
         private ContainerObject GetPopulatedManagedContainerObject()
         {
             var container = new ContainerObject();

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -16,6 +16,7 @@
 //
 //////////////////////////////////////////////////////////////////////////// 
 
+#include <sstream>
 #include <realm.hpp>
 #include "error_handling.hpp"
 #include "marshalling.hpp"
@@ -23,6 +24,7 @@
 #include "realm_export_decls.hpp"
 #include "results.hpp"
 #include "object_accessor.hpp"
+#include "wrapper_exceptions.hpp"
 
 using namespace realm;
 using namespace realm::binding;
@@ -52,8 +54,8 @@ REALM_EXPORT Object* results_get_row(Results* results_ptr, size_t ndx, NativeExc
             
             return new Object(results_ptr->get_realm(), results_ptr->get_object_schema(), results_ptr->get(ndx));
         }
-        catch (std::out_of_range &exp) {
-            return static_cast<Object*>(nullptr);
+        catch (realm::Results::OutOfBoundsIndexException &exp) {
+            throw IndexOutOfRangeException("Get from RealmResults", exp.requested, exp.valid_count);
         }
     });
 }


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes #1286 

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
