### PR TITLE
RNET-1 Custom refresh tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ vNEXT (TBD)
 * Removed the `isAdmin` parameter from `Credentials.Nickname`. It doesn't have any effect on new ROS versions anyway as logging in an admin nickname user is not supported - this change just makes it explicit. (Issue [#1879](https://github.com/realm/realm-dotnet/issues/1879))
 * Marked the `Credentials.Nickname` method as deprecated - support for the Nickname auth provider is deprecated in ROS and will be removed in a future version. (Issue [#1879](https://github.com/realm/realm-dotnet/issues/1879))
 
+### Enhancements
+* Added new credentials type: `Credentials.CustomRefreshToken` that can be used to create a user with a custom refresh token. This will then be validated by ROS against the configured `refreshTokenValidators` to obtain access tokens when opening a Realm. If creating a user like that, it's the developer's responsibility to ensure that the token is valid and refreshed as necessary to ensure that access tokens can be obtained. To that end, you can now set the refresh token of a user object by calling `User.RefreshToken = "my-new-token"`. This should only be used in combination with users obtained by calling `Credentials.CustomRefreshToken`. (PR [#1889](https://github.com/realm/realm-dotnet/pull/1889))
+
 4.0.1 (2019-06-27)
 ------------------
 

--- a/Realm/Realm/Handles/SyncUserHandle.cs
+++ b/Realm/Realm/Handles/SyncUserHandle.cs
@@ -44,6 +44,9 @@ namespace Realms.Sync
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_get_refresh_token", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_refresh_token(SyncUserHandle user, IntPtr buffer, IntPtr buffer_length, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_set_refresh_token", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr set_refresh_token(SyncUserHandle user, [MarshalAs(UnmanagedType.LPWStr)] string refresh_token, IntPtr refresh_token_len, out NativeException ex);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_get_server_url", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_server_url(SyncUserHandle user, IntPtr buffer, IntPtr buffer_length, out NativeException ex);
 
@@ -101,6 +104,12 @@ namespace Realms.Sync
                 isNull = false;
                 return NativeMethods.get_refresh_token(this, buffer, length, out ex);
             });
+        }
+
+        public void SetRefreshToken(string token)
+        {
+            NativeMethods.set_refresh_token(this, token, (IntPtr)token.Length, out var ex);
+            ex.ThrowIfNecessary();
         }
 
         public string GetServerUrl()

--- a/Realm/Realm/Sync/Credentials.cs
+++ b/Realm/Realm/Sync/Credentials.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Realms.Helpers;
 

--- a/Realm/Realm/Sync/User.cs
+++ b/Realm/Realm/Sync/User.cs
@@ -125,10 +125,15 @@ namespace Realms.Sync
         #endregion static
 
         /// <summary>
-        /// Gets this user's refresh token. This is the user's credential for accessing the Realm Object Server and should be treated as sensitive data.
+        /// Gets or sets this user's refresh token. This is the user's credential for accessing the Realm Object Server and should be treated as sensitive data.
+        /// Setting the refresh token is only supported for users authenticated with <see cref="Credentials.CustomRefreshToken"/>.
         /// </summary>
         /// <value>A unique string that can be used for refreshing the user's credentials.</value>
-        public string RefreshToken => Handle.GetRefreshToken();
+        public string RefreshToken
+        {
+            get => Handle.GetRefreshToken();
+            set => Handle.SetRefreshToken(value);
+        }
 
         /// <summary>
         /// Gets the identity of this user on the Realm Object Server. The identity is a guaranteed to be unique among all users on the Realm Object Server.

--- a/Realm/Realm/Sync/User.cs
+++ b/Realm/Realm/Sync/User.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Realms.Exceptions;
 using Realms.Helpers;
-using Realms.Sync.Exceptions;
 
 namespace Realms.Sync
 {
@@ -91,6 +90,13 @@ namespace Realms.Sync
             if (credentials.IdentityProvider == Credentials.Provider.AdminToken)
             {
                 return new User(SyncUserHandle.GetAdminTokenUser(serverUri.AbsoluteUri, credentials.Token));
+            }
+
+            if (credentials.IdentityProvider == Credentials.Provider.CustomRefreshToken)
+            {
+                var userId = (string)credentials.UserInfo[Credentials.Keys.Identity];
+                var isAdmin = (bool)credentials.UserInfo[Credentials.Keys.IsAdmin];
+                return new User(SyncUserHandle.GetSyncUser(userId, serverUri.AbsoluteUri, credentials.Token, isAdmin));
             }
 
             var result = await AuthenticationHelper.LoginAsync(credentials, serverUri);

--- a/Tests/Realm.Tests/Sync/CredentialsTests.cs
+++ b/Tests/Realm.Tests/Sync/CredentialsTests.cs
@@ -28,6 +28,7 @@ using Realms;
 using Realms.Exceptions;
 using Realms.Sync;
 using Realms.Sync.Exceptions;
+using Realms.Tests.Database;
 
 namespace Realms.Tests.Sync
 {
@@ -387,6 +388,94 @@ namespace Realms.Tests.Sync
                 var second = await User.LoginAsync(Credentials.Nickname(nickname), SyncTestHelpers.AuthServerUri);
 
                 Assert.That(first.Identity, Is.EqualTo(second.Identity));
+            });
+        }
+
+        [Test]
+        public void UserLogin_WhenCustomRefreshToken_LogsUserIn()
+        {
+            SyncTestHelpers.RunRosTestAsync(async () =>
+            {
+                // Keys
+                /*
+                -----BEGIN PRIVATE KEY-----
+                MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCMgFkzVG4bc5DW
+                VtSVtYgdMRbTIyj6UnhOmmS7LjcT02sPQxs8tB5ggwGJSd4/wtv8J0p1Bsq43wOF
+                R+LCwYwZqZ/UysLxl2qg3m4LN7NcgIeDfCSNdbc97Vwg1Li0ygBr9vQcUTq9sgKD
+                7IFu48inn0xF7fxG/FhqGQYo/frLE/RDV3cbchyB5KP9lRoaZ54Wj3yyoiMlnrsX
+                OES91aZRLld4LYWUMg7aWzrRBm41QgYqAT05SGQ5TaU/Z1x/1i61nJ5jw5w50Mn7
+                AYvl3EYJ4/E+yh0XUSYjkbr9HGO6Q2+HugGpUl2WjVTmPhQAaAj3k/dDSSJFcYZE
+                z2yNV/MFAgMBAAECggEATB4ItU9La6HbWNOnzgeP20jJ9c75l0vwk5z/b4zlF9+V
+                A6q2adenEWBIB8m2F1MI/P2IUAhC8Y8YiC9ewWY78Xc8+Pp0TJBcmxSGB5vAlx+m
+                yuwJnX2lrW4XWE4GVyOMwPEEZQb4zOZQiIorwRi0j2M03jnFT+vMNoaiGLkoErZJ
+                xOw93+v83cPivQsR6PeZ8KrPSW0V/lzvH8ZqiQQjpDMm7Y90F4Hr1g6DJ2AogEjv
+                Tv8yWTlzPYcd5reevRV1eyzSHYwcr6dhdmGl1LQLkL9uPbwiQmXLgjWywm3xmDyX
+                BWJeIVI88H+E8hPb1A2yZjyr35CXdNPbcRo2B8YGLQKBgQDLQ/W24DvqUu9TZ3/B
+                EfTTzkXzIU+mUo9qnxtxB+2DnwksTxSK6HG4H1qxo8CCuOR8RBSoqJxqqNtKkq2L
+                lIYrMGoCpYRPcT0JHP7ZfqVnh15CrAkra5QvFXEzbK4aqrJR//HuzdUvFqvb/aNS
+                jEyuVaMNUGNiMYDreD0CX+q38wKBgQCw89waZsqdBtea3A2VKo5xMMicdssC2kNt
+                MJGPCXnXwATqjTHbaFQCbamUJPqlTiMnKVRC4mTr85IXM85gXonFYLYt0CCGX5wd
+                zyC2LcdCfvQBjgrtr9ytKhvK6gq9kBEPNgWNQO9AzuqN1BXmduLfc/8welErIfgA
+                HixAcdKfJwKBgQCAi9wK6Ug66nQcBOpQSXDRujOWjMx4XOICBdku5Fqa0KrWcLSH
+                HHU+geWzTeHjSdaFl/CQsQEqmtsEEDrcePNYwOdqAQ7pxq1Y5BNvrJ4iGQPNmkq6
+                QPCXzjGm2eZJSwY2wWxZH6bgfq/1EjSFceDUp6fUNbCEWtYzE/lRVSN1bQKBgQCK
+                P1uc/OYbXHciM/4gpkj3QgfZxi3Bosi/DA0M1XhuCUVOAtYK9y17YDX22hVBBRUN
+                yYpdXwc+GOPwYLdCL1ov7OkoTcy7bwNHfsWtz4I3/3ufo1wCaz1bxORF2iheBapu
+                WeRogWzrEz3JZQNfNU73CWc8drPnoPhjDy+/ga3uTQKBgFJHP+wZix0efZymu0VS
+                SacwuyolDNg1ebQsBA7XZ/ac9HH/cxxGHxFS76cwfxM7KUpgXEhmFUtEJjuy6UME
+                tw/6uOA95dBQztjvCmAgzdzExq1lSfadgpnj/SYbr70YKBvEnwb1KOPbFlVBnX4f
+                BuwMRU4Vebrdbe6RGRg8mByy
+                -----END PRIVATE KEY-----
+
+                -----BEGIN PUBLIC KEY-----
+                MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjIBZM1RuG3OQ1lbUlbWI
+                HTEW0yMo+lJ4Tppkuy43E9NrD0MbPLQeYIMBiUneP8Lb/CdKdQbKuN8DhUfiwsGM
+                Gamf1MrC8ZdqoN5uCzezXICHg3wkjXW3Pe1cINS4tMoAa/b0HFE6vbICg+yBbuPI
+                p59MRe38RvxYahkGKP36yxP0Q1d3G3IcgeSj/ZUaGmeeFo98sqIjJZ67FzhEvdWm
+                US5XeC2FlDIO2ls60QZuNUIGKgE9OUhkOU2lP2dcf9YutZyeY8OcOdDJ+wGL5dxG
+                CePxPsodF1EmI5G6/RxjukNvh7oBqVJdlo1U5j4UAGgI95P3Q0kiRXGGRM9sjVfz
+                BQIDAQAB
+                -----END PUBLIC KEY-----
+                 */
+
+                var token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.Xhl39nnVXIgTUqDKEfz2mDiHcfH8vZGDC4gJxAHZmQ_usf-uXTXfDxkjME2W5ynKeWUQrzIhOliHaouJq-XJpzqKPvQ4d70LwtijNC53O4SUaHHaTkhh98OLOZif0md7xHeeEJAI9sixNK4GDzA88a2K5dZ9dmv3XJJ3url481CNK5mSCMgTcN5dzChbewmJ327J7mDsHF74Nvdazevk7UyShLz0YfJaPr2ny9feUXcG7yMRTfg3XoSHGUZ1IDDyvjjslfelTZWIR3ccmiua2wyN1EKAQE0o1Ft89VFHDxIHVvfgdXr9aQvtEaPR7-GChL8rx1WiqujSMJ0DZC80gQ";
+                var credentials = Credentials.CustomRefreshToken(token);
+
+                var user = await User.LoginAsync(credentials, SyncTestHelpers.AuthServerUri);
+
+                var config = new FullSyncConfiguration(new Uri("/~/foo", UriKind.Relative), user);
+                using (var realm = await Realm.GetInstanceAsync(config))
+                {
+                    realm.Write(() =>
+                    {
+                        realm.Add(new PrimaryKeyInt32Object
+                        {
+                            Int32Property = 123
+                        });
+                    });
+
+                    await realm.GetSession().WaitForUploadAsync();
+                }
+
+                var token2 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0NTYiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.Hum9NA5KfBqKNsRN6hckbijSAME4LfH2xwmqwPrfjVEBlHRg6HIOnV4gxjY_KUhaazjsExNjAGEhxAamTiefHgvTryVlXwgLjaVs2DpR7F2t1JkpB9b7bU8fo0XV1ZhQ40s9_s3_t6Gdaf8cewSr2ADe0q71c09kP4VtxHQlzXkKuDjkwVXhaXFKglaJNy2Lhk04ybKJn0g_H-sWv2keTW1-J1RhZCzkB_o1Xv-SqoB_n5lahZ3rSUvbQalcQn20mOetTlfAkYfi3Eee4bYzc0iykDdG124uUnQVXXiQR67qlB4zqJ1LuG84KBYcO7W5g_kIBq7YzNaP68xT_x2YBw";
+                var credentials2 = Credentials.CustomRefreshToken(token2);
+
+                var user2 = await User.LoginAsync(credentials2, SyncTestHelpers.AuthServerUri);
+
+                await user.ApplyPermissionsAsync(PermissionCondition.UserId(user2.Identity), "/~/foo", AccessLevel.Write);
+
+                var permissions = await user2.GetGrantedPermissionsAsync(Recipient.CurrentUser);
+
+                var userFooPermission = permissions.SingleOrDefault(p => p.Path.EndsWith("/foo"));
+                Assert.That(userFooPermission, Is.Not.Null);
+
+                var config2 = new FullSyncConfiguration(new Uri(userFooPermission.Path, UriKind.Relative), user2);
+                using (var realm = await Realm.GetInstanceAsync(config2))
+                {
+                    var objects = realm.All<PrimaryKeyInt32Object>();
+                    Assert.That(objects.Count(), Is.EqualTo(1));
+                    Assert.That(objects.Single().Int32Property, Is.EqualTo(123));
+                }
             });
         }
 

--- a/Tests/Realm.Tests/Sync/CredentialsTests.cs
+++ b/Tests/Realm.Tests/Sync/CredentialsTests.cs
@@ -391,58 +391,104 @@ namespace Realms.Tests.Sync
             });
         }
 
-        [Test]
+        #region CustomRefreshTokenTests
+
+        /*
+        // Keys
+
+        -----BEGIN PRIVATE KEY-----
+        MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCMgFkzVG4bc5DW
+        VtSVtYgdMRbTIyj6UnhOmmS7LjcT02sPQxs8tB5ggwGJSd4/wtv8J0p1Bsq43wOF
+        R+LCwYwZqZ/UysLxl2qg3m4LN7NcgIeDfCSNdbc97Vwg1Li0ygBr9vQcUTq9sgKD
+        7IFu48inn0xF7fxG/FhqGQYo/frLE/RDV3cbchyB5KP9lRoaZ54Wj3yyoiMlnrsX
+        OES91aZRLld4LYWUMg7aWzrRBm41QgYqAT05SGQ5TaU/Z1x/1i61nJ5jw5w50Mn7
+        AYvl3EYJ4/E+yh0XUSYjkbr9HGO6Q2+HugGpUl2WjVTmPhQAaAj3k/dDSSJFcYZE
+        z2yNV/MFAgMBAAECggEATB4ItU9La6HbWNOnzgeP20jJ9c75l0vwk5z/b4zlF9+V
+        A6q2adenEWBIB8m2F1MI/P2IUAhC8Y8YiC9ewWY78Xc8+Pp0TJBcmxSGB5vAlx+m
+        yuwJnX2lrW4XWE4GVyOMwPEEZQb4zOZQiIorwRi0j2M03jnFT+vMNoaiGLkoErZJ
+        xOw93+v83cPivQsR6PeZ8KrPSW0V/lzvH8ZqiQQjpDMm7Y90F4Hr1g6DJ2AogEjv
+        Tv8yWTlzPYcd5reevRV1eyzSHYwcr6dhdmGl1LQLkL9uPbwiQmXLgjWywm3xmDyX
+        BWJeIVI88H+E8hPb1A2yZjyr35CXdNPbcRo2B8YGLQKBgQDLQ/W24DvqUu9TZ3/B
+        EfTTzkXzIU+mUo9qnxtxB+2DnwksTxSK6HG4H1qxo8CCuOR8RBSoqJxqqNtKkq2L
+        lIYrMGoCpYRPcT0JHP7ZfqVnh15CrAkra5QvFXEzbK4aqrJR//HuzdUvFqvb/aNS
+        jEyuVaMNUGNiMYDreD0CX+q38wKBgQCw89waZsqdBtea3A2VKo5xMMicdssC2kNt
+        MJGPCXnXwATqjTHbaFQCbamUJPqlTiMnKVRC4mTr85IXM85gXonFYLYt0CCGX5wd
+        zyC2LcdCfvQBjgrtr9ytKhvK6gq9kBEPNgWNQO9AzuqN1BXmduLfc/8welErIfgA
+        HixAcdKfJwKBgQCAi9wK6Ug66nQcBOpQSXDRujOWjMx4XOICBdku5Fqa0KrWcLSH
+        HHU+geWzTeHjSdaFl/CQsQEqmtsEEDrcePNYwOdqAQ7pxq1Y5BNvrJ4iGQPNmkq6
+        QPCXzjGm2eZJSwY2wWxZH6bgfq/1EjSFceDUp6fUNbCEWtYzE/lRVSN1bQKBgQCK
+        P1uc/OYbXHciM/4gpkj3QgfZxi3Bosi/DA0M1XhuCUVOAtYK9y17YDX22hVBBRUN
+        yYpdXwc+GOPwYLdCL1ov7OkoTcy7bwNHfsWtz4I3/3ufo1wCaz1bxORF2iheBapu
+        WeRogWzrEz3JZQNfNU73CWc8drPnoPhjDy+/ga3uTQKBgFJHP+wZix0efZymu0VS
+        SacwuyolDNg1ebQsBA7XZ/ac9HH/cxxGHxFS76cwfxM7KUpgXEhmFUtEJjuy6UME
+        tw/6uOA95dBQztjvCmAgzdzExq1lSfadgpnj/SYbr70YKBvEnwb1KOPbFlVBnX4f
+        BuwMRU4Vebrdbe6RGRg8mByy
+        -----END PRIVATE KEY-----
+
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjIBZM1RuG3OQ1lbUlbWI
+        HTEW0yMo+lJ4Tppkuy43E9NrD0MbPLQeYIMBiUneP8Lb/CdKdQbKuN8DhUfiwsGM
+        Gamf1MrC8ZdqoN5uCzezXICHg3wkjXW3Pe1cINS4tMoAa/b0HFE6vbICg+yBbuPI
+        p59MRe38RvxYahkGKP36yxP0Q1d3G3IcgeSj/ZUaGmeeFo98sqIjJZ67FzhEvdWm
+        US5XeC2FlDIO2ls60QZuNUIGKgE9OUhkOU2lP2dcf9YutZyeY8OcOdDJ+wGL5dxG
+        CePxPsodF1EmI5G6/RxjukNvh7oBqVJdlo1U5j4UAGgI95P3Q0kiRXGGRM9sjVfz
+        BQIDAQAB
+        -----END PUBLIC KEY-----
+
+        ROS Config:
+
+        import { BasicServer } from "..";
+        import * as path from "path";
+        import { ConsoleLogger } from "../shared";
+
+        require("../../feature-token-for-tests.js");
+
+        async function main() {
+            const server = new BasicServer();
+            const publicKey = `-----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjIBZM1RuG3OQ1lbUlbWI
+        HTEW0yMo+lJ4Tppkuy43E9NrD0MbPLQeYIMBiUneP8Lb/CdKdQbKuN8DhUfiwsGM
+        Gamf1MrC8ZdqoN5uCzezXICHg3wkjXW3Pe1cINS4tMoAa/b0HFE6vbICg+yBbuPI
+        p59MRe38RvxYahkGKP36yxP0Q1d3G3IcgeSj/ZUaGmeeFo98sqIjJZ67FzhEvdWm
+        US5XeC2FlDIO2ls60QZuNUIGKgE9OUhkOU2lP2dcf9YutZyeY8OcOdDJ+wGL5dxG
+        CePxPsodF1EmI5G6/RxjukNvh7oBqVJdlo1U5j4UAGgI95P3Q0kiRXGGRM9sjVfz
+        BQIDAQAB
+        -----END PUBLIC KEY-----`;
+
+            await server.start({
+                dataPath: path.resolve("./data"),
+                graphQLServiceConfigOverride: (config) => {
+                    config.disableAuthentication = true;
+                },
+                logger: new ConsoleLogger("debug"),
+                refreshTokenValidators: [
+                    {
+                        algorithms: ["RS256"],
+                        issuer: "myissuer",
+                        publicKey,
+                        audience: "myApp",
+                        isAdminField: "admin"
+                    }
+                ]
+            });
+        }
+
+        main().catch((err) => {
+            console.log(err);
+            process.exit(1);
+        });
+
+        */
+
+        [Test, NUnit.Framework.Explicit("Requires non-default ROS")]
         public void UserLogin_WhenCustomRefreshToken_LogsUserIn()
         {
             SyncTestHelpers.RunRosTestAsync(async () =>
             {
-                // Keys
-                /*
-                -----BEGIN PRIVATE KEY-----
-                MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCMgFkzVG4bc5DW
-                VtSVtYgdMRbTIyj6UnhOmmS7LjcT02sPQxs8tB5ggwGJSd4/wtv8J0p1Bsq43wOF
-                R+LCwYwZqZ/UysLxl2qg3m4LN7NcgIeDfCSNdbc97Vwg1Li0ygBr9vQcUTq9sgKD
-                7IFu48inn0xF7fxG/FhqGQYo/frLE/RDV3cbchyB5KP9lRoaZ54Wj3yyoiMlnrsX
-                OES91aZRLld4LYWUMg7aWzrRBm41QgYqAT05SGQ5TaU/Z1x/1i61nJ5jw5w50Mn7
-                AYvl3EYJ4/E+yh0XUSYjkbr9HGO6Q2+HugGpUl2WjVTmPhQAaAj3k/dDSSJFcYZE
-                z2yNV/MFAgMBAAECggEATB4ItU9La6HbWNOnzgeP20jJ9c75l0vwk5z/b4zlF9+V
-                A6q2adenEWBIB8m2F1MI/P2IUAhC8Y8YiC9ewWY78Xc8+Pp0TJBcmxSGB5vAlx+m
-                yuwJnX2lrW4XWE4GVyOMwPEEZQb4zOZQiIorwRi0j2M03jnFT+vMNoaiGLkoErZJ
-                xOw93+v83cPivQsR6PeZ8KrPSW0V/lzvH8ZqiQQjpDMm7Y90F4Hr1g6DJ2AogEjv
-                Tv8yWTlzPYcd5reevRV1eyzSHYwcr6dhdmGl1LQLkL9uPbwiQmXLgjWywm3xmDyX
-                BWJeIVI88H+E8hPb1A2yZjyr35CXdNPbcRo2B8YGLQKBgQDLQ/W24DvqUu9TZ3/B
-                EfTTzkXzIU+mUo9qnxtxB+2DnwksTxSK6HG4H1qxo8CCuOR8RBSoqJxqqNtKkq2L
-                lIYrMGoCpYRPcT0JHP7ZfqVnh15CrAkra5QvFXEzbK4aqrJR//HuzdUvFqvb/aNS
-                jEyuVaMNUGNiMYDreD0CX+q38wKBgQCw89waZsqdBtea3A2VKo5xMMicdssC2kNt
-                MJGPCXnXwATqjTHbaFQCbamUJPqlTiMnKVRC4mTr85IXM85gXonFYLYt0CCGX5wd
-                zyC2LcdCfvQBjgrtr9ytKhvK6gq9kBEPNgWNQO9AzuqN1BXmduLfc/8welErIfgA
-                HixAcdKfJwKBgQCAi9wK6Ug66nQcBOpQSXDRujOWjMx4XOICBdku5Fqa0KrWcLSH
-                HHU+geWzTeHjSdaFl/CQsQEqmtsEEDrcePNYwOdqAQ7pxq1Y5BNvrJ4iGQPNmkq6
-                QPCXzjGm2eZJSwY2wWxZH6bgfq/1EjSFceDUp6fUNbCEWtYzE/lRVSN1bQKBgQCK
-                P1uc/OYbXHciM/4gpkj3QgfZxi3Bosi/DA0M1XhuCUVOAtYK9y17YDX22hVBBRUN
-                yYpdXwc+GOPwYLdCL1ov7OkoTcy7bwNHfsWtz4I3/3ufo1wCaz1bxORF2iheBapu
-                WeRogWzrEz3JZQNfNU73CWc8drPnoPhjDy+/ga3uTQKBgFJHP+wZix0efZymu0VS
-                SacwuyolDNg1ebQsBA7XZ/ac9HH/cxxGHxFS76cwfxM7KUpgXEhmFUtEJjuy6UME
-                tw/6uOA95dBQztjvCmAgzdzExq1lSfadgpnj/SYbr70YKBvEnwb1KOPbFlVBnX4f
-                BuwMRU4Vebrdbe6RGRg8mByy
-                -----END PRIVATE KEY-----
-
-                -----BEGIN PUBLIC KEY-----
-                MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjIBZM1RuG3OQ1lbUlbWI
-                HTEW0yMo+lJ4Tppkuy43E9NrD0MbPLQeYIMBiUneP8Lb/CdKdQbKuN8DhUfiwsGM
-                Gamf1MrC8ZdqoN5uCzezXICHg3wkjXW3Pe1cINS4tMoAa/b0HFE6vbICg+yBbuPI
-                p59MRe38RvxYahkGKP36yxP0Q1d3G3IcgeSj/ZUaGmeeFo98sqIjJZ67FzhEvdWm
-                US5XeC2FlDIO2ls60QZuNUIGKgE9OUhkOU2lP2dcf9YutZyeY8OcOdDJ+wGL5dxG
-                CePxPsodF1EmI5G6/RxjukNvh7oBqVJdlo1U5j4UAGgI95P3Q0kiRXGGRM9sjVfz
-                BQIDAQAB
-                -----END PUBLIC KEY-----
-                 */
-
                 var token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.Xhl39nnVXIgTUqDKEfz2mDiHcfH8vZGDC4gJxAHZmQ_usf-uXTXfDxkjME2W5ynKeWUQrzIhOliHaouJq-XJpzqKPvQ4d70LwtijNC53O4SUaHHaTkhh98OLOZif0md7xHeeEJAI9sixNK4GDzA88a2K5dZ9dmv3XJJ3url481CNK5mSCMgTcN5dzChbewmJ327J7mDsHF74Nvdazevk7UyShLz0YfJaPr2ny9feUXcG7yMRTfg3XoSHGUZ1IDDyvjjslfelTZWIR3ccmiua2wyN1EKAQE0o1Ft89VFHDxIHVvfgdXr9aQvtEaPR7-GChL8rx1WiqujSMJ0DZC80gQ";
                 var credentials = Credentials.CustomRefreshToken(token);
 
                 var user = await User.LoginAsync(credentials, SyncTestHelpers.AuthServerUri);
-
                 var config = new FullSyncConfiguration(new Uri("/~/foo", UriKind.Relative), user);
                 using (var realm = await Realm.GetInstanceAsync(config))
                 {
@@ -478,6 +524,39 @@ namespace Realms.Tests.Sync
                 }
             });
         }
+
+        public void User_WhenCustomRefreshToken_CanUpdateToken()
+        {
+            SyncTestHelpers.RunRosTestAsync(async () =>
+            {
+                var token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.Xhl39nnVXIgTUqDKEfz2mDiHcfH8vZGDC4gJxAHZmQ_usf-uXTXfDxkjME2W5ynKeWUQrzIhOliHaouJq-XJpzqKPvQ4d70LwtijNC53O4SUaHHaTkhh98OLOZif0md7xHeeEJAI9sixNK4GDzA88a2K5dZ9dmv3XJJ3url481CNK5mSCMgTcN5dzChbewmJ327J7mDsHF74Nvdazevk7UyShLz0YfJaPr2ny9feUXcG7yMRTfg3XoSHGUZ1IDDyvjjslfelTZWIR3ccmiua2wyN1EKAQE0o1Ft89VFHDxIHVvfgdXr9aQvtEaPR7-GChL8rx1WiqujSMJ0DZC80gQ";
+                var credentials = Credentials.CustomRefreshToken(token);
+
+                var user = await User.LoginAsync(credentials, SyncTestHelpers.AuthServerUri);
+                Assert.That(token, Is.EqualTo(user.RefreshToken));
+
+                var newToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDI1LCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.PDW_HuOXzd1cCIAyCUcH2YuQ4FI3cDuDc2x0tMjvV8Lj7UYBPo3tErApoUIVmgb8nF20KAmeLwkYQs1AHHEZqIf7n0lOa-UPSW0CkG80ebTH0QHc3_5IY_NW-lIod0iUqetq9kFw4YXV2OYJXzbqq1W5RicMhhkt1Mtwe7qewFDF8phvwLAPg7KzBusk_yFjSCuYBdaTfWZb_xb3r8so-EcAaWVLnipgvfr_JQwTChkaDGWSOFqmjWLdpNPvFHvo-jx65j07em23X6f8xKIh06PGlGEDSfGNNKBiQXHhjo1m4L4r8rfH8Kp5FBvwbuwV6DsOlRcBnQyBwfxReZlukA";
+                user.RefreshToken = newToken;
+                Assert.That(newToken, Is.EqualTo(user.RefreshToken));
+
+                // Ensure we can still sync
+                var config = new FullSyncConfiguration(new Uri("/~/bar", UriKind.Relative), user);
+                using (var realm = await Realm.GetInstanceAsync(config))
+                {
+                    realm.Write(() =>
+                    {
+                        realm.Add(new PrimaryKeyInt32Object
+                        {
+                            Int32Property = 123
+                        });
+                    });
+
+                    await realm.GetSession().WaitForUploadAsync();
+                }
+            });
+        }
+
+        #endregion
 
         private static async Task TestNewPassword(string userId)
         {

--- a/Tests/Realm.Tests/Sync/CredentialsTests.cs
+++ b/Tests/Realm.Tests/Sync/CredentialsTests.cs
@@ -396,44 +396,44 @@ namespace Realms.Tests.Sync
         /*
         // Keys
 
-        -----BEGIN PRIVATE KEY-----
-        MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCMgFkzVG4bc5DW
-        VtSVtYgdMRbTIyj6UnhOmmS7LjcT02sPQxs8tB5ggwGJSd4/wtv8J0p1Bsq43wOF
-        R+LCwYwZqZ/UysLxl2qg3m4LN7NcgIeDfCSNdbc97Vwg1Li0ygBr9vQcUTq9sgKD
-        7IFu48inn0xF7fxG/FhqGQYo/frLE/RDV3cbchyB5KP9lRoaZ54Wj3yyoiMlnrsX
-        OES91aZRLld4LYWUMg7aWzrRBm41QgYqAT05SGQ5TaU/Z1x/1i61nJ5jw5w50Mn7
-        AYvl3EYJ4/E+yh0XUSYjkbr9HGO6Q2+HugGpUl2WjVTmPhQAaAj3k/dDSSJFcYZE
-        z2yNV/MFAgMBAAECggEATB4ItU9La6HbWNOnzgeP20jJ9c75l0vwk5z/b4zlF9+V
-        A6q2adenEWBIB8m2F1MI/P2IUAhC8Y8YiC9ewWY78Xc8+Pp0TJBcmxSGB5vAlx+m
-        yuwJnX2lrW4XWE4GVyOMwPEEZQb4zOZQiIorwRi0j2M03jnFT+vMNoaiGLkoErZJ
-        xOw93+v83cPivQsR6PeZ8KrPSW0V/lzvH8ZqiQQjpDMm7Y90F4Hr1g6DJ2AogEjv
-        Tv8yWTlzPYcd5reevRV1eyzSHYwcr6dhdmGl1LQLkL9uPbwiQmXLgjWywm3xmDyX
-        BWJeIVI88H+E8hPb1A2yZjyr35CXdNPbcRo2B8YGLQKBgQDLQ/W24DvqUu9TZ3/B
-        EfTTzkXzIU+mUo9qnxtxB+2DnwksTxSK6HG4H1qxo8CCuOR8RBSoqJxqqNtKkq2L
-        lIYrMGoCpYRPcT0JHP7ZfqVnh15CrAkra5QvFXEzbK4aqrJR//HuzdUvFqvb/aNS
-        jEyuVaMNUGNiMYDreD0CX+q38wKBgQCw89waZsqdBtea3A2VKo5xMMicdssC2kNt
-        MJGPCXnXwATqjTHbaFQCbamUJPqlTiMnKVRC4mTr85IXM85gXonFYLYt0CCGX5wd
-        zyC2LcdCfvQBjgrtr9ytKhvK6gq9kBEPNgWNQO9AzuqN1BXmduLfc/8welErIfgA
-        HixAcdKfJwKBgQCAi9wK6Ug66nQcBOpQSXDRujOWjMx4XOICBdku5Fqa0KrWcLSH
-        HHU+geWzTeHjSdaFl/CQsQEqmtsEEDrcePNYwOdqAQ7pxq1Y5BNvrJ4iGQPNmkq6
-        QPCXzjGm2eZJSwY2wWxZH6bgfq/1EjSFceDUp6fUNbCEWtYzE/lRVSN1bQKBgQCK
-        P1uc/OYbXHciM/4gpkj3QgfZxi3Bosi/DA0M1XhuCUVOAtYK9y17YDX22hVBBRUN
-        yYpdXwc+GOPwYLdCL1ov7OkoTcy7bwNHfsWtz4I3/3ufo1wCaz1bxORF2iheBapu
-        WeRogWzrEz3JZQNfNU73CWc8drPnoPhjDy+/ga3uTQKBgFJHP+wZix0efZymu0VS
-        SacwuyolDNg1ebQsBA7XZ/ac9HH/cxxGHxFS76cwfxM7KUpgXEhmFUtEJjuy6UME
-        tw/6uOA95dBQztjvCmAgzdzExq1lSfadgpnj/SYbr70YKBvEnwb1KOPbFlVBnX4f
-        BuwMRU4Vebrdbe6RGRg8mByy
-        -----END PRIVATE KEY-----
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCMgFkzVG4bc5DW
+VtSVtYgdMRbTIyj6UnhOmmS7LjcT02sPQxs8tB5ggwGJSd4/wtv8J0p1Bsq43wOF
+R+LCwYwZqZ/UysLxl2qg3m4LN7NcgIeDfCSNdbc97Vwg1Li0ygBr9vQcUTq9sgKD
+7IFu48inn0xF7fxG/FhqGQYo/frLE/RDV3cbchyB5KP9lRoaZ54Wj3yyoiMlnrsX
+OES91aZRLld4LYWUMg7aWzrRBm41QgYqAT05SGQ5TaU/Z1x/1i61nJ5jw5w50Mn7
+AYvl3EYJ4/E+yh0XUSYjkbr9HGO6Q2+HugGpUl2WjVTmPhQAaAj3k/dDSSJFcYZE
+z2yNV/MFAgMBAAECggEATB4ItU9La6HbWNOnzgeP20jJ9c75l0vwk5z/b4zlF9+V
+A6q2adenEWBIB8m2F1MI/P2IUAhC8Y8YiC9ewWY78Xc8+Pp0TJBcmxSGB5vAlx+m
+yuwJnX2lrW4XWE4GVyOMwPEEZQb4zOZQiIorwRi0j2M03jnFT+vMNoaiGLkoErZJ
+xOw93+v83cPivQsR6PeZ8KrPSW0V/lzvH8ZqiQQjpDMm7Y90F4Hr1g6DJ2AogEjv
+Tv8yWTlzPYcd5reevRV1eyzSHYwcr6dhdmGl1LQLkL9uPbwiQmXLgjWywm3xmDyX
+BWJeIVI88H+E8hPb1A2yZjyr35CXdNPbcRo2B8YGLQKBgQDLQ/W24DvqUu9TZ3/B
+EfTTzkXzIU+mUo9qnxtxB+2DnwksTxSK6HG4H1qxo8CCuOR8RBSoqJxqqNtKkq2L
+lIYrMGoCpYRPcT0JHP7ZfqVnh15CrAkra5QvFXEzbK4aqrJR//HuzdUvFqvb/aNS
+jEyuVaMNUGNiMYDreD0CX+q38wKBgQCw89waZsqdBtea3A2VKo5xMMicdssC2kNt
+MJGPCXnXwATqjTHbaFQCbamUJPqlTiMnKVRC4mTr85IXM85gXonFYLYt0CCGX5wd
+zyC2LcdCfvQBjgrtr9ytKhvK6gq9kBEPNgWNQO9AzuqN1BXmduLfc/8welErIfgA
+HixAcdKfJwKBgQCAi9wK6Ug66nQcBOpQSXDRujOWjMx4XOICBdku5Fqa0KrWcLSH
+HHU+geWzTeHjSdaFl/CQsQEqmtsEEDrcePNYwOdqAQ7pxq1Y5BNvrJ4iGQPNmkq6
+QPCXzjGm2eZJSwY2wWxZH6bgfq/1EjSFceDUp6fUNbCEWtYzE/lRVSN1bQKBgQCK
+P1uc/OYbXHciM/4gpkj3QgfZxi3Bosi/DA0M1XhuCUVOAtYK9y17YDX22hVBBRUN
+yYpdXwc+GOPwYLdCL1ov7OkoTcy7bwNHfsWtz4I3/3ufo1wCaz1bxORF2iheBapu
+WeRogWzrEz3JZQNfNU73CWc8drPnoPhjDy+/ga3uTQKBgFJHP+wZix0efZymu0VS
+SacwuyolDNg1ebQsBA7XZ/ac9HH/cxxGHxFS76cwfxM7KUpgXEhmFUtEJjuy6UME
+tw/6uOA95dBQztjvCmAgzdzExq1lSfadgpnj/SYbr70YKBvEnwb1KOPbFlVBnX4f
+BuwMRU4Vebrdbe6RGRg8mByy
+-----END PRIVATE KEY-----
 
-        -----BEGIN PUBLIC KEY-----
-        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjIBZM1RuG3OQ1lbUlbWI
-        HTEW0yMo+lJ4Tppkuy43E9NrD0MbPLQeYIMBiUneP8Lb/CdKdQbKuN8DhUfiwsGM
-        Gamf1MrC8ZdqoN5uCzezXICHg3wkjXW3Pe1cINS4tMoAa/b0HFE6vbICg+yBbuPI
-        p59MRe38RvxYahkGKP36yxP0Q1d3G3IcgeSj/ZUaGmeeFo98sqIjJZ67FzhEvdWm
-        US5XeC2FlDIO2ls60QZuNUIGKgE9OUhkOU2lP2dcf9YutZyeY8OcOdDJ+wGL5dxG
-        CePxPsodF1EmI5G6/RxjukNvh7oBqVJdlo1U5j4UAGgI95P3Q0kiRXGGRM9sjVfz
-        BQIDAQAB
-        -----END PUBLIC KEY-----
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjIBZM1RuG3OQ1lbUlbWI
+HTEW0yMo+lJ4Tppkuy43E9NrD0MbPLQeYIMBiUneP8Lb/CdKdQbKuN8DhUfiwsGM
+Gamf1MrC8ZdqoN5uCzezXICHg3wkjXW3Pe1cINS4tMoAa/b0HFE6vbICg+yBbuPI
+p59MRe38RvxYahkGKP36yxP0Q1d3G3IcgeSj/ZUaGmeeFo98sqIjJZ67FzhEvdWm
+US5XeC2FlDIO2ls60QZuNUIGKgE9OUhkOU2lP2dcf9YutZyeY8OcOdDJ+wGL5dxG
+CePxPsodF1EmI5G6/RxjukNvh7oBqVJdlo1U5j4UAGgI95P3Q0kiRXGGRM9sjVfz
+BQIDAQAB
+-----END PUBLIC KEY-----
 
         ROS Config:
 
@@ -488,9 +488,10 @@ namespace Realms.Tests.Sync
                 var token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.Xhl39nnVXIgTUqDKEfz2mDiHcfH8vZGDC4gJxAHZmQ_usf-uXTXfDxkjME2W5ynKeWUQrzIhOliHaouJq-XJpzqKPvQ4d70LwtijNC53O4SUaHHaTkhh98OLOZif0md7xHeeEJAI9sixNK4GDzA88a2K5dZ9dmv3XJJ3url481CNK5mSCMgTcN5dzChbewmJ327J7mDsHF74Nvdazevk7UyShLz0YfJaPr2ny9feUXcG7yMRTfg3XoSHGUZ1IDDyvjjslfelTZWIR3ccmiua2wyN1EKAQE0o1Ft89VFHDxIHVvfgdXr9aQvtEaPR7-GChL8rx1WiqujSMJ0DZC80gQ";
                 var credentials = Credentials.CustomRefreshToken(token);
 
+                var realmPath = Guid.NewGuid().ToString();
                 var user = await User.LoginAsync(credentials, SyncTestHelpers.AuthServerUri);
-                var config = new FullSyncConfiguration(new Uri("/~/foo", UriKind.Relative), user);
-                using (var realm = await Realm.GetInstanceAsync(config))
+                var config = new FullSyncConfiguration(new Uri($"/~/{realmPath}", UriKind.Relative), user);
+                using (var realm = await GetRealmAsync(config))
                 {
                     realm.Write(() =>
                     {
@@ -500,7 +501,7 @@ namespace Realms.Tests.Sync
                         });
                     });
 
-                    await realm.GetSession().WaitForUploadAsync();
+                    await GetSession(realm).WaitForUploadAsync();
                 }
 
                 var token2 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0NTYiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.Hum9NA5KfBqKNsRN6hckbijSAME4LfH2xwmqwPrfjVEBlHRg6HIOnV4gxjY_KUhaazjsExNjAGEhxAamTiefHgvTryVlXwgLjaVs2DpR7F2t1JkpB9b7bU8fo0XV1ZhQ40s9_s3_t6Gdaf8cewSr2ADe0q71c09kP4VtxHQlzXkKuDjkwVXhaXFKglaJNy2Lhk04ybKJn0g_H-sWv2keTW1-J1RhZCzkB_o1Xv-SqoB_n5lahZ3rSUvbQalcQn20mOetTlfAkYfi3Eee4bYzc0iykDdG124uUnQVXXiQR67qlB4zqJ1LuG84KBYcO7W5g_kIBq7YzNaP68xT_x2YBw";
@@ -508,15 +509,15 @@ namespace Realms.Tests.Sync
 
                 var user2 = await User.LoginAsync(credentials2, SyncTestHelpers.AuthServerUri);
 
-                await user.ApplyPermissionsAsync(PermissionCondition.UserId(user2.Identity), "/~/foo", AccessLevel.Write);
+                await user.ApplyPermissionsAsync(PermissionCondition.UserId(user2.Identity), $"/~/{realmPath}", AccessLevel.Write);
 
                 var permissions = await user2.GetGrantedPermissionsAsync(Recipient.CurrentUser);
 
-                var userFooPermission = permissions.SingleOrDefault(p => p.Path.EndsWith("/foo"));
+                var userFooPermission = permissions.SingleOrDefault(p => p.Path.EndsWith($"/{realmPath}"));
                 Assert.That(userFooPermission, Is.Not.Null);
 
                 var config2 = new FullSyncConfiguration(new Uri(userFooPermission.Path, UriKind.Relative), user2);
-                using (var realm = await Realm.GetInstanceAsync(config2))
+                using (var realm = await GetRealmAsync(config2))
                 {
                     var objects = realm.All<PrimaryKeyInt32Object>();
                     Assert.That(objects.Count(), Is.EqualTo(1));
@@ -525,23 +526,24 @@ namespace Realms.Tests.Sync
             });
         }
 
+        [Test, NUnit.Framework.Explicit("Requires non-default ROS")]
         public void User_WhenCustomRefreshToken_CanUpdateToken()
         {
             SyncTestHelpers.RunRosTestAsync(async () =>
             {
-                var token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.Xhl39nnVXIgTUqDKEfz2mDiHcfH8vZGDC4gJxAHZmQ_usf-uXTXfDxkjME2W5ynKeWUQrzIhOliHaouJq-XJpzqKPvQ4d70LwtijNC53O4SUaHHaTkhh98OLOZif0md7xHeeEJAI9sixNK4GDzA88a2K5dZ9dmv3XJJ3url481CNK5mSCMgTcN5dzChbewmJ327J7mDsHF74Nvdazevk7UyShLz0YfJaPr2ny9feUXcG7yMRTfg3XoSHGUZ1IDDyvjjslfelTZWIR3ccmiua2wyN1EKAQE0o1Ft89VFHDxIHVvfgdXr9aQvtEaPR7-GChL8rx1WiqujSMJ0DZC80gQ";
+                var token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTYiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.FmRf5n3o83vduCIShxmXOTWBegJwQqZKWNakIjQN3OAxfjJBK2tkSJGBqBBARN7nkEAWypGQzk1VkjuIKAZfGC1QpSSyv3RBw3D85hNs_aRvHgh2PXIiWbxMvRdZF6N5gN4Zi_47TsL67FqthQV6btOvrwqUuY5EY3vqW8LJT9D-966j6xmLOG7ZeEpWjNVvFx9nR5DmOYIXvamWGLCND_cqYhWcgrSs0I0FMZ6IxfjoiUZST5vc_c18XIbuszongqDUMJEIPbvjmN31tCuLXDuorf3eOpALIIsfR1Dt-RnkoOYAJrPTUjg_NnVqbIj0RzPzdbx7lClP1gZbE3HAjw";
                 var credentials = Credentials.CustomRefreshToken(token);
 
                 var user = await User.LoginAsync(credentials, SyncTestHelpers.AuthServerUri);
                 Assert.That(token, Is.EqualTo(user.RefreshToken));
 
-                var newToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDI1LCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIn0.PDW_HuOXzd1cCIAyCUcH2YuQ4FI3cDuDc2x0tMjvV8Lj7UYBPo3tErApoUIVmgb8nF20KAmeLwkYQs1AHHEZqIf7n0lOa-UPSW0CkG80ebTH0QHc3_5IY_NW-lIod0iUqetq9kFw4YXV2OYJXzbqq1W5RicMhhkt1Mtwe7qewFDF8phvwLAPg7KzBusk_yFjSCuYBdaTfWZb_xb3r8so-EcAaWVLnipgvfr_JQwTChkaDGWSOFqmjWLdpNPvFHvo-jx65j07em23X6f8xKIh06PGlGEDSfGNNKBiQXHhjo1m4L4r8rfH8Kp5FBvwbuwV6DsOlRcBnQyBwfxReZlukA";
+                var newToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTYiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOiJteUFwcCIsImlzcyI6Im15aXNzdWVyIiwic29tZXRoaW5nIjoiZWxzZSJ9.PnfTPoeLmfbjuuKDDzLyZ6BgLVjOmx8qazVdEkVxbjy5jtJnGIyyl77y71E4Auf4sIOqLzqs6Tve4JnrZIltXSzLBnmC76JPW9t3LT0-t09UGG7K0eTYaySlXgzjTZ1bEyc3plnr2Vw4y3g4uonmsU6fliaKoqpWnW-UHDMsPdRJR3BzQYIBkj3SSwCCb-uDRsZWQhyx2CyVvsJgAow_jae5oi38QO5UC6kqCMflUxMHDR5MmSRuhTvtA3Uk0rYMTnh4LzWhmL5yH_uSgBwluTcTJxnxU_jf_S9HqnbuBnyWbwlDVsd-ABffF-LkWhj1uSCW9OpSVBJyF5ekTYDqNQ";
                 user.RefreshToken = newToken;
                 Assert.That(newToken, Is.EqualTo(user.RefreshToken));
 
                 // Ensure we can still sync
-                var config = new FullSyncConfiguration(new Uri("/~/bar", UriKind.Relative), user);
-                using (var realm = await Realm.GetInstanceAsync(config))
+                var config = new FullSyncConfiguration(new Uri($"/~/{Guid.NewGuid()}", UriKind.Relative), user);
+                using (var realm = await GetRealmAsync(config))
                 {
                     realm.Write(() =>
                     {
@@ -551,7 +553,7 @@ namespace Realms.Tests.Sync
                         });
                     });
 
-                    await realm.GetSession().WaitForUploadAsync();
+                    await GetSession(realm).WaitForUploadAsync();
                 }
             });
         }

--- a/Tests/Realm.Tests/Sync/SyncTestHelpers.cs
+++ b/Tests/Realm.Tests/Sync/SyncTestHelpers.cs
@@ -18,11 +18,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using Realms;
 using Realms.Sync;
 using Realms.Sync.Exceptions;
 using Realms.Sync.Testing;

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -59,7 +59,15 @@ REALM_EXPORT SharedSyncUser* realm_get_admintoken_user(const uint16_t* auth_serv
         return new SharedSyncUser(SyncManager::shared().get_admin_token_user(auth_server_url, token));
     });
 }
-
+    
+REALM_EXPORT void realm_syncuser_set_refresh_token(SharedSyncUser& user, const uint16_t* token_buf, size_t token_len, NativeException::Marshallable& ex)
+{
+    handle_errors(ex, [&] {
+        Utf16StringAccessor token(token_buf, token_len);
+        user->update_refresh_token(token);
+    });
+}
+    
 REALM_EXPORT SharedSyncUser* realm_get_current_sync_user(NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() -> SharedSyncUser* {


### PR DESCRIPTION
## Description

Adds support for custom refresh tokens. Depends on an yet-unreleased ROS version. Couldn't find a reasonable way to test it without rewriting the entire way we run ROS tests, so tested things against a local ROS instance.

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
