### PR TITLE
Remove dependency on runtimeinformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------
 
 ### Bug fixes
+- Fixed an issue where `EntryPointNotFoundException` would be thrown on some Android devices. (#1336)
 
 ### Enhancements
 

--- a/NuGet/Realm.Database/Realm.Database.nuspec
+++ b/NuGet/Realm.Database/Realm.Database.nuspec
@@ -24,16 +24,7 @@
         <dependency id="Fody" version="1.29.4"/>
         <dependency id="Realm.DataBinding" version="1.0.0"/>
         <dependency id="DotNetCross.Memory.Unsafe" version="0.2.2"/>
-        <dependency id="Remotion.Linq" version="2.1.1"/>
-        <dependency id="System.Console" version="4.3.0"/>
-        <dependency id="System.Diagnostics.Tools" version="4.3.0"/>
-        <dependency id="System.Dynamic.Runtime" version="4.3.0"/>
-        <dependency id="System.Globalization" version="4.3.0"/>
-        <dependency id="System.IO.FileSystem" version="4.3.0"/>
-        <dependency id="System.Reflection.Primitives" version="4.3.0"/>
-        <dependency id="System.Reflection.TypeExtensions" version="4.3.0"/>
-        <dependency id="System.Runtime.InteropServices" version="4.3.0"/>
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0"/>
+        <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
     </dependencies>
   </metadata>

--- a/NuGet/Realm.Database/Realm.Database.nuspec
+++ b/NuGet/Realm.Database/Realm.Database.nuspec
@@ -24,6 +24,7 @@
         <dependency id="Fody" version="1.29.4"/>
         <dependency id="Realm.DataBinding" version="1.0.0"/>
         <dependency id="DotNetCross.Memory.Unsafe" version="0.2.2"/>
+        <dependency id="Remotion.Linq" version="2.1.1"/>
         <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
     </dependencies>

--- a/NuGet/Realm/Realm.nuspec
+++ b/NuGet/Realm/Realm.nuspec
@@ -22,9 +22,6 @@
       <group targetFramework="netstandard1.4">
         <dependency id="Realm.Database" version="$version$"/>
         <dependency id="Newtonsoft.Json" version="9.0.1"/>
-        <dependency id="System.Collections.Concurrent" version="4.3.0"/>
-        <dependency id="System.Net.Http" version="4.3.0"/>
-        <dependency id="System.Threading.Timer" version="4.3.0"/>
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Looks like RuntimeInformation is fairly unreliable - revert back to the reflection and `Environment.OsVersion` approach.

Fixes #1335

##  TODO

* [x] Changelog entry
