### PR TITLE
Fix NRE due to weak gchandle

### DIFF
--- a/Realm/Realm/NotificationsHelper.cs
+++ b/Realm/Realm/NotificationsHelper.cs
@@ -34,8 +34,11 @@ namespace Realms
         [NativeCallback(typeof(NotifiableObjectHandleBase.NotificationCallbackDelegate))]
         private static void NotificationCallbackImpl(IntPtr managedHandle, IntPtr changes, IntPtr exception)
         {
-            var notifiable = (INotifiable)GCHandle.FromIntPtr(managedHandle).Target;
-            notifiable.NotifyCallbacks(new PtrTo<NotifiableObjectHandleBase.CollectionChangeSet>(changes).Value, new PtrTo<NativeException>(exception).Value);
+            var notifiable = GCHandle.FromIntPtr(managedHandle).Target as INotifiable;
+            if (notifiable != null)
+            {
+                notifiable.NotifyCallbacks(new PtrTo<NotifiableObjectHandleBase.CollectionChangeSet>(changes).Value, new PtrTo<NativeException>(exception).Value);
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

GCHandles for RealmObjects are weak so we may receive notifications for collected object.