### PR TITLE
Remove compiler workarounds

### DIFF
--- a/Realm/Realm.Sync/Handles/SharedRealmHandleExtensions.cs
+++ b/Realm/Realm.Sync/Handles/SharedRealmHandleExtensions.cs
@@ -69,9 +69,6 @@ namespace Realms.Sync
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool immediately_run_file_actions([MarshalAs(UnmanagedType.LPWStr)] string path, IntPtr path_len, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_reset_for_testing", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void reset_for_testing();
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncmanager_reconnect", CallingConvention = CallingConvention.Cdecl)]
             public static extern void reconnect();
 
@@ -141,9 +138,7 @@ namespace Realms.Sync
 
         public static void ResetForTesting(UserPersistenceMode? userPersistenceMode = null)
         {
-            // TODO: This should reference NativeCommon.reset_for_testing
-            // Due to mono compiler bug, it's copied to NativeMethods
-            NativeMethods.reset_for_testing();
+            NativeCommon.reset_for_testing();
             ConfigureFileSystem(userPersistenceMode, null, false);
         }
 

--- a/Realm/Realm/Native/Configuration.cs
+++ b/Realm/Realm/Native/Configuration.cs
@@ -34,10 +34,8 @@ namespace Realms.Native
     [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:AccessibleFieldsMustBeginWithUpperCaseLetter")]
     internal struct Configuration
     {
-        // TODO: make path private
-        // It's public due to mono compiler bug
         [MarshalAs(UnmanagedType.LPWStr)]
-        public string path;
+        private string path;
         private IntPtr path_len;
 
         internal string Path


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Removes a few workarounds introduced when the compiler had trouble with .NET standard packages.