### PR TITLE
Expose OS’s reconnect method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If you encounter any issues after the upgrade, we recommend clearing the `bin` a
 
 ### Enhancements
 - Introduce APIs for safely passing objects between threads. Create a thread-safe reference to a thread-confined object by passing it to the `ThreadSafeReference.Create` factory method, which you can then safely pass to another thread to resolve in the new realm with `Realm.ResolveReference`. (#1300)
+- Introduce API for attempting to reconnect all sessions. This could be used in conjunction with the [connectivity plugin](https://github.com/jamesmontemagno/ConnectivityPlugin) to monitor for connectivity changes and proactively request reconnecting, rather than rely on the built-in retry mechanism. (#1310)
 
 ### Breaking Changes
 - `DateTimeOffset` properties that are not set will now correctly default to `0001-1-1` instead of `1970-1-1` after the object is passed to `realm.Add`. (#1293)

--- a/Platform.PCL/Realm.Sync.PCL/SessionPCL.cs
+++ b/Platform.PCL/Realm.Sync.PCL/SessionPCL.cs
@@ -73,6 +73,20 @@ namespace Realms.Sync
         }
 
         /// <summary>
+        /// Attempts to reconnect all sessions.
+        /// </summary>
+        /// <remarks>
+        /// By default, the sync engine will attempt to reconnect sessions at incrementing intervals. This method is
+        /// useful when you are monitoring connectivity yourself, using e.g.
+        /// <see href="https://github.com/jamesmontemagno/ConnectivityPlugin">Connectivity Plugin</see> or through the
+        /// native connectivity API and you wish to cancel that delay and try to reconnect immediately.
+        /// </remarks>
+        public static void Reconnect()
+        {
+            RealmPCLHelpers.ThrowProxyShouldNeverBeUsed();
+        }
+
+        /// <summary>
         /// Gets an <see cref="IObservable{T}"/> that can be used to track upload or download progress.
         /// </summary>
         /// <remarks>

--- a/Realm/Realm.Sync/Handles/SharedRealmHandleExtensions.cs
+++ b/Realm/Realm.Sync/Handles/SharedRealmHandleExtensions.cs
@@ -67,6 +67,10 @@ namespace Realms.Sync
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_reset_for_testing", CallingConvention = CallingConvention.Cdecl)]
             public static extern void reset_for_testing();
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncmanager_reconnect", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void reconnect();
+
         }
 
         static unsafe SharedRealmHandleExtensions()
@@ -144,6 +148,11 @@ namespace Realms.Sync
             ex.ThrowIfNecessary();
 
             return result;
+        }
+
+        public static void ReconnectSessions()
+        {
+            NativeMethods.reconnect();
         }
 
         [NativeCallback(typeof(NativeMethods.RefreshAccessTokenCallbackDelegate))]

--- a/Realm/Realm.Sync/Handles/SharedRealmHandleExtensions.cs
+++ b/Realm/Realm.Sync/Handles/SharedRealmHandleExtensions.cs
@@ -70,7 +70,6 @@ namespace Realms.Sync
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncmanager_reconnect", CallingConvention = CallingConvention.Cdecl)]
             public static extern void reconnect();
-
         }
 
         static unsafe SharedRealmHandleExtensions()

--- a/Realm/Realm.Sync/Session.cs
+++ b/Realm/Realm.Sync/Session.cs
@@ -110,6 +110,20 @@ namespace Realms.Sync
             Handle = handle;
         }
 
+        /// <summary>
+        /// Attempts to reconnect all sessions.
+        /// </summary>
+        /// <remarks>
+        /// By default, the sync engine will attempt to reconnect sessions at incrementing intervals. This method is
+        /// useful when you are monitoring connectivity yourself, using e.g.
+        /// <see href="https://github.com/jamesmontemagno/ConnectivityPlugin">Connectivity Plugin</see> or through the
+        /// native connectivity API and you wish to cancel that delay and try to reconnect immediately.
+        /// </remarks>
+        public static void Reconnect()
+        {
+            SharedRealmHandleExtensions.ReconnectSessions();
+        }
+
         internal static Session Create(IntPtr sessionPtr)
         {
             if (sessionPtr == IntPtr.Zero)

--- a/wrappers/src/sync_manager_cs.cpp
+++ b/wrappers/src/sync_manager_cs.cpp
@@ -108,6 +108,11 @@ REALM_EXPORT bool realm_syncmanager_immediately_run_file_actions(uint16_t* pathb
         return SyncManager::shared().immediately_run_file_actions(path);
     });
 }
+    
+REALM_EXPORT void realm_syncmanager_reconnect()
+{
+    SyncManager::shared().reconnect();
+}
 
 }
 


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes #1268 

##  TODO

* [x] Changelog entry
* [ ] ~Tests (if applicable)~ - there's no easy way to validate that the reconnect is triggered, but as we're just proxying to an OS method, which in turn proxies to a sync method, we hope that it works :)
* [x] Update PCL (if applicable)