### PR TITLE
POC of the new object notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ If you encounter any issues after the upgrade, we recommend clearing the `bin` a
 - Attempting to get an item at index that is out of range should now correctly throw `ArgumentOutOfRangeException` for all `IRealmCollection` implementations. (#1295)
 - The layout of the .lock file has changed, which may affect scenarios where different processes attempt to write to the same Realm file at the same time. (#1296)
 - This version is not compatible with versions of the Realm Object Server lower than 1.3.0. (#1300)
+- `PropertyChanged` notifications use a new, more reliable, mechanism, that behaves slightly differently from the old one. Notifications will be sent only after a transaction is committed (making it consistent with the way collection notifications are handled). To make sure that your UI is promptly updated, you should avoid keeping long lived transactions around. (#1316)
 
 1.1.1 (2017-03-15)
 ------------------

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -17,58 +17,19 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace Realms
 {
-    internal abstract class CollectionHandleBase : RealmHandle, IThreadConfinedHandle
+    internal abstract class CollectionHandleBase : NotifiableObjectHandleBase
     {
-        private static class NativeMethods
-        {
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "collection_destroy_notificationtoken", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr destroy_notificationtoken(IntPtr token, out NativeException ex);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct CollectionChangeSet
-        {
-            public MarshaledVector<IntPtr> Deletions;
-            public MarshaledVector<IntPtr> Insertions;
-            public MarshaledVector<IntPtr> Modifications;
-
-            [StructLayout(LayoutKind.Sequential)]
-            public struct Move
-            {
-                public IntPtr From;
-                public IntPtr To;
-            }
-
-            public MarshaledVector<Move> Moves;
-        }
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void NotificationCallbackDelegate(IntPtr managedCollectionHandle, IntPtr collectionChanges, IntPtr notficiationException);
-
         public abstract bool IsValid { get; }
 
         protected CollectionHandleBase(RealmHandle root) : base(root)
         {
         }
 
-        public abstract IntPtr AddNotificationCallback(IntPtr managedCollectionHandle, NotificationCallbackDelegate callback);
-
         public abstract IntPtr GetObjectAtIndex(int index);
 
         public abstract int Count();
-
-        public IntPtr DestroyNotificationToken(IntPtr token)
-        {
-            NativeException nativeException;
-            var result = NativeMethods.destroy_notificationtoken(token, out nativeException);
-            nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public abstract ThreadSafeReferenceHandle GetThreadSafeReference();
     }
 }

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -126,10 +126,10 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public override IntPtr AddNotificationCallback(IntPtr managedCollectionHandle, NotificationCallbackDelegate callback)
+        public override IntPtr AddNotificationCallback(IntPtr managedObjectHandle, NotificationCallbackDelegate callback)
         {
             NativeException nativeException;
-            var result = NativeMethods.add_notification_callback(this, managedCollectionHandle, callback, out nativeException);
+            var result = NativeMethods.add_notification_callback(this, managedObjectHandle, callback, out nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm/Realm/Handles/NotifiableObjectHandleBase.cs
+++ b/Realm/Realm/Handles/NotifiableObjectHandleBase.cs
@@ -1,0 +1,69 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Realms
+{
+    internal abstract class NotifiableObjectHandleBase : RealmHandle, IThreadConfinedHandle
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct CollectionChangeSet
+        {
+            public MarshaledVector<IntPtr> Deletions;
+            public MarshaledVector<IntPtr> Insertions;
+            public MarshaledVector<IntPtr> Modifications;
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct Move
+            {
+                public IntPtr From;
+                public IntPtr To;
+            }
+
+            public MarshaledVector<Move> Moves;
+            public MarshaledVector<IntPtr> Properties;
+        }
+
+        private static class NativeMethods
+        {
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_destroy_notificationtoken", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr destroy_notificationtoken(IntPtr token, out NativeException ex);
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void NotificationCallbackDelegate(IntPtr managedHandle, IntPtr changes, IntPtr notificationException);
+
+        protected NotifiableObjectHandleBase(RealmHandle root) : base(root)
+        {
+        }
+
+        public IntPtr DestroyNotificationToken(IntPtr token)
+        {
+            NativeException nativeException;
+            var result = NativeMethods.destroy_notificationtoken(token, out nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public abstract IntPtr AddNotificationCallback(IntPtr managedObjectHandle, NotificationCallbackDelegate callback);
+
+        public abstract ThreadSafeReferenceHandle GetThreadSafeReference();
+    }
+}

--- a/Realm/Realm/Handles/NotificationTokenHandle.cs
+++ b/Realm/Realm/Handles/NotificationTokenHandle.cs
@@ -15,8 +15,7 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
- 
-using System;
+
 using System.Runtime.InteropServices;
 
 namespace Realms
@@ -25,19 +24,19 @@ namespace Realms
     // We need to mirror this same relationship here.
     internal class NotificationTokenHandle : RealmHandle
     {
-        private CollectionHandleBase _collectionHandle;
+        private readonly NotifiableObjectHandleBase _notifiableHandle;
 
-        public NotificationTokenHandle(CollectionHandleBase root) : base(root.Root ?? root)
+        public NotificationTokenHandle(NotifiableObjectHandleBase root) : base(root.Root ?? root)
         {
             // We save this because RealmHandle doesn't support a parent chain like
             // NotificationToken -> List -> Realm
-            _collectionHandle = root;
+            _notifiableHandle = root;
         }
 
         protected override void Unbind()
         {
-            var managedCollectionHandle = _collectionHandle.DestroyNotificationToken(handle);
-            GCHandle.FromIntPtr(managedCollectionHandle).Free();
+            var managedObjectHandle = _notifiableHandle.DestroyNotificationToken(handle);
+            GCHandle.FromIntPtr(managedObjectHandle).Free();
         }
     }
 }

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 
 namespace Realms
 {
-    internal class ObjectHandle : RealmHandle, IThreadConfinedHandle
+    internal class ObjectHandle : NotifiableObjectHandleBase
     {
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter")]
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1121:UseBuiltInTypeAlias")]
@@ -140,6 +140,9 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_thread_safe_reference", CallingConvention = CallingConvention.Cdecl)]
             public static extern ThreadSafeReferenceHandle get_thread_safe_reference(ObjectHandle objectHandle, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_add_notification_callback", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr add_notification_callback(ObjectHandle objectHandle, IntPtr managedObjectHandle, NotificationCallbackDelegate callback, out NativeException ex);
         }
 
         public bool IsValid
@@ -582,12 +585,20 @@ namespace Realms
             return resultsHandle;
         }
 
-        public ThreadSafeReferenceHandle GetThreadSafeReference()
+        public override ThreadSafeReferenceHandle GetThreadSafeReference()
         {
             NativeException nativeException;
             var result = NativeMethods.get_thread_safe_reference(this, out nativeException);
             nativeException.ThrowIfNecessary();
 
+            return result;
+        }
+
+        public override IntPtr AddNotificationCallback(IntPtr managedObjectHandle, NotificationCallbackDelegate callback)
+        {
+            NativeException nativeException;
+            var result = NativeMethods.add_notification_callback(this, managedObjectHandle, callback, out nativeException);
+            nativeException.ThrowIfNecessary();
             return result;
         }
     }

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -114,10 +114,10 @@ namespace Realms
             return queryHandle;
         }
 
-        public override IntPtr AddNotificationCallback(IntPtr managedCollectionHandle, NotificationCallbackDelegate callback)
+        public override IntPtr AddNotificationCallback(IntPtr managedObjectHandle, NotificationCallbackDelegate callback)
         {
             NativeException nativeException;
-            var result = NativeMethods.add_notification_callback(this, managedCollectionHandle, callback, out nativeException);
+            var result = NativeMethods.add_notification_callback(this, managedObjectHandle, callback, out nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -74,12 +74,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_schema_version", CallingConvention = CallingConvention.Cdecl)]
             public static extern ulong get_schema_version(SharedRealmHandle sharedRealm, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_add_observed_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_observed_object(SharedRealmHandle sharedRealm, ObjectHandle objectHandle, IntPtr managedRealmObjectHandle, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_remove_observed_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void remove_observed_object(SharedRealmHandle sharedRealm, IntPtr managedRealmObjectHandle, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_compact", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool compact(SharedRealmHandle sharedRealm, out NativeException ex);
@@ -134,20 +128,6 @@ namespace Realms
             var result = NativeMethods.get_managed_state_handle(this, out nativeException);
             nativeException.ThrowIfNecessary();
             return result;
-        }
-
-        public void AddObservedObject(ObjectHandle objectHandle, IntPtr managedRealmObjectHandle)
-        {
-            NativeException nativeException;
-            NativeMethods.add_observed_object(this, objectHandle, managedRealmObjectHandle, out nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void RemoveObservedObject(IntPtr managedRealmObjectHandle)
-        {
-            NativeException nativeException;
-            NativeMethods.remove_observed_object(this, managedRealmObjectHandle, out nativeException);
-            nativeException.ThrowIfNecessary();
         }
 
         public void BeginTransaction()

--- a/Realm/Realm/Native/NativeCommon.cs
+++ b/Realm/Realm/Native/NativeCommon.cs
@@ -33,13 +33,6 @@ namespace Realms
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void NotifyRealmCallback(IntPtr stateHandle);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        [return: MarshalAs(UnmanagedType.I1)]
-        public delegate bool NotifyRealmObjectCallback(IntPtr realmObjectHandle, IntPtr propertyIndex);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void FreeGCHandleCallback(IntPtr handle);
-
 #if DEBUG
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public unsafe delegate void DebugLoggerCallback(byte* utf8String, IntPtr stringLen);
@@ -60,12 +53,6 @@ namespace Realms
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "delete_pointer", CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe void delete_pointer(void* pointer);
-
-        [DllImport(InteropConfig.DLL_NAME, EntryPoint = "register_notify_realm_object_changed", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void register_notify_realm_object_changed(NotifyRealmObjectCallback callback);
-
-        [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_install_gchandle_deleter", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void install_gchandle_deleter(FreeGCHandleCallback callback);
 
         [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_reset_for_testing", CallingConvention = CallingConvention.Cdecl)]
         public static extern void reset_for_testing();
@@ -98,19 +85,6 @@ namespace Realms
             GCHandle.Alloc(logger);
             set_debug_logger(logger);
 #endif
-
-            FreeGCHandleCallback gchandleDeleter = FreeGCHandle;
-            GCHandle.Alloc(gchandleDeleter);
-            install_gchandle_deleter(gchandleDeleter);
-        }
-
-        [NativeCallback(typeof(FreeGCHandleCallback))]
-        public static void FreeGCHandle(IntPtr handle)
-        {
-            if (handle != IntPtr.Zero)
-            {
-                GCHandle.FromIntPtr(handle).Free();
-            }
         }
     }
 }

--- a/Realm/Realm/NotificationsHelper.cs
+++ b/Realm/Realm/NotificationsHelper.cs
@@ -22,20 +22,20 @@ using Realms.Native;
 
 namespace Realms
 {
-    internal static class RealmCollectionNativeHelper
+    internal static class NotificationsHelper
     {
-        internal interface Interface
+        internal interface INotifiable
         {
-            void NotifyCallbacks(CollectionHandleBase.CollectionChangeSet? changes, NativeException? exception);
+            void NotifyCallbacks(NotifiableObjectHandleBase.CollectionChangeSet? changes, NativeException? exception);
         }
 
-        internal static readonly CollectionHandleBase.NotificationCallbackDelegate NotificationCallback = NotificationCallbackImpl;
+        internal static readonly NotifiableObjectHandleBase.NotificationCallbackDelegate NotificationCallback = NotificationCallbackImpl;
 
-        [NativeCallback(typeof(CollectionHandleBase.NotificationCallbackDelegate))]
-        private static void NotificationCallbackImpl(IntPtr managedResultsHandle, IntPtr changes, IntPtr exception)
+        [NativeCallback(typeof(NotifiableObjectHandleBase.NotificationCallbackDelegate))]
+        private static void NotificationCallbackImpl(IntPtr managedHandle, IntPtr changes, IntPtr exception)
         {
-            var results = (Interface)GCHandle.FromIntPtr(managedResultsHandle).Target;
-            results.NotifyCallbacks(new PtrTo<CollectionHandleBase.CollectionChangeSet>(changes).Value, new PtrTo<NativeException>(exception).Value);
+            var notifiable = (INotifiable)GCHandle.FromIntPtr(managedHandle).Target;
+            notifiable.NotifyCallbacks(new PtrTo<NotifiableObjectHandleBase.CollectionChangeSet>(changes).Value, new PtrTo<NativeException>(exception).Value);
         }
     }
 }

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -89,7 +89,6 @@
     <Compile Include="Handles\UnownedRealmHandle.cs" />
     <Compile Include="Linq\ExpressionVisitor.cs" />
     <Compile Include="Linq\IRealmCollection.cs" />
-    <Compile Include="Linq\RealmCollectionNativeHelper.cs" />
     <Compile Include="Linq\RealmResults.cs" />
     <Compile Include="Linq\RealmResultsProvider.cs" />
     <Compile Include="Linq\RealmResultsVisitor.cs" />
@@ -118,6 +117,8 @@
     <Compile Include="Thread Handover\ThreadSafeReference.cs" />
     <Compile Include="Handles\ThreadSafeReferenceHandle.cs" />
     <Compile Include="Handles\IThreadConfinedHandle.cs" />
+    <Compile Include="Handles\NotifiableObjectHandleBase.cs" />
+    <Compile Include="NotificationsHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 namespace Realms
 {
     internal abstract class RealmCollectionBase<T> 
-        : RealmCollectionNativeHelper.Interface, 
+        : NotificationsHelper.INotifiable, 
           IRealmCollection<T>, 
           INotifyCollectionChanged, 
           INotifyPropertyChanged,
@@ -158,7 +158,7 @@ namespace Realms
 
             var managedResultsHandle = GCHandle.Alloc(this);
             var token = new NotificationTokenHandle(Handle.Value);
-            var tokenHandle = Handle.Value.AddNotificationCallback(GCHandle.ToIntPtr(managedResultsHandle), RealmCollectionNativeHelper.NotificationCallback);
+            var tokenHandle = Handle.Value.AddNotificationCallback(GCHandle.ToIntPtr(managedResultsHandle), NotificationsHelper.NotificationCallback);
 
             token.SetHandle(tokenHandle);
 
@@ -302,7 +302,7 @@ namespace Realms
 
         #endregion
 
-        void RealmCollectionNativeHelper.Interface.NotifyCallbacks(CollectionHandleBase.CollectionChangeSet? changes, NativeException? exception)
+        void NotificationsHelper.INotifiable.NotifyCallbacks(NotifiableObjectHandleBase.CollectionChangeSet? changes, NativeException? exception)
         {
             var managedException = exception?.Convert();
             ChangeSet changeset = null;

--- a/Realm/Realm/Transaction.cs
+++ b/Realm/Realm/Transaction.cs
@@ -48,16 +48,7 @@ namespace Realms
                 return;
             }
 
-            // var exceptionOccurred = Marshal.GetExceptionPointers() != IntPtr.Zero || Marshal.GetExceptionCode() != 0;
-            var exceptionOccurred = true; // TODO: Can we find this out on iOS? Otherwise, we have to remove it!
-            if (exceptionOccurred)
-            {
-                Rollback();
-            }
-            else
-            {
-                Commit();
-            }
+            Rollback();
         }
 
         /// <summary>
@@ -73,6 +64,7 @@ namespace Realms
 
             _realm.SharedRealmHandle.CancelTransaction();
             _isOpen = false;
+            _realm.DrainTransactionQueue();
         }
 
         /// <summary>
@@ -88,6 +80,7 @@ namespace Realms
 
             _realm.SharedRealmHandle.CommitTransaction();
             _isOpen = false;
+            _realm.DrainTransactionQueue();
         }
     }
 }

--- a/Tests/Tests.Shared/PropertyChangedTests.cs
+++ b/Tests/Tests.Shared/PropertyChangedTests.cs
@@ -269,6 +269,9 @@ namespace IntegrationTests
         }
 
         [Test]
+#if WINDOWS
+        [Ignore("ExtenrnalCommitHelper hangs on Windows in this test. Reenable when we have proper condvar.")]
+#endif
         public void MultipleManagedObjects()
         {
             var firstNotifiedPropertyNames = new List<string>();

--- a/Tests/Tests.XamarinIOS/Tests.XamarinIOS.csproj
+++ b/Tests/Tests.XamarinIOS/Tests.XamarinIOS.csproj
@@ -163,14 +163,12 @@
     </NativeReference>
   </ItemGroup>
   <Import Project="..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets')" />
-  <UsingTask 
-		TaskName="RealmBuildTasks.WeaveRealmAssembly" 
-		AssemblyFile="$(SolutionDir)Weaver\Realm.BuildTasks\bin\$(Configuration)\Realm.BuildTasks.dll" />
+  <UsingTask TaskName="RealmBuildTasks.WeaveRealmAssembly" AssemblyFile="$(SolutionDir)Weaver\Realm.BuildTasks\bin\$(Configuration)\Realm.BuildTasks.dll" />
   <Target Name="WeaveRealmAssemblyTarget" BeforeTargets="_CompileToNative">
     <ItemGroup>
       <FilteredReferences Include="@(ReferencePath)" Condition="('%(Filename)%(Extension)' == 'Realm.dll') Or ('%(Filename)%(Extension)' == 'Realm.Sync.dll')" />
-      <ReferencePath Include="$(OutputPath)Realm.dll" Condition="Exists('$(OutputPath)Realm.dll')"/>
-      <ReferencePath Include="$(OutputPath)Realm.Sync.dll" Condition="Exists('$(OutputPath)Realm.Sync.dll')"/>
+      <ReferencePath Include="$(OutputPath)Realm.dll" Condition="Exists('$(OutputPath)Realm.dll')" />
+      <ReferencePath Include="$(OutputPath)Realm.Sync.dll" Condition="Exists('$(OutputPath)Realm.Sync.dll')" />
       <ReferencePath Remove="@(FilteredReferences)" />
       <ReferenceCopyLocalPaths Remove="@(FilteredReferences)" />
     </ItemGroup>

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -23,8 +23,8 @@
 #include "realm_export_decls.hpp"
 #include "wrapper_exceptions.hpp"
 #include "object_accessor.hpp"
-#include "collection_cs.hpp"
 #include "object-store/src/thread_safe_reference.hpp"
+#include "notifications_cs.hpp"
 
 using namespace realm;
 using namespace realm::binding;

--- a/wrappers/src/notifications_cs.hpp
+++ b/wrappers/src/notifications_cs.hpp
@@ -62,49 +62,51 @@ namespace realm {
         return -1;
     }
     
-    inline ManagedNotificationTokenContext* subscribe_for_notifications(void* managed_object, ManagedNotificationCallback callback, std::function<NotificationToken(CollectionChangeCallback)> subscriber, ObjectSchema* schema = nullptr)
+    static void handle_changes(ManagedNotificationTokenContext* context, CollectionChangeSet changes, std::exception_ptr e) {
+        if (e) {
+            try {
+                std::rethrow_exception(e);
+            } catch (...) {
+                auto exception = convert_exception();
+                auto marshallable_exception = exception.for_marshalling();
+                context->callback(context->managed_object, nullptr, &marshallable_exception);
+            }
+        } else if (changes.empty()) {
+            context->callback(context->managed_object, nullptr, nullptr);
+        } else {
+            std::vector<size_t> deletions(changes.deletions.as_indexes().begin(), changes.deletions.as_indexes().end());
+            std::vector<size_t> insertions(changes.insertions.as_indexes().begin(), changes.insertions.as_indexes().end());
+            std::vector<size_t> modifications(changes.modifications.as_indexes().begin(), changes.modifications.as_indexes().end());
+            
+            std::vector<size_t> properties;
+            
+            for (size_t i = 0; i < changes.columns.size(); i++) {
+                if (!changes.columns[i].empty()) {
+                    properties.emplace_back(get_property_index(context->schema, i));
+                }
+            }
+            
+            MarshallableCollectionChangeSet marshallable_changes {
+                { deletions.data(), deletions.size() },
+                { insertions.data(), insertions.size() },
+                { modifications.data(), modifications.size() },
+                { changes.moves.data(), changes.moves.size() },
+                { properties.data(), properties.size() }
+            };
+            
+            context->callback(context->managed_object, &marshallable_changes, nullptr);
+        }
+    }
+
+    template<typename Subscriber>
+    inline ManagedNotificationTokenContext* subscribe_for_notifications(void* managed_object, ManagedNotificationCallback callback, Subscriber subscriber, ObjectSchema* schema = nullptr)
     {
         auto context = new ManagedNotificationTokenContext();
         context->managed_object = managed_object;
         context->callback = callback;
         context->schema = schema;
         context->token = subscriber([context](CollectionChangeSet changes, std::exception_ptr e) {
-            if (e) {
-                try {
-                    std::rethrow_exception(e);
-                } catch (...) {
-                    auto exception = convert_exception();
-                    auto marshallable_exception = exception.for_marshalling();
-                    context->callback(context->managed_object, nullptr, &marshallable_exception);
-                }
-            } else if (changes.empty()) {
-                context->callback(context->managed_object, nullptr, nullptr);
-            } else {
-                std::vector<size_t> deletions(changes.deletions.as_indexes().begin(), changes.deletions.as_indexes().end());
-                std::vector<size_t> insertions(changes.insertions.as_indexes().begin(), changes.insertions.as_indexes().end());
-                std::vector<size_t> modifications(changes.modifications.as_indexes().begin(), changes.modifications.as_indexes().end());
-                
-                std::vector<size_t> properties;
-                
-                for (size_t i = 0; i < changes.columns.size(); i++) {
-                    if (!changes.columns[i].empty()) {
-                        for (auto c : changes.columns[i]) {
-                            auto b = c;
-                        }
-                        properties.emplace_back(get_property_index(context->schema, i));
-                    }
-                }
-                
-                MarshallableCollectionChangeSet marshallable_changes {
-                    { deletions.data(), deletions.size() },
-                    { insertions.data(), insertions.size() },
-                    { modifications.data(), modifications.size() },
-                    { changes.moves.data(), changes.moves.size() },
-                    { properties.data(), properties.size() }
-                };
-                
-                context->callback(context->managed_object, &marshallable_changes, nullptr);
-            }
+            handle_changes(context, changes, e);
         });
         
         return context;

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -24,6 +24,7 @@
 #include "timestamp_helpers.hpp"
 #include "object_cs.hpp"
 #include "object-store/src/thread_safe_reference.hpp"
+#include "notifications_cs.hpp"
 
 using namespace realm;
 using namespace realm::binding;
@@ -264,8 +265,6 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_link(column_ndx, target_object.row().get_index());
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -276,8 +275,6 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().nullify_link(column_ndx);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -291,8 +288,6 @@ extern "C" {
                 throw std::invalid_argument("Column is not nullable");
             
             object.row().set_null(column_ndx);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -316,8 +311,6 @@ extern "C" {
             }
             
             object.row().set_null_unique(column_ndx);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -327,8 +320,6 @@ extern "C" {
             verify_can_set(object);
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_bool(column_ndx, size_t_to_bool(value));
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -339,8 +330,6 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_int(column_ndx, value);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -362,8 +351,6 @@ extern "C" {
             }
             
             object.row().set_int_unique(column_ndx, value);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -374,8 +361,6 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_float(column_ndx, value);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -385,8 +370,6 @@ extern "C" {
             verify_can_set(object);
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_double(column_ndx, value);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -398,8 +381,6 @@ extern "C" {
             const size_t column_ndx = get_column_index(object, property_ndx);
             Utf16StringAccessor str(value, value_len);
             object.row().set_string(column_ndx, str);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -422,8 +403,6 @@ extern "C" {
             }
             
             object.row().set_string_unique(column_ndx, str);
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -434,8 +413,6 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_binary(column_ndx, BinaryData(value, value_len));
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -446,8 +423,6 @@ extern "C" {
             
             const size_t column_ndx = get_column_index(object, property_ndx);
             object.row().set_timestamp(column_ndx, from_ticks(value));
-            
-            notify_changes(object, property_ndx);
         });
     }
     
@@ -461,13 +436,7 @@ extern "C" {
             verify_can_set(object);
             
             auto const row_index = object.row().get_index();
-            auto const table_index = object.row().get_table()->get_index_in_group();
             object.row().get_table()->move_last_over(row_index);
-            
-            if (realm->m_binding_context != nullptr) {
-                auto const& csharp_context = static_cast<binding::CSharpBindingContext*>(object.realm()->m_binding_context.get());
-                csharp_context->notify_removed(row_index, table_index);
-            }
         });
     }
     
@@ -482,6 +451,24 @@ extern "C" {
     {
         return handle_errors(ex, [&]() {
             return new ThreadSafeReference<Object>{object.realm()->obtain_thread_safe_reference(object)};
+        });
+    }
+    
+    REALM_EXPORT void* object_destroy_notificationtoken(ManagedNotificationTokenContext* token_ptr, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [&]() {
+            void* managed_collection = token_ptr->managed_object;
+            delete token_ptr;
+            return managed_collection;
+        });
+    }
+    
+    REALM_EXPORT ManagedNotificationTokenContext* object_add_notification_callback(Object* object, void* managed_object, ManagedNotificationCallback callback, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [=]() {
+            return subscribe_for_notifications(managed_object, callback, [object](CollectionChangeCallback callback) {
+                return object->add_notification_block(callback);
+            }, new ObjectSchema(object->get_object_schema()));
         });
     }
     

--- a/wrappers/src/object_cs.hpp
+++ b/wrappers/src/object_cs.hpp
@@ -46,11 +46,4 @@ namespace realm {
     inline size_t get_column_index(const Object& object, const size_t property_index) {
         return object.get_object_schema().persisted_properties[property_index].table_column;
     }
-    
-    inline void notify_changes(const Object& object, const size_t property_index) {
-        if (object.realm()->m_binding_context != nullptr) {
-            auto const& csharp_context = static_cast<binding::CSharpBindingContext*>(object.realm()->m_binding_context.get());
-            csharp_context->notify_change(object.row().get_index(), object.row().get_table()->get_index_in_group(), property_index);
-        }
-    }
 }

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -20,12 +20,12 @@
 #include <realm.hpp>
 #include "error_handling.hpp"
 #include "marshalling.hpp"
-#include "collection_cs.hpp"
 #include "realm_export_decls.hpp"
 #include "results.hpp"
 #include "object_accessor.hpp"
 #include "wrapper_exceptions.hpp"
 #include "object-store/src/thread_safe_reference.hpp"
+#include "notifications_cs.hpp"
 
 using namespace realm;
 using namespace realm::binding;
@@ -92,15 +92,6 @@ REALM_EXPORT ManagedNotificationTokenContext* results_add_notification_callback(
     });
 }
 
-REALM_EXPORT void* collection_destroy_notificationtoken(ManagedNotificationTokenContext* token_ptr, NativeException::Marshallable& ex)
-{
-    return handle_errors(ex, [&]() {
-        void* managed_collection = token_ptr->managed_collection;
-        delete token_ptr;
-        return managed_collection;
-    });
-}
-    
 REALM_EXPORT Query* results_get_query(Results* results_ptr, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -51,52 +51,17 @@ struct Configuration
 namespace realm {
 namespace binding {
     
-    struct ObservedObjectDetails {
-        ObservedObjectDetails(const ObjectSchema& schema, void* managed_object_handle) : schema(schema), managed_object_handle(managed_object_handle) {}
-
-        const ObjectSchema& schema;
-        void* managed_object_handle;
-    };
-    
     class CSharpBindingContext: public BindingContext {
     public:
         CSharpBindingContext(void* managed_state_handle);
         void did_change(std::vector<CSharpBindingContext::ObserverState> const& observed, std::vector<void*> const& invalidated, bool version_changed) override;
-        void add_observed_row(const Object& object, void* managed_object_handle);
-        void remove_observed_row(void* managed_object_handle);
-        void notify_change(const size_t row_ndx, const size_t table_ndx, const size_t property_index);
-        void notify_removed(const size_t row_ndx, const size_t table_ndx);
         
         void* get_managed_state_handle()
         {
             return m_managed_state_handle;
         }
-        
-        std::vector<CSharpBindingContext::ObserverState> get_observed_rows() override
-        {
-            return m_observed_rows;
-        }
-
-        ~CSharpBindingContext();
     private:
         void* m_managed_state_handle;
-        std::vector<BindingContext::ObserverState> m_observed_rows;
-
-        inline void remove_observed_rows(std::function<bool (const BindingContext::ObserverState*, const ObservedObjectDetails*)> filter)
-        {
-            if (!m_observed_rows.empty()) {
-                for (auto it = m_observed_rows.begin(); it != m_observed_rows.end();) {
-                    auto const& details = static_cast<ObservedObjectDetails*>(it->info);
-                    if (filter(&*it, details)) {
-                        delete(details);
-                        it = m_observed_rows.erase(it);
-                    } else {
-                        ++it;
-                    }
-                    
-                }
-            }
-        }
     };
 }
     

--- a/wrappers/wrappers.xcodeproj/project.pbxproj
+++ b/wrappers/wrappers.xcodeproj/project.pbxproj
@@ -109,7 +109,7 @@
 		48ED7C5D1C16F9C200AF23A4 /* realm_error_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = realm_error_type.hpp; path = src/realm_error_type.hpp; sourceTree = "<group>"; };
 		48ED7C5E1C16F9C200AF23A4 /* realm_export_decls.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = realm_export_decls.hpp; path = src/realm_export_decls.hpp; sourceTree = "<group>"; };
 		48ED7C5F1C16F9C200AF23A4 /* realm-csharp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "realm-csharp.cpp"; path = "src/realm-csharp.cpp"; sourceTree = "<group>"; };
-		48ED7C621C16F9C200AF23A4 /* collection_cs.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = collection_cs.hpp; path = src/collection_cs.hpp; sourceTree = "<group>"; };
+		48ED7C621C16F9C200AF23A4 /* notifications_cs.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = notifications_cs.hpp; path = src/notifications_cs.hpp; sourceTree = "<group>"; };
 		48ED7C631C16F9C200AF23A4 /* shared_realm_cs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = shared_realm_cs.cpp; path = src/shared_realm_cs.cpp; sourceTree = "<group>"; };
 		48ED7C641C16F9C200AF23A4 /* table_cs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = table_cs.cpp; path = src/table_cs.cpp; sourceTree = "<group>"; };
 		48EE96C51D75D60600666046 /* schema_cs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = schema_cs.cpp; path = src/schema_cs.cpp; sourceTree = "<group>"; };
@@ -217,7 +217,7 @@
 				48EE96C71D75D60F00666046 /* schema_cs.hpp */,
 				51A51F251DAEB5660057BAE6 /* object_cs.cpp */,
 				519B58381DB0F8E7000CB2BB /* object_cs.hpp */,
-				48ED7C621C16F9C200AF23A4 /* collection_cs.hpp */,
+				48ED7C621C16F9C200AF23A4 /* notifications_cs.hpp */,
 				8510C5001D3D1194000CAD87 /* shared_realm_cs.hpp */,
 				48ED7C631C16F9C200AF23A4 /* shared_realm_cs.cpp */,
 				48ED7C641C16F9C200AF23A4 /* table_cs.cpp */,


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

This is a POC of using the new object notifications API from OS. There are two breaking changes compared to our old approach:

- You can't subscribe for notifications during a write transaction. That means that if you open a page with an ongoing transaction (like we do with the quickjournal), you won't be able to subscribe for notifications until the transaction is committed.
- You don't get notifications until a write transaction is committed. Previously, we would send notifications to same-thread subscribers as soon as the change is made. This means that if you subscribe on the main thread and then start manipulating realm objects there, the UI will be updated only after the transaction has completed.

These may or may not be a deal breaker. The huge benefit we get from that approach is the radically simplified notifications code as well as (hopefully) fixing all those annoying deleting subscriber while sending notifications race conditions.

##  TODO

* [x] Changelog entry