### PR TITLE
Cleanup some PCL warnings

### DIFF
--- a/Platform.PCL/Realm.PCL/RealmPCL.cs
+++ b/Platform.PCL/Realm.PCL/RealmPCL.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Realms.Exceptions;
 using Realms.Schema;

--- a/Platform.PCL/Realm.Sync.PCL/Realm.Sync.PCL.csproj
+++ b/Platform.PCL/Realm.Sync.PCL/Realm.Sync.PCL.csproj
@@ -36,9 +36,6 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CredentialsPCL.cs" />
-    <Compile Include="..\Realm.PCL\RealmPCLHelpers.cs">
-      <Link>RealmPCLHelpers.cs</Link>
-    </Compile>
     <Compile Include="SessionPCL.cs" />
     <Compile Include="SyncConfigurationPCL.cs" />
     <Compile Include="UserPCL.cs" />


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

A redundant reference (since we already depend on Realm, we can use the original helper) and a using statement to correctly resolve the xml reference.