### PR TITLE
Fix the FodyHelpers dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ vNext (TBD)
 
 ### Fixed
 * Fixed an issue that would result in a compile error when `[Required]` is applied on `IList<string>` property. (Contributed by [braudabaugh](https://github.com/braudabaugh))
+* Fixed an issue that prevented projects that include the Realm NuGet package from being debugged. (PR [#1927](https://github.com/realm/realm-dotnet/pull/1927))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.

--- a/Realm.sln
+++ b/Realm.sln
@@ -24,6 +24,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.XamarinMac", "Tests\T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{963FF6EA-00B7-42BF-8319-0F9B9EADCA9F}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		Directory.build.props = Directory.build.props
 		global.json = global.json
 	EndProjectSection

--- a/Realm/Realm.Fody/Realm.Fody.csproj
+++ b/Realm/Realm.Fody/Realm.Fody.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Realms.Fody</RootNamespace>
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
     <BuildOutputTargetFolder>weaver</BuildOutputTargetFolder>
@@ -9,7 +9,7 @@
     <Description>Realm.Fody is a Fody weaver used to replace the property setters and getters of your Realm models with Realm-backed ones.</Description>
   </PropertyGroup>
   <ItemGroup Label="References">
-    <PackageReference Include="FodyHelpers" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="FodyHelpers" Version="6.*" PrivateAssets="All" />
     <PackageReference Include="System.Management" Version="4.5.0" PrivateAssets="Build;Compile;Runtime" />
     <PackageReference Include="StyleCop.MSBuild" Version="6.0.0" Condition="'$(MSBuildRuntimeType)' != 'Core'" PrivateAssets="All" />
   </ItemGroup>

--- a/Realm/Realm.Fody/Realm.Fody.csproj
+++ b/Realm/Realm.Fody/Realm.Fody.csproj
@@ -9,7 +9,7 @@
     <Description>Realm.Fody is a Fody weaver used to replace the property setters and getters of your Realm models with Realm-backed ones.</Description>
   </PropertyGroup>
   <ItemGroup Label="References">
-    <PackageReference Include="FodyHelpers" Version="6.0.0" PrivateAssets="Build;Compile;Runtime" />
+    <PackageReference Include="FodyHelpers" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Management" Version="4.5.0" PrivateAssets="Build;Compile;Runtime" />
     <PackageReference Include="StyleCop.MSBuild" Version="6.0.0" Condition="'$(MSBuildRuntimeType)' != 'Core'" PrivateAssets="All" />
   </ItemGroup>

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Fody" Version="6.0.0" PrivateAssets="None" />
+    <PackageReference Include="Fody" Version="6.*" PrivateAssets="None" />
     <PackageReference Include="Nito.AsyncEx.Context" Version="5.0.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />

--- a/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
+++ b/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="PropertyChanged.Fody" Version="3.1.3">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </PackageReference>
-    <PackageReference Include="FodyHelpers" Version="6.0.0" />
+    <PackageReference Include="FodyHelpers" Version="6.*" />
     <ProjectReference Include="..\AssemblyToProcess\AssemblyToProcess.csproj" />
     <ProjectReference Include="..\Realm.FakeForWeaverTests\Realm.FakeForWeaverTests.csproj" />
     <ProjectReference Include="..\RealmFreeAssemblyToProcess\RealmFreeAssemblyToProcess.csproj" />


### PR DESCRIPTION
## Description
Make the [FodyHelpers](https://www.nuget.org/packages/fodyhelpers) package a private dependency of the Realm.Fody package. This will stop it being included as a transient dependency in user projects, which in turn breaks debugging.

Thanks to @Dids and @SimonCropp for diagnosing the issue.

Fixes #1910

##  TODO

* [x] Changelog entry
* [ ] Tests (if applicable)
