### PR TITLE
Fix crash when querying [MapTo]-ed columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Enhancements
 
 ### Bug fixes
+- Fix a crash when querying over properties that have `[MapTo]` applied. ([#1405](https://github.com/realm/realm-dotnet/pull/1405))
 
 ### Breaking Changes
 

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Realms</RootNamespace>
     <AssemblyName>Realm</AssemblyName>
-    <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
+    <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <DocumentationFile>bin\$(Configuration)\Realm.xml</DocumentationFile>
   </PropertyGroup>

--- a/Tests/Tests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Tests/Tests.Shared/RealmResults/SimpleLINQtests.cs
@@ -947,8 +947,8 @@ namespace Tests.Database
         {
             var objs = MakeThreeMappedObjects();
 
-            Assert.That(objs.Where(o => o.Name.StartsWith("p", StringComparison.OrdinalIgnoreCase)).Count(), Is.EqualTo(2));
-            Assert.That(objs.Where(o => o.Id > 2), Is.EqualTo(1));
+            Assert.That(objs.Count(o => o.Name.StartsWith("p", StringComparison.OrdinalIgnoreCase)), Is.EqualTo(2));
+            Assert.That(objs.Count(o => o.Id > 2), Is.EqualTo(1));
         }
 
         [Test]

--- a/Tests/Tests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Tests/Tests.Shared/RealmResults/SimpleLINQtests.cs
@@ -364,7 +364,7 @@ namespace Tests.Database
             Assert.That(equality.Length, Is.EqualTo(1));
             Assert.That(equality[0].FullName, Is.EqualTo("John Doe"));
         }
-       
+
         [Test]
         public void SearchComparingInstanceProperties()
         {
@@ -596,7 +596,7 @@ namespace Tests.Database
 
             var regularQuery = _realm.All<IntPrimaryKeyWithValueObject>().Where(o => o.StringValue.Like(pattern, caseSensitive));
             var negatedQuery = _realm.All<IntPrimaryKeyWithValueObject>().Where(o => !o.StringValue.Like(pattern, caseSensitive));
-            
+
             if (expected)
             {
                 Assert.That(regularQuery.Count(), Is.EqualTo(1));
@@ -940,6 +940,61 @@ namespace Tests.Database
             Assert.That(hasJohnSmith, Is.False);
         }
 
+        #region [MapTo] Test cases
+
+        [Test]
+        public void Where_WhenPropertyIsMappedTo_FiltersCorrectly()
+        {
+            var objs = MakeThreeMappedObjects();
+
+            Assert.That(objs.Where(o => o.Name.StartsWith("p", StringComparison.OrdinalIgnoreCase)).Count(), Is.EqualTo(2));
+            Assert.That(objs.Where(o => o.Id > 2), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void OrderBy_WhenPropertyIsMappedTo_OrderdsCorrectly()
+        {
+            var objs = MakeThreeMappedObjects();
+
+            var objsById = objs.OrderByDescending(o => o.Id).ToArray().Select(o => o.Id);
+
+            Assert.That(objsById, Is.EqualTo(new[] { 3, 2, 1 }));
+
+            var objsByName = objs.OrderBy(o => o.Name).ToArray().Select(o => o.Id);
+
+            Assert.That(objsByName, Is.EqualTo(new[] { 3, 2, 1 }));
+        }
+
+        #endregion
+
+        private IQueryable<RemappedPropertiesObject> MakeThreeMappedObjects()
+        {
+            _realm.Write(() =>
+            {
+                _realm.RemoveAll<RemappedPropertiesObject>();
+
+                _realm.Add(new RemappedPropertiesObject
+                {
+                    Id = 1,
+                    Name = "Peter"
+                });
+
+                _realm.Add(new RemappedPropertiesObject
+                {
+                    Id = 2,
+                    Name = "Patrick"
+                });
+
+                _realm.Add(new RemappedPropertiesObject
+                {
+                    Id = 3,
+                    Name = "George"
+                });
+            });
+
+            return _realm.All<RemappedPropertiesObject>();
+        }
+
         private void MakeThreePatricks()
         {
             _realm.Write(() =>
@@ -980,7 +1035,7 @@ namespace Tests.Database
         private class InstanceConstants
         {
             public readonly long SixtyThousandField = 60000;
-           
+
             public long SixtyThousandProperty { get; } = 60000;
         }
     }

--- a/Tests/Tests.Shared/TestObjects.cs
+++ b/Tests/Tests.Shared/TestObjects.cs
@@ -166,7 +166,7 @@ namespace Tests
 
         public string PublicMethod()
         {
-            return null; 
+            return null;
         }
 
         [Ignored]
@@ -236,5 +236,16 @@ namespace Tests
 
         [Backlink(nameof(Parent))]
         public IQueryable<RecursiveBacklinksObject> Children { get; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class RemappedPropertiesObject : RealmObject
+    {
+        [PrimaryKey]
+        [MapTo("id")]
+        public int Id { get; set; }
+
+        [MapTo("name")]
+        public string Name { get; set; }
     }
 }


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes #1404

Ignore the first commit - it's only cosmetic changes. Here's the actual change: https://github.com/realm/realm-dotnet/pull/1405/files/4ae2fadabfaa861a53f26162f0dfd4b6624905e3..9311aea824d449ab7433e6f3764ace81d18a5284

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
