### PR TITLE
Make generic operators lazily initialized

### DIFF
--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -37,8 +37,8 @@ namespace Realms.Helpers
 
         private static class GenericOperator<T, U>
         {
-            private static Lazy<Func<T, U, T>> _add;
-            private static Lazy<Func<T, U>> _convert;
+            private static readonly Lazy<Func<T, U, T>> _add;
+            private static readonly Lazy<Func<T, U>> _convert;
 
             public static Func<T, U, T> Add => _add.Value;
 

--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -37,14 +37,17 @@ namespace Realms.Helpers
 
         private static class GenericOperator<T, U>
         {
-            public static Func<T, U, T> Add { get; }
+            private static Lazy<Func<T, U, T>> _add;
+            private static Lazy<Func<T, U>> _convert;
 
-            public static Func<T, U> Convert { get; }
+            public static Func<T, U, T> Add => _add.Value;
+
+            public static Func<T, U> Convert => _convert.Value;
 
             static GenericOperator()
             {
-                Add = CreateAdd();
-                Convert = CreateConvert();
+                _add = new Lazy<Func<T, U, T>>(CreateAdd);
+                _convert = new Lazy<Func<T, U>>(CreateConvert);
             }
 
             private static Func<T, U, T> CreateAdd()


### PR DESCRIPTION
When debugging an application that uses Realm with Just My Code debugging disabled the debugger stops at first chance exceptions even when they're handled inside Realm. This change makes one such first chance exception opportunity occur more rarely by relying on lazy initialization of the `GenericOperator<T, U>` helpers.