### PR TITLE
Execute migrations on a background thread when opening a local realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - `ApplyPermissions`, `OfferPermissions`, and `AcceptPermissionOffer` allow you to grant, revoke, offer, and accept permissions.
   - `GetPermissionOffers`, `GetPermissionOfferResponses`, and `GetPermissionChanges` allow you to review objects, added via the above mentioned methods.
   - `GetGrantedPermissions` allows you to inspect permissions granted to or by the current user.
+- When used with `RealmConfiguration` (i.e. local Realm), `Realm.GetInstanceAsync` will perform potentially costly operation, such as executing migrations or compaction on a background thread. ([#1406](https://github.com/realm/realm-dotnet/pull/1406))
 
 ### Bug fixes
 - Fix a crash when querying over properties that have `[MapTo]` applied. ([#1405](https://github.com/realm/realm-dotnet/pull/1405))

--- a/Realm/Realm/RealmConfiguration.cs
+++ b/Realm/Realm/RealmConfiguration.cs
@@ -190,7 +190,9 @@ namespace Realms
                 // This doesn't use await, because MTouch crashes with MT2091 at a completely unrelated location.
                 return Task.Run(() =>
                 {
-                    CreateRealm(schema);
+                    using (CreateRealm(schema))
+                    {
+                    }
                 }).ContinueWith(t =>
                 {
                     return CreateRealm(schema);

--- a/Tests/Tests.Shared/InstanceTests.cs
+++ b/Tests/Tests.Shared/InstanceTests.cs
@@ -624,7 +624,7 @@ namespace Tests.Database
                      }, TaskScheduler.FromCurrentSynchronizationContext());
 
                 var ticks = 0;
-                while (!hasCompletedMigration)
+                while (realm == null)
                 {
                     await Task.Delay(100);
                     ticks++;

--- a/Tests/Tests.Shared/InstanceTests.cs
+++ b/Tests/Tests.Shared/InstanceTests.cs
@@ -583,7 +583,7 @@ namespace Tests.Database
             AsyncContext.Run(async () =>
             {
                 Realm realm = null;
-                var config = new RealmConfiguration(SpecialRealmName)
+                var config = new RealmConfiguration("asyncmigration.realm")
                 {
                     SchemaVersion = 1,
                 };

--- a/Tests/Tests.Shared/InstanceTests.cs
+++ b/Tests/Tests.Shared/InstanceTests.cs
@@ -330,9 +330,9 @@ namespace Tests.Database
         }
 
         [Test]
-        #if !WINDOWS
+#if !WINDOWS
         [Ignore("Compact works on this platform")]
-        #endif
+#endif
         public void ShouldCompactOnLaunch_OnWindows_ThrowsRealmException()
         {
             var config = new RealmConfiguration
@@ -574,6 +574,79 @@ namespace Tests.Database
                 }
 
                 other.Dispose();
+            });
+        }
+
+        [Test]
+        public void GetInstanceAsync_ExecutesMigrationsInBackground()
+        {
+            AsyncContext.Run(async () =>
+            {
+                Realm realm = null;
+                var config = new RealmConfiguration("GetInstanceAsync.realm")
+                {
+                    SchemaVersion = 1,
+                };
+
+                Realm.DeleteRealm(config);
+
+                try
+                {
+                    using (var firstRealm = Realm.GetInstance(config))
+                    {
+                        Assert.That(firstRealm.All<IntPrimaryKeyWithValueObject>().Count(), Is.Zero);
+                    }
+
+                    var threadId = Environment.CurrentManagedThreadId;
+                    var hasCompletedMigration = false;
+                    config.SchemaVersion = 2;
+                    config.MigrationCallback = (migration, oldSchemaVersion) =>
+                    {
+                        Assert.That(Environment.CurrentManagedThreadId, Is.Not.EqualTo(threadId));
+                        Thread.Sleep(300);
+                        migration.NewRealm.Add(new IntPrimaryKeyWithValueObject
+                        {
+                            Id = 123
+                        });
+                        hasCompletedMigration = true;
+                    };
+
+                    Exception ex = null;
+                    Realm.GetInstanceAsync(config)
+                         .ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            ex = t.Exception;
+                        }
+                        else
+                        {
+                            realm = t.Result;
+                        }
+                    }, TaskScheduler.FromCurrentSynchronizationContext());
+
+                    var ticks = 0;
+                    while (!hasCompletedMigration)
+                    {
+                        await Task.Delay(100);
+                        ticks++;
+
+                        if (ticks > 10)
+                        {
+                            Assert.Fail("Migration should have completed by now.");
+                        }
+                    }
+
+                    Assert.That(ex, Is.Null);
+                    Assert.That(hasCompletedMigration);
+                    Assert.That(ticks, Is.GreaterThanOrEqualTo(3));
+                    Assert.That(realm.All<IntPrimaryKeyWithValueObject>().Count(), Is.EqualTo(1));
+                }
+                finally
+                {
+                    realm?.Dispose();
+                    Realm.DeleteRealm(config);
+                }
             });
         }
 


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes #1400 

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)