### PR TITLE
fix a leak when marshalling strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ If you encounter any issues after the upgrade, we recommend clearing the `bin` a
 - Fixes the `RemoveAll(string)` overload to work correctly. (#1288)
 - Resolved an issue that would lead to crashes when refreshing the token for an invalid session. (#1289)
 - The `IObservable` returned from `session.GetProgressObservable` will correctly call `OnComplete` when created with `mode: ProgressMode.ForCurrentlyOutstandingWork`. (#1292)
+- Fixed a memory leak when accessing string properties. (#1318)
 
 ### Enhancements
 - Introduce APIs for safely passing objects between threads. Create a thread-safe reference to a thread-confined object by passing it to the `ThreadSafeReference.Create` factory method, which you can then safely pass to another thread to resolve in the new realm with `Realm.ResolveReference`. (#1300)


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes #1312

##  TODO

* [x] Changelog entry
* [ ] ~Tests (if applicable)~ - Tested manually
