### PR TITLE
Throw NotSupported exception when comparing to an unmanaged object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+3.2.0 (TBD)
+------------------
+
+### Enhancements
+
+### Bug fixes
+- When constructing queries that compare an invalid/unmanaged RealmObject (e.g. `realm.All<Foo>().Where(f => f.Bar == someBar)`),
+a meaningful exception will now be thrown rather than an obscure ArgumentNullException. 
+
+### Breaking Changes
+
+
 3.1.0 (2018-07-04)
 ------------------
 

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -597,7 +597,12 @@ namespace Realms
 
                 if (!TryExtractConstantValue(node.Right, out object rightValue))
                 {
-                    throw new NotSupportedException($"The rhs of the binary operator '{rightExpression.NodeType}' should be a constant or closure variable expression. \nUnable to process `{node.Right}`");
+                    throw new NotSupportedException($"The rhs of the binary operator '{rightExpression.NodeType}' should be a constant or closure variable expression. \nUnable to process '{node.Right}'.");
+                }
+
+                if (rightValue is RealmObject obj && (!obj.IsManaged || !obj.IsValid))
+                {
+                    throw new NotSupportedException($"The rhs of the binary operator '{rightExpression.NodeType}' should be a managed RealmObject. \nUnable to process '{node.Right}'.");
                 }
 
                 switch (node.NodeType)

--- a/Tests/Tests.Shared/RealmResults/SimpleLINQtests.cs
+++ b/Tests/Tests.Shared/RealmResults/SimpleLINQtests.cs
@@ -571,6 +571,38 @@ namespace Tests.Database
         }
 
         [Test]
+        public void SearchComparingObjects_WhenObjectIsUnmanaged_ShouldFail()
+        {
+            var rex = new Dog { Name = "Rex" };
+            Assert.That(
+                () => _realm.All<Owner>().Where(o => o.TopDog == rex).ToArray(),
+                Throws.TypeOf<NotSupportedException>().And.Message.Contains("should be a managed RealmObject"));
+        }
+
+        [Test]
+        public void SearchComparingObjects_WhenObjectIsDeleted_ShouldFail()
+        {
+            var rex = new Dog { Name = "Rex" };
+            _realm.Write(() =>
+            {
+                _realm.Add(rex);
+            });
+
+            Assert.That(
+                () => _realm.All<Owner>().Where(o => o.TopDog == rex).ToArray(),
+                Throws.Nothing);
+
+            _realm.Write(() =>
+            {
+                _realm.Remove(rex);
+            });
+
+            Assert.That(
+                () => _realm.All<Owner>().Where(o => o.TopDog == rex).ToArray(),
+                Throws.TypeOf<NotSupportedException>().And.Message.Contains("should be a managed RealmObject"));
+        }
+
+        [Test]
         public void StringSearch_Equals_CaseSensitivityTests()
         {
             MakeThreePatricks();


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) and State (`S:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Fixes https://github.com/realm/realm-dotnet/issues/1760

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
