### PR TITLE
Throw when trying to access a list/query in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix an exception being thrown when comparing non-constant character value in a query. ([#1471](https://github.com/realm/realm-dotnet/pull/1471))
 - Fix an exception being thrown when comparing non-constant byte or short value in a query. ([#1472](https://github.com/realm/realm-dotnet/pull/1472))
 - Fix a bug where calling the non-generic version of `IQueryProvider.CreateQuery` on Realm's IQueryable results, an exception would be thrown. ([#1487](https://github.com/realm/realm-dotnet/pull/1487))
+- Trying to use an `IList` or `IQueryable` property in a LINQ query will now throw `NotSupportedException` rather than crash the app. ([#1505](https://github.com/realm/realm-dotnet/pull/1505))
 
 ### Breaking Changes
 

--- a/Tests/Tests.Shared/RealmResults/DisallowedPredicateParameters.cs
+++ b/Tests/Tests.Shared/RealmResults/DisallowedPredicateParameters.cs
@@ -34,22 +34,36 @@ namespace Tests.Database
             using (var realm = Realm.GetInstance())
             {
                 var accessPublicField = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PublicField == null);
-                Assert.Throws<NotSupportedException>(() => accessPublicField.ToList());
+                Assert.That(() => accessPublicField.ToList(), Throws.TypeOf<NotSupportedException>());
 
                 var accessPublicMethod = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PublicMethod() == null);
-                Assert.Throws<NotSupportedException>(() => accessPublicMethod.ToList());
+                Assert.That(() => accessPublicMethod.ToList(), Throws.TypeOf<NotSupportedException>());
 
                 var accessIgnoredProperty = realm.All<ClassWithUnqueryableMembers>().Where(c => c.IgnoredProperty == null);
-                Assert.Throws<NotSupportedException>(() => accessIgnoredProperty.ToList());
+                Assert.That(() => accessIgnoredProperty.ToList(), Throws.TypeOf<NotSupportedException>());
 
                 var accessNonAutomaticProperty = realm.All<ClassWithUnqueryableMembers>().Where(c => c.NonAutomaticProperty == null);
-                Assert.Throws<NotSupportedException>(() => accessNonAutomaticProperty.ToList());
+                Assert.That(() => accessNonAutomaticProperty.ToList(), Throws.TypeOf<NotSupportedException>());
 
                 var accessPropertyWithOnlyGet = realm.All<ClassWithUnqueryableMembers>().Where(c => c.PropertyWithOnlyGet == null);
-                Assert.Throws<NotSupportedException>(() => accessPropertyWithOnlyGet.ToList());
+                Assert.That(() => accessPropertyWithOnlyGet.ToList(), Throws.TypeOf<NotSupportedException>());
 
                 var indirectAccess = realm.All<ClassWithUnqueryableMembers>().Where(c => c.RealmObjectProperty.FirstName == null);
-                Assert.Throws<NotSupportedException>(() => indirectAccess.ToList());
+                Assert.That(() => indirectAccess.ToList(), Throws.TypeOf<NotSupportedException>());
+
+                var listAccess = realm.All<ClassWithUnqueryableMembers>().Where(c => c.RealmListProperty != null);
+                Assert.That(() => listAccess.ToArray(), Throws.TypeOf<NotSupportedException>());
+
+                var person = new Person();
+                var listContains = realm.All<ClassWithUnqueryableMembers>().Where(c => c.RealmListProperty.Contains(person));
+                Assert.That(() => listContains.ToArray(), Throws.TypeOf<NotSupportedException>());
+
+                var backlinkAccess = realm.All<ClassWithUnqueryableMembers>().Where(c => c.BacklinkProperty != null);
+                Assert.That(() => backlinkAccess.ToArray(), Throws.TypeOf<NotSupportedException>());
+
+                var backlinkItem = new UnqueryableBacklinks();
+                var backlinkContains = realm.All<ClassWithUnqueryableMembers>().Where(c => c.BacklinkProperty.Contains(backlinkItem));
+                Assert.That(() => backlinkContains.ToArray(), Throws.TypeOf<NotSupportedException>());
             }
         }
     }

--- a/Tests/Tests.Shared/TestObjects.cs
+++ b/Tests/Tests.Shared/TestObjects.cs
@@ -208,6 +208,19 @@ namespace Tests
         }
 
         public Person RealmObjectProperty { get; set; }
+
+        public IList<Person> RealmListProperty { get; }
+
+        public string FirstName { get; set; }
+
+        [Backlink(nameof(UnqueryableBacklinks.Parent))]
+        public IQueryable<UnqueryableBacklinks> BacklinkProperty { get; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class UnqueryableBacklinks : RealmObject
+    {
+        public ClassWithUnqueryableMembers Parent { get; set; }
     }
 
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Throws NotSupportedException when trying to use an IList or IQueryable property in queries. Also fixes a corner case where querying by a related property could produce incorrect results.

Fixes #1353

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)