### PR TITLE
RNET-184: Add support for frozen objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ vNext(TBD)
 ------------------
 
 ### Enhancements
-* None
+* Added the notion of "frozen objects" - these are objects, queries, lists, or Realms that have been "frozen" at a specific version. This allows you to access the data from any thread, but it will never change. All frozen objects can be accessed and queried as normal, but attempting to mutate them or add change listeners will throw an exception. (Issue [#1945](https://github.com/realm/realm-dotnet/issues/1945))
+  * Added `Realm.Freeze()`, `RealmObject.Freeze()`, `RealmObject.FreezeInPlace()`, `IQueryable<RealmObject>.Freeze()`, `IList<T>.Freeze()`, and `IRealmCollection<T>.Freeze()`. These methods will produce the frozen version of the instance on which they are called.
+  * Added `Realm.IsFrozen`, `RealmObject.IsFrozen`, and `IRealmCollection<T>.IsFrozen`, which returns whether or not the data is frozen.
+  * Added `RealmConfigurationBase.MaxNumberOfActiveVersions`. Setting this will cause Realm to throw an exception if too many versions of the Realm data are live at the same time. Having too many versions can dramatically increase the filesize of the Realm.
 
 ### Fixed
 * Fixed `Access to invalidated List object` being thrown when adding objects to a list while at the same time deleting the object containing the list. (Issue [#1971](https://github.com/realm/realm-dotnet/issues/1971))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,19 +176,15 @@ stage('Test') {
         unstash 'dotnet-source'
         dir('Realm/packages') { unstash 'packages' }
 
+        sh 'mkdir -p temp'
         dir('Tests/Tests.iOS') {
           msbuild restore: true,
                   properties: [ Platform: 'iPhoneSimulator', RestoreConfigFile: "${env.WORKSPACE}/Tests/Test.NuGet.config" ] << props
           dir("bin/iPhoneSimulator/${configuration}") {
-            stash includes: 'Tests.iOS.app/**/*', name: 'ios-tests'
+            runSimulator('Tests.iOS.app', 'io.realm.dotnettests', "--headless --resultpath ${env.WORKSPACE}/temp/TestResults.iOS.xml")
           }
         }
-      }
-      rlmNode('xamarin.ios') {
-        unstash 'ios-tests'
 
-        sh 'mkdir -p temp'
-        runSimulator('Tests.iOS.app', 'io.realm.dotnettests', "--headless --resultpath ${env.WORKSPACE}/temp/TestResults.iOS.xml")
         junit 'temp/TestResults.iOS.xml'
       }
     },
@@ -197,21 +193,16 @@ stage('Test') {
         unstash 'dotnet-source'
         dir('Realm/packages') { unstash 'packages' }
 
+        sh 'mkdir -p temp'
         dir('Tests/Tests.XamarinMac') {
           msbuild restore: true,
                   properties: [ RestoreConfigFile: "${env.WORKSPACE}/Tests/Test.NuGet.config" ] << props
-          dir("bin/${configuration}") {
-            stash includes: 'Tests.XamarinMac.app/**/*', name: 'macos-tests'
+          dir("bin/${configuration}/Tests.XamarinMac.app/Contents") {
+            sh "MacOS/Tests.XamarinMac --headless --labels=All --result=${env.WORKSPACE}/temp/TestResults.macOS.xml"
           }
         }
-      }
-      rlmNode('osx') {
-        unstash 'macos-tests'
 
-        dir("Tests.XamarinMac.app/Contents") {
-          sh "MacOS/Tests.XamarinMac --headless --labels=All --result=${env.WORKSPACE}/TestResults.macOS.xml"
-        }
-        reportTests 'TestResults.macOS.xml'
+        reportTests 'temp/TestResults.macOS.xml'
       }
     },
     'Xamarin Android': {
@@ -394,7 +385,10 @@ def msbuild(Map args = [:]) {
 }
 
 def reportTests(spec) {
-  xunit([NUnit3(deleteOutputFiles: true, failIfNotNew: true, pattern: spec, skipNoTestFiles: false, stopProcessingIfError: true)])
+  xunit(
+    [NUnit3(deleteOutputFiles: true, failIfNotNew: true, pattern: spec, skipNoTestFiles: false, stopProcessingIfError: true)],
+    thresholds: [ failed(unstableThreshold: '1') ]
+  )
 }
 
 // Required due to JENKINS-27421

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -386,7 +386,7 @@ def msbuild(Map args = [:]) {
 
 def reportTests(spec) {
   xunit(
-    [NUnit3(deleteOutputFiles: true, failIfNotNew: true, pattern: spec, skipNoTestFiles: false, stopProcessingIfError: true)],
+    step: [NUnit3(deleteOutputFiles: true, failIfNotNew: true, pattern: spec, skipNoTestFiles: false, stopProcessingIfError: true)],
     thresholds: [ failed(unstableThreshold: '1') ]
   )
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -386,7 +386,7 @@ def msbuild(Map args = [:]) {
 
 def reportTests(spec) {
   xunit(
-    step: [NUnit3(deleteOutputFiles: true, failIfNotNew: true, pattern: spec, skipNoTestFiles: false, stopProcessingIfError: true)],
+    tools: [NUnit3(deleteOutputFiles: true, failIfNotNew: true, pattern: spec, skipNoTestFiles: false, stopProcessingIfError: true)],
     thresholds: [ failed(unstableThreshold: '1') ]
   )
 }

--- a/Realm/Realm/Configurations/InMemoryConfiguration.cs
+++ b/Realm/Realm/Configurations/InMemoryConfiguration.cs
@@ -18,7 +18,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Realms.Native;
 using Realms.Schema;
 
 namespace Realms
@@ -50,13 +49,8 @@ namespace Realms
 
         internal override Realm CreateRealm(RealmSchema schema)
         {
-            var configuration = new Configuration
-            {
-                Path = DatabasePath,
-                schema_version = SchemaVersion,
-                enable_cache = EnableCache,
-                in_memory = true
-            };
+            var configuration = CreateConfiguration();
+            configuration.in_memory = true;
 
             var srPtr = SharedRealmHandle.Open(configuration, schema, EncryptionKey);
             return new Realm(new SharedRealmHandle(srPtr), this, schema);

--- a/Realm/Realm/Configurations/RealmConfiguration.cs
+++ b/Realm/Realm/Configurations/RealmConfiguration.cs
@@ -125,14 +125,9 @@ namespace Realms
 
         internal override Realm CreateRealm(RealmSchema schema)
         {
-            var configuration = new Configuration
-            {
-                Path = DatabasePath,
-                read_only = IsReadOnly,
-                delete_if_migration_needed = ShouldDeleteIfMigrationNeeded,
-                schema_version = SchemaVersion,
-                enable_cache = EnableCache
-            };
+            var configuration = CreateConfiguration();
+            configuration.delete_if_migration_needed = ShouldDeleteIfMigrationNeeded;
+            configuration.read_only = IsReadOnly;
 
             Migration migration = null;
             if (MigrationCallback != null)

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -126,6 +126,12 @@ namespace Realms
             }
         }
 
+        /// <summary>
+        /// Gets or sets the maximum number of active versions allowed before an exception is thrown.
+        /// </summary>
+        /// <seealso cref="Realm.Freeze"/>
+        public ulong MaxNumberOfActiveVersions { get; set; } = ulong.MaxValue;
+
         internal RealmConfigurationBase()
         {
         }
@@ -143,5 +149,16 @@ namespace Realms
         internal abstract Realm CreateRealm(RealmSchema schema);
 
         internal abstract Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken);
+
+        internal Native.Configuration CreateConfiguration()
+        {
+            return new Native.Configuration
+            {
+                Path = DatabasePath,
+                schema_version = SchemaVersion,
+                enable_cache = EnableCache,
+                max_number_of_active_versions = MaxNumberOfActiveVersions
+            };
+        }
     }
 }

--- a/Realm/Realm/Configurations/SyncConfigurationBase.cs
+++ b/Realm/Realm/Configurations/SyncConfigurationBase.cs
@@ -214,12 +214,7 @@ namespace Realms.Sync
 
         internal override Realm CreateRealm(RealmSchema schema)
         {
-            var configuration = new Realms.Native.Configuration
-            {
-                Path = DatabasePath,
-                schema_version = SchemaVersion,
-                enable_cache = EnableCache
-            };
+            var configuration = CreateConfiguration();
 
             var srHandle = SharedRealmHandleExtensions.OpenWithSync(configuration, ToNative(), schema, EncryptionKey);
             if (IsDynamic && !schema.Any())
@@ -233,12 +228,7 @@ namespace Realms.Sync
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The Realm instance will own its handle")]
         internal override async Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken)
         {
-            var configuration = new Realms.Native.Configuration
-            {
-                Path = DatabasePath,
-                schema_version = SchemaVersion,
-                enable_cache = EnableCache
-            };
+            var configuration = CreateConfiguration();
 
             var tcs = new TaskCompletionSource<ThreadSafeReferenceHandle>();
             var tcsHandle = GCHandle.Alloc(tcs);

--- a/Realm/Realm/Exceptions/RealmFrozenException.cs
+++ b/Realm/Realm/Exceptions/RealmFrozenException.cs
@@ -1,0 +1,31 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Realms.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when trying to subscribe to changes or modify a frozen <see cref="Realm"/>, <see cref="RealmObject"/>, or
+    /// <see cref="IRealmCollection{T}"/>.
+    /// </summary>
+    public class RealmFrozenException : RealmException
+    {
+        internal RealmFrozenException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/Realm/Realm/Extensions/CollectionNotificationsExtensions.cs
+++ b/Realm/Realm/Extensions/CollectionNotificationsExtensions.cs
@@ -35,20 +35,21 @@ namespace Realms
         /// A convenience method that casts <see cref="IQueryable{T}"/> to <see cref="IRealmCollection{T}"/> which
         /// implements <see cref="INotifyCollectionChanged"/>.
         /// </summary>
-        /// <param name="results">The <see cref="IQueryable{T}" /> to observe for changes.</param>
+        /// <param name="query">The <see cref="IQueryable{T}" /> to observe for changes.</param>
         /// <typeparam name="T">Type of the <see cref="RealmObject"/> in the results.</typeparam>
         /// <seealso cref="IRealmCollection{T}.SubscribeForNotifications"/>
         /// <returns>The collection, implementing <see cref="INotifyCollectionChanged"/>.</returns>
-        public static IRealmCollection<T> AsRealmCollection<T>(this IQueryable<T> results)
+        public static IRealmCollection<T> AsRealmCollection<T>(this IQueryable<T> query)
             where T : RealmObject
         {
-            var collection = results as IRealmCollection<T>;
-            if (collection == null)
+            Argument.NotNull(query, nameof(query));
+
+            if (query is IRealmCollection<T> collection)
             {
-                throw new ArgumentException($"{nameof(results)} must be an instance of IRealmCollection<{typeof(T).Name}>.", nameof(results));
+                return collection;
             }
 
-            return collection;
+            throw new ArgumentException($"{nameof(query)} must be an instance of IRealmCollection<{typeof(T).Name}>.", nameof(query));
         }
 
         /// <summary>
@@ -80,13 +81,12 @@ namespace Realms
         {
             Argument.NotNull(list, nameof(list));
 
-            var collection = list as IRealmCollection<T>;
-            if (collection == null)
+            if (list is IRealmCollection<T> collection)
             {
-                throw new ArgumentException($"{nameof(list)} must be an instance of IRealmCollection<{typeof(T).Name}>.", nameof(list));
+                return collection;
             }
 
-            return collection;
+            throw new ArgumentException($"{nameof(list)} must be an instance of IRealmCollection<{typeof(T).Name}>.", nameof(list));
         }
 
         /// <summary>
@@ -117,6 +117,7 @@ namespace Realms
         public static void Move<T>(this IList<T> list, T item, int index)
         {
             Argument.NotNull(list, nameof(list));
+
             var from = list.IndexOf(item);
             list.Move(from, index);
         }
@@ -136,6 +137,7 @@ namespace Realms
         public static void Move<T>(this IList<T> list, int from, int to)
         {
             Argument.NotNull(list, nameof(list));
+
             if (list is RealmList<T> realmList)
             {
                 realmList.Move(from, to);
@@ -154,7 +156,7 @@ namespace Realms
         /// supports SORT and DISTINCT clauses in addition to filtering.
         /// </summary>
         /// <typeparam name="T">The type of the objects that will be filtered.</typeparam>
-        /// <param name="results">
+        /// <param name="query">
         /// A Queryable collection, obtained by calling <see cref="Realm.All{T}"/>.
         /// </param>
         /// <param name="predicate">The predicate that will be applied.</param>
@@ -177,9 +179,9 @@ namespace Realms
         /// Examples of the NSPredicate syntax
         /// </seealso>
         /// <seealso href="https://academy.realm.io/posts/nspredicate-cheatsheet/">NSPredicate Cheatsheet</seealso>
-        public static IQueryable<T> Filter<T>(this IQueryable<T> results, string predicate)
+        public static IQueryable<T> Filter<T>(this IQueryable<T> query, string predicate)
         {
-            var realmResults = Argument.EnsureType<RealmResults<T>>(results, $"{nameof(results)} must be a query obtained by calling Realm.All.", nameof(results));
+            var realmResults = Argument.EnsureType<RealmResults<T>>(query, $"{nameof(query)} must be a query obtained by calling Realm.All.", nameof(query));
             return realmResults.GetFilteredResults(predicate);
         }
     }

--- a/Realm/Realm/Extensions/FrozenObjectsExtensions.cs
+++ b/Realm/Realm/Extensions/FrozenObjectsExtensions.cs
@@ -1,0 +1,123 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Realms.Exceptions;
+using Realms.Helpers;
+
+namespace Realms
+{
+    /// <summary>
+    /// A set of extension methods on top of RealmObject.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class FrozenObjectsExtensions
+    {
+        /// <summary>
+        /// Returns a frozen snapshot of this object. The frozen copy can be read and queried from any thread without throwing an exception.
+        /// <para/>
+        /// Freezing a RealmObject also creates a frozen Realm which has its own lifecycle, but if the live Realm that spawned the
+        /// original object is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
+        /// object will be closed as well.
+        /// <para/>
+        /// Frozen objects can be queried as normal, but trying to mutate it in any way or attempting to register a listener will
+        /// throw a <see cref="Exceptions.RealmFrozenException"/>.
+        /// <para/>
+        /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
+        /// of the Realm. In order to avoid such a situation it is possible to set <see cref="RealmConfigurationBase.MaxNumberOfActiveVersions"/>.
+        /// </summary>
+        /// <param name="realmObj">The <see cref="RealmObject"/> instance that you want to create a frozen version of.</param>
+        /// <typeparam name="T">The type of the <see cref="RealmObject"/>.</typeparam>
+        /// <returns>A new frozen instance of the passed in object or the object itself if it was already frozen.</returns>
+        /// <seealso cref="RealmObject.FreezeInPlace"/>
+        public static T Freeze<T>(this T realmObj)
+            where T : RealmObject
+        {
+            Argument.NotNull(realmObj, nameof(realmObj));
+
+            if (realmObj.IsFrozen)
+            {
+                return realmObj;
+            }
+
+            var (realm, objectHandle) = realmObj.FreezeImpl();
+            return (T)realm.MakeObject(realmObj.ObjectMetadata, objectHandle);
+        }
+
+        /// <summary>
+        /// Creates a frozen snapshot of this list. The frozen copy can be read and iterated over from any thread. If the list is
+        /// not managed, a <see cref="RealmException"/> will be thrown.
+        /// <para/>
+        /// Freezing a list also creates a frozen Realm which has its own lifecycle, but if the live Realm that spawned the
+        /// original list is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
+        /// list will be closed as well.
+        /// <para/>
+        /// Frozen lists can be read and iterated as normal, but trying to mutate it in any way or attempting to register a listener will
+        /// throw a <see cref="RealmFrozenException"/>.
+        /// <para/>
+        /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
+        /// of the Realm. In order to avoid such a situation it is possible to set <see cref="RealmConfigurationBase.MaxNumberOfActiveVersions"/>.
+        /// </summary>
+        /// <param name="list">The list you want to create a frozen copy of.</param>
+        /// <typeparam name="T">Type of the objects in the list.</typeparam>
+        /// <returns>A frozen copy of this list.</returns>
+        public static IList<T> Freeze<T>(this IList<T> list)
+        {
+            Argument.NotNull(list, nameof(list));
+
+            if (list is RealmList<T> realmList)
+            {
+                return (RealmList<T>)realmList.Freeze();
+            }
+
+            throw new RealmException("Unmanaged lists cannot be frozen.");
+        }
+
+        /// <summary>
+        /// Creates a frozen snapshot of this query. The frozen copy can be read and queried from any thread. If the query is
+        /// not managed (i.e. not a result of <see cref="Realm.All{T}"/> invocation), a <see cref="RealmException"/> will be thrown.
+        /// <para/>
+        /// Freezing a query also creates a frozen Realm which has its own lifecycle, but if the live Realm that spawned the
+        /// original query is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
+        /// query will be closed as well.
+        /// <para/>
+        /// Frozen queries can be read and iterated as normal, but trying to mutate it in any way or attempting to register a listener will
+        /// throw a <see cref="RealmFrozenException"/>.
+        /// <para/>
+        /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
+        /// of the Realm. In order to avoid such a situation it is possible to set <see cref="RealmConfigurationBase.MaxNumberOfActiveVersions"/>.
+        /// </summary>
+        /// <param name="query">The query you want to create a frozen copy of.</param>
+        /// <typeparam name="T">The type of the <see cref="RealmObject"/> in the query.</typeparam>
+        /// <returns>A frozen copy of this query.</returns>
+        public static IQueryable<T> Freeze<T>(this IQueryable<T> query)
+            where T : RealmObject
+        {
+            Argument.NotNull(query, nameof(query));
+
+            if (query is RealmResults<T> realmResults)
+            {
+                return (RealmResults<T>)realmResults.Freeze();
+            }
+
+            throw new RealmException("Unmanaged queries cannot be frozen.");
+        }
+    }
+}

--- a/Realm/Realm/Extensions/RealmSyncExtensions.cs
+++ b/Realm/Realm/Extensions/RealmSyncExtensions.cs
@@ -18,9 +18,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
 using Realms.Helpers;
 
 namespace Realms.Sync

--- a/Realm/Realm/GlobalSuppressions.cs
+++ b/Realm/Realm/GlobalSuppressions.cs
@@ -21,3 +21,4 @@
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.RealmCollectionBase`1._collectionChanged")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.RealmCollectionBase`1._propertyChanged")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.RealmObject._propertyChanged")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.Realm._realmChanged")]

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -1,4 +1,4 @@
-﻿////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
 //
 // Copyright 2016 Realm Inc.
 //
@@ -153,6 +153,13 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_snapshot", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr snapshot(ListHandle list, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static extern bool get_is_frozen(ListHandle list, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_freeze", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr freeze(ListHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
 
 #pragma warning restore IDE1006 // Naming Styles
         }
@@ -379,6 +386,23 @@ namespace Realms
         public override ResultsHandle GetFilteredResults(string query)
         {
             throw new NotImplementedException("Lists can't be filtered yet.");
+        }
+
+        public override bool IsFrozen
+        {
+            get
+            {
+                var result = NativeMethods.get_is_frozen(this, out var nativeException);
+                nativeException.ThrowIfNecessary();
+                return result;
+            }
+        }
+
+        public ListHandle Freeze(SharedRealmHandle frozenRealmHandle)
+        {
+            var result = NativeMethods.freeze(this, frozenRealmHandle, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return new ListHandle(frozenRealmHandle, result);
         }
     }
 }

--- a/Realm/Realm/Handles/NotifiableObjectHandleBase.cs
+++ b/Realm/Realm/Handles/NotifiableObjectHandleBase.cs
@@ -52,5 +52,7 @@ namespace Realms
         public abstract NotificationTokenHandle AddNotificationCallback(IntPtr managedObjectHandle, NotificationCallbackDelegate callback);
 
         public abstract ThreadSafeReferenceHandle GetThreadSafeReference();
+
+        public abstract bool IsFrozen { get; }
     }
 }

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -147,6 +147,13 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_backlink_count", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_backlink_count(ObjectHandle objectHandle, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static extern bool get_is_frozen(ObjectHandle objectHandle, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_freeze", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr freeze(ObjectHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
+
 #pragma warning restore SA1121 // Use built-in type alias
 #pragma warning restore IDE1006 // Naming Styles
         }
@@ -189,6 +196,16 @@ namespace Realms
             nativeException.ThrowIfNecessary();
 
             return result;
+        }
+
+        public override bool IsFrozen
+        {
+            get
+            {
+                var result = NativeMethods.get_is_frozen(this, out var nativeException);
+                nativeException.ThrowIfNecessary();
+                return result;
+            }
         }
 
         protected override void Unbind()
@@ -568,6 +585,13 @@ namespace Realms
             NativeMethods.get_key(this, out var result, out var nativeException);
             nativeException.ThrowIfNecessary();
             return result;
+        }
+
+        public ObjectHandle Freeze(SharedRealmHandle frozenRealmHandle)
+        {
+            var result = NativeMethods.freeze(this, frozenRealmHandle, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return new ObjectHandle(frozenRealmHandle, result);
         }
     }
 }

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -1,4 +1,4 @@
-﻿////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
 //
 // Copyright 2016 Realm Inc.
 //
@@ -81,6 +81,13 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_find_object", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr find_object(ResultsHandle results, ObjectHandle objectHandle, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static extern bool get_is_frozen(ResultsHandle results, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_freeze", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr freeze(ResultsHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
 
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore SA1121 // Use built-in type alias
@@ -215,6 +222,23 @@ namespace Realms
             var result = NativeMethods.find_object(this, objectHandle, out var nativeException);
             nativeException.ThrowIfNecessary();
             return (int)result;
+        }
+
+        public override bool IsFrozen
+        {
+            get
+            {
+                var result = NativeMethods.get_is_frozen(this, out var nativeException);
+                nativeException.ThrowIfNecessary();
+                return result;
+            }
+        }
+
+        public ResultsHandle Freeze(SharedRealmHandle frozenRealmHandle)
+        {
+            var result = NativeMethods.freeze(this, frozenRealmHandle, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return new ResultsHandle(frozenRealmHandle, result);
         }
     }
 }

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -129,6 +129,13 @@ namespace Realms
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool has_changed(SharedRealmHandle sharedRealm);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static extern bool get_is_frozen(SharedRealmHandle sharedRealm, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_freeze", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr freeze(SharedRealmHandle sharedRealm, out NativeException ex);
+
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore SA1121 // Use built-in type alias
         }
@@ -176,6 +183,16 @@ namespace Realms
         {
             NativeMethods.close_realm(this, out var nativeException);
             nativeException.ThrowIfNecessary();
+        }
+
+        public bool IsFrozen
+        {
+            get
+            {
+                var result = NativeMethods.get_is_frozen(this, out var nativeException);
+                nativeException.ThrowIfNecessary();
+                return result;
+            }
         }
 
         public void SetManagedStateHandle(IntPtr managedStateHandle)
@@ -330,6 +347,13 @@ namespace Realms
         public bool HasChanged()
         {
             return NativeMethods.has_changed(this);
+        }
+
+        public SharedRealmHandle Freeze()
+        {
+            var result = NativeMethods.freeze(this, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return new SharedRealmHandle(result);
         }
 
         private ObjectHandle CreateObjectWithPrimaryKey(TableHandle table, long? key, bool isNullable, bool update, out bool isNew)

--- a/Realm/Realm/Linq/IRealmCollection.cs
+++ b/Realm/Realm/Linq/IRealmCollection.cs
@@ -70,6 +70,36 @@ namespace Realms
         bool IsValid { get; }
 
         /// <summary>
+        /// Gets the <see cref="Realm"/> instance this collection belongs to.
+        /// </summary>
+        /// <value>The <see cref="Realm"/> instance this collection belongs to.</value>
+        Realm Realm { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this collection is frozen. Frozen collections are immutable and can be accessed
+        /// from any thread. The objects read from a frozen collection will also be frozen.
+        /// </summary>
+        bool IsFrozen { get; }
+
+        /// <summary>
+        /// Creates a frozen snapshot of this collection. The frozen copy can be read and queried from any thread.
+        /// <para/>
+        /// Freezing a collection also creates a frozen Realm which has its own lifecycle, but if the live Realm that spawned the
+        /// original collection is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
+        /// collection will be closed as well.
+        /// <para/>
+        /// Frozen collections can be queried as normal, but trying to mutate it in any way or attempting to register a listener will
+        /// throw a <see cref="Exceptions.RealmFrozenException"/>.
+        /// <para/>
+        /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
+        /// of the Realm. In order to avoid such a situation it is possible to set <see cref="RealmConfigurationBase.MaxNumberOfActiveVersions"/>.
+        /// </summary>
+        /// <returns>A frozen copy of this collection.</returns>
+        /// <seealso cref="FrozenObjectsExtensions.Freeze{T}(IList{T})"/>
+        /// <seealso cref="FrozenObjectsExtensions.Freeze{T}(System.Linq.IQueryable{T})"/>
+        IRealmCollection<T> Freeze();
+
+        /// <summary>
         /// Register a callback to be invoked each time this <see cref="IRealmCollection{T}"/> changes.
         /// </summary>
         /// <remarks>
@@ -101,6 +131,8 @@ namespace Realms
         /// A subscription token. It must be kept alive for as long as you want to receive change notifications.
         /// To stop receiving notifications, call <see cref="IDisposable.Dispose" />.
         /// </returns>
+        /// <seealso cref="CollectionNotificationsExtensions.SubscribeForNotifications{T}(IList{T}, NotificationCallbackDelegate{T})"/>
+        /// <seealso cref="CollectionNotificationsExtensions.SubscribeForNotifications{T}(System.Linq.IQueryable{T}, NotificationCallbackDelegate{T})"/>
         IDisposable SubscribeForNotifications(NotificationCallbackDelegate<T> callback);
     }
 }

--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -50,6 +50,18 @@ namespace Realms
 
         public QueryHandle CreateQuery() => ResultsHandle.CreateQuery();
 
+        public override IRealmCollection<T> Freeze()
+        {
+            if (IsFrozen)
+            {
+                return this;
+            }
+
+            var frozenRealm = Realm.Freeze();
+            var frozenHandle = ResultsHandle.Freeze(frozenRealm.SharedRealmHandle);
+            return new RealmResults<T>(frozenRealm, Metadata, frozenHandle);
+        }
+
         internal override CollectionHandleBase CreateHandle()
         {
             if (_handle != null)

--- a/Realm/Realm/Native/Configuration.cs
+++ b/Realm/Realm/Native/Configuration.cs
@@ -63,5 +63,7 @@ namespace Realms.Native
 
         [MarshalAs(UnmanagedType.I1)]
         internal bool enable_cache;
+
+        internal ulong max_number_of_active_versions;
     }
 }

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -108,9 +108,14 @@ namespace Realms
 
         public bool IsValid => Handle.Value.IsValid;
 
+        public bool IsFrozen => Handle.Value.IsFrozen;
+
+        public Realm Realm { get; }
+
+        public abstract IRealmCollection<T> Freeze();
+
         IThreadConfinedHandle IThreadConfined.Handle => Handle.Value;
 
-        internal readonly Realm Realm;
         internal readonly Lazy<CollectionHandleBase> Handle;
 
         internal RealmCollectionBase(Realm realm, RealmObject.Metadata metadata)

--- a/Realm/Realm/RealmList.cs
+++ b/Realm/Realm/RealmList.cs
@@ -234,6 +234,18 @@ namespace Realms
             _listHandle.Move((IntPtr)sourceIndex, (IntPtr)targetIndex);
         }
 
+        public override IRealmCollection<T> Freeze()
+        {
+            if (IsFrozen)
+            {
+                return this;
+            }
+
+            var frozenRealm = Realm.Freeze();
+            var frozenHandle = _listHandle.Freeze(frozenRealm.SharedRealmHandle);
+            return new RealmList<T>(frozenRealm, frozenHandle, Metadata);
+        }
+
         DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression expression) => new MetaRealmList(expression, this);
 
         private static void Execute(T item,

--- a/Tests/Realm.Tests/RealmInstanceTest.cs
+++ b/Tests/Realm.Tests/RealmInstanceTest.cs
@@ -38,28 +38,32 @@ namespace Realms.Tests
             CleanupOnTearDown(obj.Realm);
         }
 
-        protected T Freeze<T>(T obj) where T : RealmObject
+        protected T Freeze<T>(T obj)
+            where T : RealmObject
         {
             var result = obj.Freeze();
             CleanupOnTearDown(result.Realm);
             return result;
         }
 
-        protected IRealmCollection<T> Freeze<T>(IRealmCollection<T> collection) where T : RealmObject
+        protected IRealmCollection<T> Freeze<T>(IRealmCollection<T> collection)
+            where T : RealmObject
         {
             var result = collection.Freeze();
             CleanupOnTearDown(result.Realm);
             return result;
         }
 
-        protected IList<T> Freeze<T>(IList<T> list) where T : RealmObject
+        protected IList<T> Freeze<T>(IList<T> list)
+            where T : RealmObject
         {
             var result = list.Freeze();
             CleanupOnTearDown(result.AsRealmCollection().Realm);
             return result;
         }
 
-        protected IQueryable<T> Freeze<T>(IQueryable<T> query) where T : RealmObject
+        protected IQueryable<T> Freeze<T>(IQueryable<T> query)
+            where T : RealmObject
         {
             var result = query.Freeze();
             CleanupOnTearDown(result.AsRealmCollection().Realm);

--- a/Tests/Realm.Tests/RealmInstanceTest.cs
+++ b/Tests/Realm.Tests/RealmInstanceTest.cs
@@ -17,7 +17,9 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Realms.Tests
 {
@@ -30,17 +32,44 @@ namespace Realms.Tests
 
         protected Realm _realm => _lazyRealm.Value;
 
-        protected override void CustomSetUp()
+        protected void FreezeInPlace(RealmObject obj)
         {
-            _lazyRealm = new Lazy<Realm>(() => Realm.GetInstance(_configuration));
-            base.CustomSetUp();
+            obj.FreezeInPlace();
+            CleanupOnTearDown(obj.Realm);
         }
 
-        protected override void CustomTearDown()
+        protected T Freeze<T>(T obj) where T : RealmObject
         {
-            _realm.Dispose();
-            Realm.DeleteRealm(_realm.Config);
-            base.CustomTearDown();
+            var result = obj.Freeze();
+            CleanupOnTearDown(result.Realm);
+            return result;
+        }
+
+        protected IRealmCollection<T> Freeze<T>(IRealmCollection<T> collection) where T : RealmObject
+        {
+            var result = collection.Freeze();
+            CleanupOnTearDown(result.Realm);
+            return result;
+        }
+
+        protected IList<T> Freeze<T>(IList<T> list) where T : RealmObject
+        {
+            var result = list.Freeze();
+            CleanupOnTearDown(result.AsRealmCollection().Realm);
+            return result;
+        }
+
+        protected IQueryable<T> Freeze<T>(IQueryable<T> query) where T : RealmObject
+        {
+            var result = query.Freeze();
+            CleanupOnTearDown(result.AsRealmCollection().Realm);
+            return result;
+        }
+
+        protected override void CustomSetUp()
+        {
+            _lazyRealm = new Lazy<Realm>(() => GetRealm(_configuration));
+            base.CustomSetUp();
         }
     }
 }

--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 
@@ -24,6 +25,8 @@ namespace Realms.Tests
     [Preserve(AllMembers = true)]
     public abstract class RealmTest
     {
+        private readonly List<Realm> _realms = new List<Realm>();
+
         private bool _isSetup;
 
         protected virtual bool OverrideDefaultConfig => true;
@@ -53,6 +56,11 @@ namespace Realms.Tests
         {
         }
 
+        protected void CleanupOnTearDown(Realm realm)
+        {
+            _realms.Add(realm);
+        }
+
         [TearDown]
         public void TearDown()
         {
@@ -68,6 +76,24 @@ namespace Realms.Tests
 
         protected virtual void CustomTearDown()
         {
+            foreach (var realm in _realms)
+            {
+                try
+                {
+                    realm.Dispose();
+                    Realm.DeleteRealm(realm.Config);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        protected Realm GetRealm(RealmConfigurationBase config = null)
+        {
+            var result = Realm.GetInstance(config ?? RealmConfiguration.DefaultConfiguration);
+            CleanupOnTearDown(result);
+            return result;
         }
     }
 }

--- a/Tests/Realm.Tests/Sync/SyncTestBase.cs
+++ b/Tests/Realm.Tests/Sync/SyncTestBase.cs
@@ -28,7 +28,6 @@ namespace Realms.Tests.Sync
     public abstract class SyncTestBase : RealmTest
     {
         private readonly List<Session> _sessions = new List<Session>();
-        private readonly List<Realm> _realms = new List<Realm>();
 
         protected override void CustomSetUp()
         {
@@ -65,18 +64,6 @@ namespace Realms.Tests.Sync
         {
             base.CustomTearDown();
 
-            foreach (var realm in _realms)
-            {
-                try
-                {
-                    realm.Dispose();
-                    Realm.DeleteRealm(realm.Config);
-                }
-                catch
-                {
-                }
-            }
-
             foreach (var session in _sessions)
             {
                 session?.CloseHandle();
@@ -86,11 +73,6 @@ namespace Realms.Tests.Sync
         protected void CleanupOnTearDown(Session session)
         {
             _sessions.Add(session);
-        }
-
-        protected void CleanupOnTearDown(Realm realm)
-        {
-            _realms.Add(realm);
         }
 
         protected Session GetSession(Realm realm)
@@ -112,13 +94,6 @@ namespace Realms.Tests.Sync
             var session = realm.GetSession();
             await session.WaitForDownloadAsync();
             session.CloseHandle();
-        }
-
-        protected Realm GetRealm(RealmConfigurationBase config)
-        {
-            var result = Realm.GetInstance(config);
-            CleanupOnTearDown(result);
-            return result;
         }
 
         protected async Task<Realm> GetRealmAsync(RealmConfigurationBase config, bool openAsync = true, CancellationToken cancellationToken = default)

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -321,9 +321,9 @@ REALM_EXPORT size_t list_get_binary(List& list, size_t ndx, char* return_buffer,
 REALM_EXPORT size_t list_find_object(List& list, const Object& object_ptr, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
-		if (list.get_realm() != object_ptr.realm()) {
-			throw ObjectManagedByAnotherRealmException("Can't look up index of an object that belongs to a different Realm.");
-		}
+        if (list.get_realm() != object_ptr.realm()) {
+            throw ObjectManagedByAnotherRealmException("Can't look up index of an object that belongs to a different Realm.");
+        }
 
         return list.find(object_ptr.obj());
     });
@@ -457,6 +457,20 @@ REALM_EXPORT Results* list_snapshot(const List& list, NativeException::Marshalla
 {
     return handle_errors(ex, [&]() {
         return new Results(list.snapshot());
+    });
+}
+
+REALM_EXPORT bool list_get_is_frozen(const List& list, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return list.is_frozen();
+    });
+}
+
+REALM_EXPORT List* list_freeze(const List& list, const SharedRealm& realm, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return new List(list.freeze(realm));
     });
 }
 

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -365,5 +365,19 @@ extern "C" {
             return object.obj().get_backlink_count();
         });
     }
-    
+
+    REALM_EXPORT bool object_get_is_frozen(const Object& object, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [&]() {
+            return object.is_frozen();
+        });
+    }
+
+    REALM_EXPORT Object* object_freeze(const Object& object, const SharedRealm& realm, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [&]() {
+            return new Object(object.freeze(realm));
+        });
+    }
+
 }   // extern "C"

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -182,4 +182,18 @@ REALM_EXPORT size_t results_find_object(Results& results, const Object& object, 
     });
 }
 
+REALM_EXPORT bool results_get_is_frozen(Results& results, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return results.is_frozen();
+    });
+}
+
+REALM_EXPORT Results* results_freeze(Results& results, const SharedRealm& realm, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return new Results(results.freeze(realm));
+    });
+}
+
 }   // extern "C"

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -78,6 +78,7 @@ REALM_EXPORT SharedRealm* shared_realm_open(Configuration configuration, SchemaO
         Realm::Config config;
         config.path = pathStr.to_string();
         config.in_memory = configuration.in_memory;
+        config.max_number_of_active_versions = configuration.max_number_of_active_versions;
 
         // by definition the key is only allowed to be 64 bytes long, enforced by C# code
         if (encryption_key )
@@ -121,7 +122,6 @@ REALM_EXPORT SharedRealm* shared_realm_open(Configuration configuration, SchemaO
             config.should_compact_on_launch_function = [&configuration](uint64_t total_bytes, uint64_t used_bytes) {
                 return configuration.should_compact_callback(configuration.managed_should_compact_delegate, total_bytes, used_bytes);
             };
-            
         }
         
         config.cache = configuration.enable_cache;
@@ -377,6 +377,21 @@ REALM_EXPORT void shared_realm_get_schema(const SharedRealm& realm, void* manage
 REALM_EXPORT bool shared_realm_has_changed(const SharedRealm& realm)
 {
     return TestHelper::has_changed(realm);
+}
+
+REALM_EXPORT bool shared_realm_get_is_frozen(const SharedRealm& realm, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return realm->is_frozen();
+    });
+}
+
+REALM_EXPORT SharedRealm* shared_realm_freeze(const SharedRealm& realm, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        auto frozen_realm = realm->freeze();
+        return new SharedRealm{ frozen_realm };
+    });
 }
 
 }

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -51,6 +51,7 @@ struct Configuration
     void* managed_should_compact_delegate;
     
     bool enable_cache;
+    uint64_t max_number_of_active_versions;
 };
 
 namespace realm {

--- a/wrappers/src/sync_manager_cs.cpp
+++ b/wrappers/src/sync_manager_cs.cpp
@@ -91,6 +91,7 @@ Realm::Config get_shared_realm_config(Configuration configuration, SyncConfigura
     }
     
     config.schema_version = configuration.schema_version;
+    config.max_number_of_active_versions = configuration.max_number_of_active_versions;
     
     std::string realm_url(Utf16StringAccessor(sync_configuration.url, sync_configuration.url_len));
     


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

This introduces support for "frozen objects". These are objects, collections, or Realms that have been pinned at a particular version. This allows moving them between threads, but also means that they are not immutable and will not be updated as changes to the database happen. Trying to open a write transaction on a frozen Realm or subscribe for changes on an object/collection will throw an exception.

Below is a high level overview of the newly added API

```csharp
var liveRealm = Realm.GetInstance();

// Get a frozen Realm from a live one
var frozenRealm = liveRealm.Freeze();

// Check if a Realm is frozen
frozenRealm.IsFrozen; // true

// Frozen Realms can be queried as normal
var frozenFoos = frozenRealm.All<Foo>().Where(f => f.Bar > 5);

// Queries in frozen Realms are frozen themselves
frozenFoos.IsFrozen(); // true

// Writing to a frozen Realm or subscribing for changes is not allowed
// frozenRealm.Write(...) <-- throws
// frozenRealm.RealmChanged += (...) <-- throws

// Get a frozen query from a live one
var frozenFoos = liveRealm.All<Foo>().Where(f => f.Bar > 5).Freeze(); // extension method on IQueryable<T>
frozenFoos.IsFrozen(); // extension method on IQueryable<T> -> true

// Objects in a frozen query are frozen themselves
frozenFoos().First().IsFrozen; // true

// Get a frozen list from a live one
var liveFoo = liveRealm.Find<Foo>("123");
var frozenBars = liveFoo.Bars.Freeze(); // extension method on IList<T>
frozenBars.IsFrozen(); // extension method on IList<T> -> true

// Get a frozen object from a live one
var frozenFoo = liveFoo.Freeze();
frozenFoo.IsFrozen; // true

// RealmObjects can be frozen in place too if you no longer need the live version
liveFoo.FreezeInPlace();
liveFoo.IsFrozen; // true
```

Having multiple frozen Realms at different versions will cause file growth. To control the maximum number of pinned versions, a new property - `MaxNumberOfActiveVersions` is added to all `RealmConfiguration` classes. When set, Realm will keep track of the number of active versions and throw an exception if the limit is exceeded.

Fixes #1945, RNET-184

##  TODO

* [x] Wire up MaxNumberOfActiveVersions
* [x] Changelog entry
* [x] Tests for collections
* [x] Tests for MaxNumberOfActiveVersions
