### PR TITLE
Ensure tests always use temp filenames

### DIFF
--- a/Platform.PCL/Realm.Sync.PCL/UserPCL.cs
+++ b/Platform.PCL/Realm.Sync.PCL/UserPCL.cs
@@ -218,7 +218,7 @@ namespace Realms.Sync
         /// A queryable collection of <see cref="Permission"/> objects that provide detailed information
         /// regarding the granted access.
         /// </returns>
-        /// <param name="recipient">The optional recepient of the permission.</param>
+        /// <param name="recipient">The optional recipient of the permission.</param>
         /// <param name="millisecondTimeout">
         /// The timeout in milliseconds for downloading server changes. If the download times out, no error will be thrown
         /// and instead the latest local state will be returned. If set to 0, the latest state will be returned immediately.

--- a/Realm/Realm/RealmConfiguration.cs
+++ b/Realm/Realm/RealmConfiguration.cs
@@ -122,7 +122,6 @@ namespace Realms
 
         internal override Realm CreateRealm(RealmSchema schema)
         {
-
             var configuration = new Native.Configuration
             {
                 Path = DatabasePath,

--- a/Tests/Tests.Shared/ConfigurationTests.cs
+++ b/Tests/Tests.Shared/ConfigurationTests.cs
@@ -83,7 +83,7 @@ namespace Tests.Database
             // Assert
             Assert.That(Path.IsPathRooted(config.DatabasePath));
             Assert.That(config.DatabasePath, Does.EndWith(Path.Combine("Documents", "fred.realm")));
-            Assert.That(config.DatabasePath.Contains(".."), Is.False);  // our use of relative up and down again was normalised out
+            Assert.That(config.DatabasePath, Does.Not.Contain(".."));  // our use of relative up and down again was normalised out
         }
 
         [Test]

--- a/Tests/Tests.Shared/InstanceTests.cs
+++ b/Tests/Tests.Shared/InstanceTests.cs
@@ -604,7 +604,7 @@ namespace Tests.Database
                 config.MigrationCallback = (migration, oldSchemaVersion) =>
                 {
                     Assert.That(Environment.CurrentManagedThreadId, Is.Not.EqualTo(threadId));
-                    Thread.Sleep(300);
+                    Task.Delay(300).Wait();
                     migration.NewRealm.Add(new IntPrimaryKeyWithValueObject
                     {
                         Id = 123

--- a/Tests/Tests.Shared/LifetimeTests.cs
+++ b/Tests/Tests.Shared/LifetimeTests.cs
@@ -24,19 +24,13 @@ using Realms;
 namespace Tests.Database
 {
     [TestFixture, Preserve(AllMembers = true)]
-    public class LifetimeTests
+    public class LifetimeTests : RealmTest
     {
         // This method was extracted to ensure that the actual realm instance
         // isn't preserved in the scope of the test, even when the debugger is running.
         private static WeakReference GetWeakRealm()
         {
-            return new WeakReference(Realm.GetInstance("LifetimeTests.realm"));
-        }
-
-        [SetUp]
-        public void SetUp()
-        {
-            Realm.DeleteRealm(new RealmConfiguration("LifetimeTests.realm"));
+            return new WeakReference(Realm.GetInstance());
         }
 
         [Test]
@@ -73,7 +67,7 @@ namespace Tests.Database
         public void FinalizedRealmsShouldNotInvalidateSiblingRealms()
         {
             // Arrange
-            var realm = Realm.GetInstance("LifetimeTests.realm");
+            var realm = Realm.GetInstance(RealmConfiguration.DefaultConfiguration.DatabasePath);
             var realmThatWillBeFinalized = GetWeakRealm();
             Person person = null;
             realm.Write(() =>

--- a/Tests/Tests.Shared/NotificationTests.cs
+++ b/Tests/Tests.Shared/NotificationTests.cs
@@ -98,7 +98,7 @@ namespace Tests.Database
                 Console.SetError(sw);
                 _realm.NotifyError(new Exception());
 
-                Assert.That(sw.ToString(), Contains.Substring("exception").And.Contains("Realm.Error"));
+                Assert.That(sw.ToString(), Does.Contain("exception").And.Contains("Realm.Error"));
                 Console.SetError(original);
             }
         }

--- a/Tests/Tests.Shared/RealmResults/DisallowedPredicateParameters.cs
+++ b/Tests/Tests.Shared/RealmResults/DisallowedPredicateParameters.cs
@@ -26,7 +26,7 @@ using Realms;
 namespace Tests.Database
 {
     [TestFixture, Preserve(AllMembers = true)]
-    public class DisallowedPredicateParameters
+    public class DisallowedPredicateParameters : RealmTest
     {
         [Test]
         public void DisallowedPredicateParametersShouldThrow()

--- a/Tests/Tests.Shared/RealmResults/DisallowedPredicateParameters.cs
+++ b/Tests/Tests.Shared/RealmResults/DisallowedPredicateParameters.cs
@@ -31,26 +31,26 @@ namespace Tests.Database
         [Test]
         public void DisallowedPredicateParametersShouldThrow()
         {
-            var realm = Realm.GetInstance();
+            using (var realm = Realm.GetInstance())
+            {
+                var accessPublicField = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PublicField == null);
+                Assert.Throws<NotSupportedException>(() => accessPublicField.ToList());
 
-            var accessPublicField = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PublicField == null);
-            Assert.Throws<NotSupportedException>(() => accessPublicField.ToList());
+                var accessPublicMethod = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PublicMethod() == null);
+                Assert.Throws<NotSupportedException>(() => accessPublicMethod.ToList());
 
-            var accessPublicMethod = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PublicMethod() == null);
-            Assert.Throws<NotSupportedException>(() => accessPublicMethod.ToList());
+                var accessIgnoredProperty = realm.All<ClassWithUnqueryableMembers>().Where(c => c.IgnoredProperty == null);
+                Assert.Throws<NotSupportedException>(() => accessIgnoredProperty.ToList());
 
-            var accessIgnoredProperty = realm.All<ClassWithUnqueryableMembers>().Where(c => c.IgnoredProperty == null);
-            Assert.Throws<NotSupportedException>(() => accessIgnoredProperty.ToList());
+                var accessNonAutomaticProperty = realm.All<ClassWithUnqueryableMembers>().Where(c => c.NonAutomaticProperty == null);
+                Assert.Throws<NotSupportedException>(() => accessNonAutomaticProperty.ToList());
 
-            var accessNonAutomaticProperty = realm.All<ClassWithUnqueryableMembers>().Where(c => c.NonAutomaticProperty == null);
-            Assert.Throws<NotSupportedException>(() => accessNonAutomaticProperty.ToList());
+                var accessPropertyWithOnlyGet = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PropertyWithOnlyGet == null);
+                Assert.Throws<NotSupportedException>(() => accessPropertyWithOnlyGet.ToList());
 
-            var accessPropertyWithOnlyGet = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PropertyWithOnlyGet == null);
-            Assert.Throws<NotSupportedException>(() => accessPropertyWithOnlyGet.ToList());
-
-            var indirectAccess =
-                realm.All<ClassWithUnqueryableMembers>().Where(c => c.RealmObjectProperty.FirstName == null);
-            Assert.Throws<NotSupportedException>(() => indirectAccess.ToList());
+                var indirectAccess = realm.All<ClassWithUnqueryableMembers>().Where(c => c.RealmObjectProperty.FirstName == null);
+                Assert.Throws<NotSupportedException>(() => indirectAccess.ToList());
+            }
         }
     }
 }

--- a/Tests/Tests.Shared/RealmTest.cs
+++ b/Tests/Tests.Shared/RealmTest.cs
@@ -27,12 +27,18 @@ namespace Tests.Database
     {
         private bool _isSetup;
 
+        protected virtual bool OverrideDefaultConfig => true;
+
         [SetUp]
         public void SetUp()
         {
             if (!_isSetup)
             {
-                RealmConfiguration.DefaultConfiguration = new RealmConfiguration(Path.GetTempFileName());
+                if (OverrideDefaultConfig)
+                {
+                    RealmConfiguration.DefaultConfiguration = new RealmConfiguration(Path.GetTempFileName());
+                }
+
                 CustomSetUp();
                 _isSetup = true;
             }
@@ -50,6 +56,7 @@ namespace Tests.Database
                 CustomTearDown();
                 NativeCommon.reset_for_testing();
                 _isSetup = false;
+                Realm.DeleteRealm(RealmConfiguration.DefaultConfiguration);
             }
         }
 

--- a/Tests/Tests.Shared/StandAloneObjectTests.cs
+++ b/Tests/Tests.Shared/StandAloneObjectTests.cs
@@ -25,21 +25,14 @@ using Realms;
 namespace Tests.Database
 {
     [TestFixture, Preserve(AllMembers = true)]
-    public class StandAloneObjectTests
+    public class StandAloneObjectTests : RealmTest
     {
         private Person _person;
 
-        [SetUp]
-        public void SetUp()
+        protected override void CustomSetUp()
         {
             _person = new Person();
-            Realm.DeleteRealm(RealmConfiguration.DefaultConfiguration);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            NativeCommon.reset_for_testing();
+            base.CustomSetUp();
         }
 
         [Test]
@@ -67,11 +60,10 @@ namespace Tests.Database
 
             using (var realm = Realm.GetInstance())
             {
-                using (var transaction = realm.BeginWrite())
+                realm.Write(() =>
                 {
                     realm.Add(_person);
-                    transaction.Commit();
-                }
+                });
 
                 Assert.That(_person.IsManaged);
 


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description
On non-sandboxed environments (e.g. Windows, macOS, etc.), our tests operate in the same documents folder, so parallel builds often report false negatives.