### PR TITLE
Make sure RealmObject.Equals doesn't return true for deleted objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.y.z (TBD)
 
 ### Bug fixes
 - Fixed an issue where initial collection change notification is not delivered to all subscribers. ([#1696](https://github.com/realm/realm-dotnet/pull/1696))
+- Fixed a corner case where `RealmObject.Equals` would return `true` for objects that are no longer managed by Realm. ([#1698](https://github.com/realm/realm-dotnet/pull/1698))
 
 ### Breaking Changes
 

--- a/Tests/Tests.Shared/RealmObjectTests.cs
+++ b/Tests/Tests.Shared/RealmObjectTests.cs
@@ -161,6 +161,25 @@ namespace Tests.Database
             Assert.That(first.OnManagedCalled, Is.EqualTo(1));
         }
 
+        [Test]
+        public void RealmObjectEqualsCheck_WhenDeleted_ReturnsFalse()
+        {
+            var george = new Person { FirstName = "George" };
+            var peter = new Person { FirstName = "Peter" };
+            _realm.Write(() =>
+            {
+                _realm.Add(george);
+                _realm.Add(peter);
+            });
+
+            Assert.That(george, Is.Not.EqualTo(peter));
+
+            _realm.Write(() => _realm.Remove(george));
+
+            Assert.That(george, Is.Not.EqualTo(peter));
+            Assert.That(peter, Is.Not.EqualTo(george));
+        }
+
         private class OnManagedTestClass : RealmObject
         {
             [PrimaryKey]

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -389,7 +389,9 @@ extern "C" {
     REALM_EXPORT bool object_equals_object(const Object& object, const Object& other_object, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {
-            return object.row().get_index() == other_object.row().get_index();
+            return object.is_valid() &&
+                other_object.is_valid() &&
+                object.row().get_index() == other_object.row().get_index();
         });
     }
 


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes #1695 

Based on #1696 to include that fix in the prerelease package.

##  TODO

* [ ] Changelog entry
* [x] Tests (if applicable)
