### PR TITLE
Refactor RealmObject to reduce the number of methods

### DIFF
--- a/Realm/Realm.Fody/ImportedReferences.cs
+++ b/Realm/Realm.Fody/ImportedReferences.cs
@@ -101,6 +101,12 @@ namespace RealmWeaver
 
         public MethodReference RealmObject_GetBacklinks { get; private set; }
 
+        public MethodReference RealmObject_GetPrimitiveValue { get; private set; }
+
+        public MethodReference RealmObject_SetPrimitiveValue { get; private set; }
+
+        public MethodReference RealmObject_SetPrimitiveValueUnique { get; private set; }
+
         public TypeReference IRealmObjectHelper { get; private set; }
 
         public TypeReference PreserveAttribute { get; private set; }
@@ -128,6 +134,8 @@ namespace RealmWeaver
         public MethodReference PropertyChanged_DoNotNotifyAttribute_Constructor { get; private set; }
 
         public MethodReference RealmSchema_AddDefaultTypes { get; private set; }
+
+        public TypeReference RealmSchema_PropertyType { get; private set; }
 
         protected ModuleDefinition Module { get; }
 
@@ -239,6 +247,7 @@ namespace RealmWeaver
         {
             Realm = new TypeReference("Realms", "Realm", Module, realmAssembly);
             RealmObject = new TypeReference("Realms", "RealmObject", Module, realmAssembly);
+            RealmSchema_PropertyType = new TypeReference("Realms.Schema", "PropertyType", Module, realmAssembly, valueType: true);
 
             {
                 RealmIntegerOfT = new TypeReference("Realms", "RealmInteger`1", Module, realmAssembly)
@@ -311,6 +320,33 @@ namespace RealmWeaver
                 RealmObject_GetBacklinks.Parameters.Add(new ParameterDefinition(Types.StringReference));
             }
 
+            {
+                RealmObject_GetPrimitiveValue = new MethodReference("GetPrimitiveValue", Types.VoidReference, RealmObject) { HasThis = true };
+                var T = new GenericParameter(RealmObject_GetPrimitiveValue);
+                RealmObject_GetPrimitiveValue.ReturnType = T;
+                RealmObject_GetPrimitiveValue.GenericParameters.Add(T);
+                RealmObject_GetPrimitiveValue.Parameters.Add(new ParameterDefinition(Types.StringReference));
+            }
+
+            {
+                RealmObject_SetPrimitiveValue = new MethodReference("SetPrimitiveValue", Types.VoidReference, RealmObject) { HasThis = true };
+                var T = new GenericParameter(RealmObject_SetPrimitiveValue);
+                RealmObject_SetPrimitiveValue.GenericParameters.Add(T);
+                RealmObject_SetPrimitiveValue.Parameters.Add(new ParameterDefinition(Types.StringReference));
+                RealmObject_SetPrimitiveValue.Parameters.Add(new ParameterDefinition(T));
+                RealmObject_SetPrimitiveValue.Parameters.Add(new ParameterDefinition(RealmSchema_PropertyType));
+            }
+
+            {
+                RealmObject_SetPrimitiveValueUnique = new MethodReference("SetPrimitiveValueUnique", Types.VoidReference, RealmObject) { HasThis = true };
+                var T = new GenericParameter(RealmObject_SetPrimitiveValueUnique);
+                RealmObject_SetPrimitiveValueUnique.GenericParameters.Add(T);
+                RealmObject_SetPrimitiveValueUnique.Parameters.Add(new ParameterDefinition(Types.StringReference));
+                RealmObject_SetPrimitiveValueUnique.Parameters.Add(new ParameterDefinition(T));
+                RealmObject_SetPrimitiveValueUnique.Parameters.Add(new ParameterDefinition(RealmSchema_PropertyType));
+            }
+
+
             IRealmObjectHelper = new TypeReference("Realms.Weaving", "IRealmObjectHelper", Module, realmAssembly);
 
             PreserveAttribute = new TypeReference("Realms", "PreserveAttribute", Module, realmAssembly);
@@ -371,6 +407,11 @@ namespace RealmWeaver
             }
 
             return assembly;
+        }
+
+        public FieldReference GetPropertyTypeField(string name)
+        {
+            return new FieldReference(name, RealmSchema_PropertyType, RealmSchema_PropertyType);
         }
 
         public GenericParameter GetRealmIntegerGenericParameter(IGenericParameterProvider owner)

--- a/Realm/Realm.Fody/ImportedReferences.cs
+++ b/Realm/Realm.Fody/ImportedReferences.cs
@@ -326,6 +326,7 @@ namespace RealmWeaver
                 RealmObject_GetPrimitiveValue.ReturnType = T;
                 RealmObject_GetPrimitiveValue.GenericParameters.Add(T);
                 RealmObject_GetPrimitiveValue.Parameters.Add(new ParameterDefinition(Types.StringReference));
+                RealmObject_GetPrimitiveValue.Parameters.Add(new ParameterDefinition(RealmSchema_PropertyType));
             }
 
             {

--- a/Realm/Realm/Dynamic/MetaRealmObject.cs
+++ b/Realm/Realm/Dynamic/MetaRealmObject.cs
@@ -39,7 +39,7 @@ namespace Realms.Dynamic
                                                                                               .MakeGenericMethod(typeof(DynamicRealmObject));
 
         private static readonly MethodInfo PrimitiveValueGetMethod = typeof(PrimitiveValue).GetMethod(nameof(PrimitiveValue.Get), BindingFlags.Public | BindingFlags.Instance);
-        private static readonly MethodInfo CreatePrimitiveMethod = typeof(PrimitiveValue).GetMethod(nameof(PrimitiveValue.Generic), BindingFlags.Public | BindingFlags.Static);
+        private static readonly MethodInfo CreatePrimitiveMethod = typeof(PrimitiveValue).GetMethod(nameof(PrimitiveValue.Create), BindingFlags.Public | BindingFlags.Static);
 
         private static readonly ObjectHandle DummyHandle = new ObjectHandle(null, IntPtr.Zero);
 

--- a/Realm/Realm/Dynamic/MetaRealmObject.cs
+++ b/Realm/Realm/Dynamic/MetaRealmObject.cs
@@ -144,7 +144,7 @@ namespace Realms.Dynamic
                 {
                     case PropertyType.Int:
                     case PropertyType.Bool:
-                    case Schema.PropertyType.Float:
+                    case PropertyType.Float:
                     case PropertyType.Double:
                     case PropertyType.Date:
                         arguments.Add(Expression.Constant(property.Type));
@@ -277,20 +277,24 @@ namespace Realms.Dynamic
             return convertedExpression;
         }
 
+        // GetString(colKey)
+        // GetByteArray(colKey)
         private static MethodInfo GetGetMethod<TResult>(Func<ColumnKey, TResult> @delegate) => @delegate.GetMethodInfo();
 
         // GetPrimitive(colKey, propertyType)
         private static MethodInfo GetGetMethod<TResult>(Func<ColumnKey, PropertyType, TResult> @delegate) => @delegate.GetMethodInfo();
 
+        // GetBacklinks(propertyIndex)
         private static MethodInfo GetGetMethod<TResult>(Func<IntPtr, TResult> @delegate) => @delegate.GetMethodInfo();
 
-        private static MethodInfo GetSetMethod<TValue>(Action<ColumnKey, TValue> @delegate) => @delegate.GetMethodInfo();
-
-        // SetXXXUnique(colKey, isNullable, value)
-        private static MethodInfo GetSetMethod<TValue>(Action<ColumnKey, bool, TValue> @delegate) => @delegate.GetMethodInfo();
-
+        // GetList(realm, colKey, objectType)
+        // GetObject(realm, colKey, objectType)
         private static MethodInfo GetGetMethod<TResult>(Func<Realm, ColumnKey, string, TResult> @delegate) => @delegate.GetMethodInfo();
 
+        // SetXXX(colKey)
+        private static MethodInfo GetSetMethod<TValue>(Action<ColumnKey, TValue> @delegate) => @delegate.GetMethodInfo();
+
+        // SetObject(realm, colKey)
         private static MethodInfo GetSetMethod<TValue>(Action<Realm, ColumnKey, TValue> @delegate) => @delegate.GetMethodInfo();
     }
 }

--- a/Realm/Realm/Handles/QueryHandle.cs
+++ b/Realm/Realm/Handles/QueryHandle.cs
@@ -68,101 +68,25 @@ namespace Realms
             public static extern void string_like(QueryHandle queryPtr, ColumnKey columnKey,
                         [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.I1)] bool caseSensitive, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_bool_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void bool_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
+            // primitive is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
+            // that causes incorrect marshalling of the struct.
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_equal", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void primitive_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr primitive, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_bool_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void bool_not_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_not_equal", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void primitive_not_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr primitive, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_int_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void int_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_less", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void primitive_less(QueryHandle queryPtr, ColumnKey columnKey, IntPtr primitive, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_int_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void int_not_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_less_equal", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void primitive_less_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr primitive, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_int_less", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void int_less(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_greater", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void primitive_greater(QueryHandle queryPtr, ColumnKey columnKey, IntPtr primitive, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_int_less_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void int_less_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_int_greater", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void int_greater(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_int_greater_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void int_greater_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_long_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void long_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_long_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void long_not_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_long_less", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void long_less(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_long_less_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void long_less_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_long_greater", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void long_greater(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_long_greater_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void long_greater_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_float_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void float_equal(QueryHandle queryPtr, ColumnKey columnKey, Single value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_float_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void float_not_equal(QueryHandle queryPtr, ColumnKey columnKey, Single value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_float_less", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void float_less(QueryHandle queryPtr, ColumnKey columnKey, Single value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_float_less_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void float_less_equal(QueryHandle queryPtr, ColumnKey columnKey, Single value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_float_greater", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void float_greater(QueryHandle queryPtr, ColumnKey columnKey, Single value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_float_greater_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void float_greater_equal(QueryHandle queryPtr, ColumnKey columnKey, Single value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_double_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void double_equal(QueryHandle queryPtr, ColumnKey columnKey, Double value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_double_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void double_not_equal(QueryHandle queryPtr, ColumnKey columnKey, Double value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_double_less", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void double_less(QueryHandle queryPtr, ColumnKey columnKey, Double value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_double_less_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void double_less_equal(QueryHandle queryPtr, ColumnKey columnKey, Double value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_double_greater", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void double_greater(QueryHandle queryPtr, ColumnKey columnKey, Double value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_double_greater_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void double_greater_equal(QueryHandle queryPtr, ColumnKey columnKey, Double value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_timestamp_ticks_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void timestamp_ticks_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_timestamp_ticks_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void timestamp_ticks_not_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_timestamp_ticks_less", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void timestamp_ticks_less(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_timestamp_ticks_less_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void timestamp_ticks_less_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_timestamp_ticks_greater", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void timestamp_ticks_greater(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_timestamp_ticks_greater_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void timestamp_ticks_greater_equal(QueryHandle queryPtr, ColumnKey columnKey, Int64 value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_greater_equal", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void primitive_greater_equal(QueryHandle queryPtr, ColumnKey columnKey, IntPtr primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_object_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void query_object_equal(QueryHandle queryPtr, ColumnKey columnKey, ObjectHandle objectHandle, out NativeException ex);
@@ -206,18 +130,6 @@ namespace Realms
         {
             NativeMethods.destroy(handle);
         }
-
-        public NumericQueryMethods NumericEqualMethods => new NumericQueryMethods(IntEqual, LongEqual, FloatEqual, DoubleEqual);
-
-        public NumericQueryMethods NumericNotEqualMethods => new NumericQueryMethods(IntNotEqual, LongNotEqual, FloatNotEqual, DoubleNotEqual);
-
-        public NumericQueryMethods NumericLessMethods => new NumericQueryMethods(IntLess, LongLess, FloatLess, DoubleLess);
-
-        public NumericQueryMethods NumericLessEqualMethods => new NumericQueryMethods(IntLessEqual, LongLessEqual, FloatLessEqual, DoubleLessEqual);
-
-        public NumericQueryMethods NumericGreaterMethods => new NumericQueryMethods(IntGreater, LongGreater, FloatGreater, DoubleGreater);
-
-        public NumericQueryMethods NumericGreaterEqualMethods => new NumericQueryMethods(IntGreaterEqual, LongGreaterEqual, FloatGreaterEqual, DoubleGreaterEqual);
 
         public void BinaryEqual(ColumnKey columnKey, IntPtr buffer, IntPtr bufferLength)
         {
@@ -291,195 +203,45 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public void BoolEqual(ColumnKey columnKey, bool value)
+        public unsafe void PrimitiveEqual(ColumnKey columnKey, PrimitiveValue value)
         {
-            NativeMethods.bool_equal(this, columnKey, MarshalHelpers.BoolToIntPtr(value), out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_equal(this, columnKey, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void BoolNotEqual(ColumnKey columnKey, bool value)
+        public unsafe void PrimitiveNotEqual(ColumnKey columnKey, PrimitiveValue value)
         {
-            NativeMethods.bool_not_equal(this, columnKey, MarshalHelpers.BoolToIntPtr(value), out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_not_equal(this, columnKey, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void IntEqual(ColumnKey columnKey, int value)
+        public unsafe void PrimitiveLess(ColumnKey columnKey, PrimitiveValue value)
         {
-            NativeMethods.int_equal(this, columnKey, (IntPtr)value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_less(this, columnKey, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void IntNotEqual(ColumnKey columnKey, int value)
+        public unsafe void PrimitiveLessEqual(ColumnKey columnKey, PrimitiveValue value)
         {
-            NativeMethods.int_not_equal(this, columnKey, (IntPtr)value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_less_equal(this, columnKey, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void IntLess(ColumnKey columnKey, int value)
+        public unsafe void PrimitiveGreater(ColumnKey columnKey, PrimitiveValue value)
         {
-            NativeMethods.int_less(this, columnKey, (IntPtr)value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_greater(this, columnKey, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
-        public void IntLessEqual(ColumnKey columnKey, int value)
+        public unsafe void PrimitiveGreaterEqual(ColumnKey columnKey, PrimitiveValue value)
         {
-            NativeMethods.int_less_equal(this, columnKey, (IntPtr)value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void IntGreater(ColumnKey columnKey, int value)
-        {
-            NativeMethods.int_greater(this, columnKey, (IntPtr)value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void IntGreaterEqual(ColumnKey columnKey, int value)
-        {
-            NativeMethods.int_greater_equal(this, columnKey, (IntPtr)value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void LongEqual(ColumnKey columnKey, long value)
-        {
-            NativeMethods.long_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void LongNotEqual(ColumnKey columnKey, long value)
-        {
-            NativeMethods.long_not_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void LongLess(ColumnKey columnKey, long value)
-        {
-            NativeMethods.long_less(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void LongLessEqual(ColumnKey columnKey, long value)
-        {
-            NativeMethods.long_less_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void LongGreater(ColumnKey columnKey, long value)
-        {
-            NativeMethods.long_greater(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void LongGreaterEqual(ColumnKey columnKey, long value)
-        {
-            NativeMethods.long_greater_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void FloatEqual(ColumnKey columnKey, float value)
-        {
-            NativeMethods.float_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void FloatNotEqual(ColumnKey columnKey, float value)
-        {
-            NativeMethods.float_not_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void FloatLess(ColumnKey columnKey, float value)
-        {
-            NativeMethods.float_less(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void FloatLessEqual(ColumnKey columnKey, float value)
-        {
-            NativeMethods.float_less_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void FloatGreater(ColumnKey columnKey, float value)
-        {
-            NativeMethods.float_greater(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void FloatGreaterEqual(ColumnKey columnKey, float value)
-        {
-            NativeMethods.float_greater_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void DoubleEqual(ColumnKey columnKey, double value)
-        {
-            NativeMethods.double_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void DoubleNotEqual(ColumnKey columnKey, double value)
-        {
-            NativeMethods.double_not_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void DoubleLess(ColumnKey columnKey, double value)
-        {
-            NativeMethods.double_less(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void DoubleLessEqual(ColumnKey columnKey, double value)
-        {
-            NativeMethods.double_less_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void DoubleGreater(ColumnKey columnKey, double value)
-        {
-            NativeMethods.double_greater(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void DoubleGreaterEqual(ColumnKey columnKey, double value)
-        {
-            NativeMethods.double_greater_equal(this, columnKey, value, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void TimestampTicksEqual(ColumnKey columnKey, DateTimeOffset value)
-        {
-            NativeMethods.timestamp_ticks_equal(this, columnKey, value.ToUniversalTime().Ticks, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void TimestampTicksNotEqual(ColumnKey columnKey, DateTimeOffset value)
-        {
-            NativeMethods.timestamp_ticks_not_equal(this, columnKey, value.ToUniversalTime().Ticks, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void TimestampTicksLess(ColumnKey columnKey, DateTimeOffset value)
-        {
-            NativeMethods.timestamp_ticks_less(this, columnKey, value.ToUniversalTime().Ticks, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void TimestampTicksLessEqual(ColumnKey columnKey, DateTimeOffset value)
-        {
-            NativeMethods.timestamp_ticks_less_equal(this, columnKey, value.ToUniversalTime().Ticks, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void TimestampTicksGreater(ColumnKey columnKey, DateTimeOffset value)
-        {
-            NativeMethods.timestamp_ticks_greater(this, columnKey, value.ToUniversalTime().Ticks, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void TimestampTicksGreaterEqual(ColumnKey columnKey, DateTimeOffset value)
-        {
-            NativeMethods.timestamp_ticks_greater_equal(this, columnKey, value.ToUniversalTime().Ticks, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_greater_equal(this, columnKey, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -632,10 +632,10 @@ namespace Realms
                     queryHandle.StringEqual(columnKey, stringValue, caseSensitive: true);
                     break;
                 case bool boolValue:
-                    queryHandle.PrimitiveEqual(columnKey, PrimitiveValue.Create(boolValue, PropertyType.Bool));
+                    queryHandle.PrimitiveEqual(columnKey, PrimitiveValue.Bool(boolValue));
                     break;
                 case DateTimeOffset dateValue:
-                    queryHandle.PrimitiveEqual(columnKey, PrimitiveValue.Create(dateValue, PropertyType.Date));
+                    queryHandle.PrimitiveEqual(columnKey, PrimitiveValue.Date(dateValue));
                     break;
                 case byte[] buffer:
                     if (buffer.Length == 0)
@@ -676,10 +676,10 @@ namespace Realms
                     queryHandle.StringNotEqual(columnKey, stringValue, caseSensitive: true);
                     break;
                 case bool boolValue:
-                    queryHandle.PrimitiveNotEqual(columnKey, PrimitiveValue.Create(boolValue, PropertyType.Bool));
+                    queryHandle.PrimitiveNotEqual(columnKey, PrimitiveValue.Bool(boolValue));
                     break;
                 case DateTimeOffset date:
-                    queryHandle.PrimitiveNotEqual(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
+                    queryHandle.PrimitiveNotEqual(columnKey, PrimitiveValue.Date(date));
                     break;
                 case byte[] buffer:
                     if (buffer.Length == 0)
@@ -715,7 +715,7 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.PrimitiveLess(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
+                    queryHandle.PrimitiveLess(columnKey, PrimitiveValue.Date(date));
                     break;
                 case string _:
                 case bool _:
@@ -733,7 +733,7 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.PrimitiveLessEqual(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
+                    queryHandle.PrimitiveLessEqual(columnKey, PrimitiveValue.Date(date));
                     break;
                 case string _:
                 case bool _:
@@ -751,7 +751,7 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.PrimitiveGreater(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
+                    queryHandle.PrimitiveGreater(columnKey, PrimitiveValue.Date(date));
                     break;
                 case string _:
                 case bool _:
@@ -769,7 +769,7 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.PrimitiveGreaterEqual(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
+                    queryHandle.PrimitiveGreaterEqual(columnKey, PrimitiveValue.Date(date));
                     break;
                 case string _:
                 case bool _:
@@ -798,15 +798,15 @@ namespace Realms
                 columnType == typeof(RealmInteger<int>) ||
                 columnType == typeof(RealmInteger<long>))
             {
-                action(columnKey, PrimitiveValue.Create((long)Convert.ChangeType(value, typeof(long)), PropertyType.Int));
+                action(columnKey, PrimitiveValue.Int((long)Convert.ChangeType(value, typeof(long))));
             }
             else if (columnType == typeof(float))
             {
-                action(columnKey, PrimitiveValue.Create((float)Convert.ChangeType(value, typeof(float)), PropertyType.Float));
+                action(columnKey, PrimitiveValue.Float((float)Convert.ChangeType(value, typeof(float))));
             }
             else if (columnType == typeof(double))
             {
-                action(columnKey, PrimitiveValue.Create((double)Convert.ChangeType(value, typeof(double)), PropertyType.Double));
+                action(columnKey, PrimitiveValue.Double((double)Convert.ChangeType(value, typeof(double))));
             }
             else
             {

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -632,10 +632,10 @@ namespace Realms
                     queryHandle.StringEqual(columnKey, stringValue, caseSensitive: true);
                     break;
                 case bool boolValue:
-                    queryHandle.BoolEqual(columnKey, boolValue);
+                    queryHandle.PrimitiveEqual(columnKey, PrimitiveValue.Create(boolValue, PropertyType.Bool));
                     break;
                 case DateTimeOffset dateValue:
-                    queryHandle.TimestampTicksEqual(columnKey, dateValue);
+                    queryHandle.PrimitiveEqual(columnKey, PrimitiveValue.Create(dateValue, PropertyType.Date));
                     break;
                 case byte[] buffer:
                     if (buffer.Length == 0)
@@ -659,7 +659,7 @@ namespace Realms
                     break;
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.NumericEqualMethods);
+                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.PrimitiveEqual);
                     break;
             }
         }
@@ -676,10 +676,10 @@ namespace Realms
                     queryHandle.StringNotEqual(columnKey, stringValue, caseSensitive: true);
                     break;
                 case bool boolValue:
-                    queryHandle.BoolNotEqual(columnKey, boolValue);
+                    queryHandle.PrimitiveNotEqual(columnKey, PrimitiveValue.Create(boolValue, PropertyType.Bool));
                     break;
                 case DateTimeOffset date:
-                    queryHandle.TimestampTicksNotEqual(columnKey, date);
+                    queryHandle.PrimitiveNotEqual(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
                     break;
                 case byte[] buffer:
                     if (buffer.Length == 0)
@@ -704,7 +704,7 @@ namespace Realms
                     break;
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.NumericNotEqualMethods);
+                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.PrimitiveNotEqual);
                     break;
             }
         }
@@ -715,14 +715,14 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.TimestampTicksLess(columnKey, date);
+                    queryHandle.PrimitiveLess(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
                     break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.NumericLessMethods);
+                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.PrimitiveLess);
                     break;
             }
         }
@@ -733,14 +733,14 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.TimestampTicksLessEqual(columnKey, date);
+                    queryHandle.PrimitiveLessEqual(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
                     break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.NumericLessEqualMethods);
+                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.PrimitiveLessEqual);
                     break;
             }
         }
@@ -751,14 +751,14 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.TimestampTicksGreater(columnKey, date);
+                    queryHandle.PrimitiveGreater(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
                     break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.NumericGreaterMethods);
+                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.PrimitiveGreater);
                     break;
             }
         }
@@ -769,19 +769,19 @@ namespace Realms
             switch (value)
             {
                 case DateTimeOffset date:
-                    queryHandle.TimestampTicksGreaterEqual(columnKey, date);
+                    queryHandle.PrimitiveGreaterEqual(columnKey, PrimitiveValue.Create(date, PropertyType.Date));
                     break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.NumericGreaterEqualMethods);
+                    AddQueryForConvertibleTypes(columnKey, value, columnType, queryHandle.PrimitiveGreaterEqual);
                     break;
             }
         }
 
-        private static void AddQueryForConvertibleTypes(ColumnKey columnKey, object value, Type columnType, QueryHandle.NumericQueryMethods queryMethods)
+        private static void AddQueryForConvertibleTypes(ColumnKey columnKey, object value, Type columnType, Action<ColumnKey, PrimitiveValue> action)
         {
             if (columnType.IsConstructedGenericType && columnType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
@@ -792,24 +792,21 @@ namespace Realms
                 columnType == typeof(short) ||
                 columnType == typeof(char) ||
                 columnType == typeof(int) ||
+                columnType == typeof(long) ||
                 columnType == typeof(RealmInteger<byte>) ||
                 columnType == typeof(RealmInteger<short>) ||
-                columnType == typeof(RealmInteger<int>))
+                columnType == typeof(RealmInteger<int>) ||
+                columnType == typeof(RealmInteger<long>))
             {
-                queryMethods.Int(columnKey, (int)Convert.ChangeType(value, typeof(int)));
-            }
-            else if (columnType == typeof(long) ||
-                     columnType == typeof(RealmInteger<long>))
-            {
-                queryMethods.Long(columnKey, (long)Convert.ChangeType(value, typeof(long)));
+                action(columnKey, PrimitiveValue.Create((long)Convert.ChangeType(value, typeof(long)), PropertyType.Int));
             }
             else if (columnType == typeof(float))
             {
-                queryMethods.Float(columnKey, (float)Convert.ChangeType(value, typeof(float)));
+                action(columnKey, PrimitiveValue.Create((float)Convert.ChangeType(value, typeof(float)), PropertyType.Float));
             }
             else if (columnType == typeof(double))
             {
-                queryMethods.Double(columnKey, (double)Convert.ChangeType(value, typeof(double)));
+                action(columnKey, PrimitiveValue.Create((double)Convert.ChangeType(value, typeof(double)), PropertyType.Double));
             }
             else
             {

--- a/Realm/Realm/Native/PrimitiveValue.cs
+++ b/Realm/Realm/Native/PrimitiveValue.cs
@@ -120,7 +120,7 @@ namespace Realms.Native
             int_value = value.GetValueOrDefault().ToUniversalTime().Ticks
         };
 
-        public static PrimitiveValue Generic<T>(T value, PropertyType type)
+        public static PrimitiveValue Create<T>(T value, PropertyType type)
         {
             var result = new PrimitiveValue
             {

--- a/Realm/Realm/RealmList.cs
+++ b/Realm/Realm/RealmList.cs
@@ -162,7 +162,7 @@ namespace Realms
                 case PropertyType.Data | PropertyType.Nullable:
                     return _listHandle.Find(Operator.Convert<T, byte[]>(value));
                 default:
-                    return _listHandle.Find(PrimitiveValue.Generic(value, _argumentType));
+                    return _listHandle.Find(PrimitiveValue.Create(value, _argumentType));
             }
         }
 
@@ -268,7 +268,7 @@ namespace Realms
                     binaryHandler(Operator.Convert<T, byte[]>(item));
                     break;
                 default:
-                    primitiveHandler(PrimitiveValue.Generic(item, _argumentType));
+                    primitiveHandler(PrimitiveValue.Create(item, _argumentType));
                     break;
             }
         }

--- a/Realm/Realm/RealmObject.cs
+++ b/Realm/Realm/RealmObject.cs
@@ -209,74 +209,11 @@ namespace Realms
             return _objectHandle.GetString(_metadata.ColumnKeys[propertyName]);
         }
 
-        protected char GetCharValue(string propertyName)
+        protected T GetPrimitiveValue<T>(string propertyName)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Int).Get<char>();
-        }
-
-        protected char? GetNullableCharValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Int | PropertyType.Nullable).Get<char?>();
-        }
-
-        protected float GetSingleValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Float).Get<float>();
-        }
-
-        protected float? GetNullableSingleValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Float | PropertyType.Nullable).Get<float?>();
-        }
-
-        protected double GetDoubleValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Double).Get<double>();
-        }
-
-        protected double? GetNullableDoubleValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Double | PropertyType.Nullable).Get<double?>();
-        }
-
-        protected bool GetBooleanValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Bool).Get<bool>();
-        }
-
-        protected bool? GetNullableBooleanValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Bool | PropertyType.Nullable).Get<bool?>();
-        }
-
-        protected DateTimeOffset GetDateTimeOffsetValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Date).Get<DateTimeOffset>();
-        }
-
-        protected DateTimeOffset? GetNullableDateTimeOffsetValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Date | PropertyType.Nullable).Get<DateTimeOffset?>();
+            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Int).Get<T>();
         }
 
         protected internal IList<T> GetListValue<T>(string propertyName)
@@ -353,6 +290,20 @@ namespace Realms
 
         #region Setters
 
+        protected void SetPrimitiveValue<T>(string propertyName, T value, PropertyType propertyType)
+        {
+            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
+
+            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.Create(value, propertyType));
+        }
+
+        protected void SetPrimitiveValueUnique<T>(string propertyName, T value, PropertyType propertyType)
+        {
+            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
+
+            _objectHandle.SetPrimitiveUnique(_metadata.ColumnKeys[propertyName], PrimitiveValue.Create(value, propertyType));
+        }
+
         protected void SetStringValue(string propertyName, string value)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
@@ -365,90 +316,6 @@ namespace Realms
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
             _objectHandle.SetStringUnique(_metadata.ColumnKeys[propertyName], value);
-        }
-
-        protected void SetCharValue(string propertyName, char value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.Int(value));
-        }
-
-        protected void SetCharValueUnique(string propertyName, char value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitiveUnique(_metadata.ColumnKeys[propertyName], PrimitiveValue.Int(value));
-        }
-
-        protected void SetNullableCharValue(string propertyName, char? value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.NullableInt(value));
-        }
-
-        protected void SetNullableCharValueUnique(string propertyName, char? value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitiveUnique(_metadata.ColumnKeys[propertyName], PrimitiveValue.NullableInt(value));
-        }
-
-        protected void SetSingleValue(string propertyName, float value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.Float(value));
-        }
-
-        protected void SetNullableSingleValue(string propertyName, float? value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.NullableFloat(value));
-        }
-
-        protected void SetDoubleValue(string propertyName, double value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.Double(value));
-        }
-
-        protected void SetNullableDoubleValue(string propertyName, double? value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.NullableDouble(value));
-        }
-
-        protected void SetBooleanValue(string propertyName, bool value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.Bool(value));
-        }
-
-        protected void SetNullableBooleanValue(string propertyName, bool? value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.NullableBool(value));
-        }
-
-        protected void SetDateTimeOffsetValue(string propertyName, DateTimeOffset value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.Date(value));
-        }
-
-        protected void SetNullableDateTimeOffsetValue(string propertyName, DateTimeOffset? value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.ColumnKeys[propertyName], PrimitiveValue.NullableDate(value));
         }
 
         // Originally a generic fallback, now used only for RealmObject To-One relationship properties

--- a/Realm/Realm/RealmObject.cs
+++ b/Realm/Realm/RealmObject.cs
@@ -209,11 +209,11 @@ namespace Realms
             return _objectHandle.GetString(_metadata.ColumnKeys[propertyName]);
         }
 
-        protected T GetPrimitiveValue<T>(string propertyName)
+        protected T GetPrimitiveValue<T>(string propertyName, PropertyType propertyType)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], PropertyType.Int).Get<T>();
+            return _objectHandle.GetPrimitive(_metadata.ColumnKeys[propertyName], propertyType).Get<T>();
         }
 
         protected internal IList<T> GetListValue<T>(string propertyName)
@@ -276,7 +276,7 @@ namespace Realms
             where T : struct, IFormattable, IComparable<T>
         {
             var columnKey = _metadata.ColumnKeys[propertyName];
-            var result = _objectHandle.GetPrimitive(columnKey, PropertyType.Int | PropertyType.Nullable).Get<T?>();
+            var result = _objectHandle.GetPrimitive(columnKey, PropertyType.NullableInt).Get<T?>();
 
             if (result.HasValue)
             {

--- a/Tests/Weaver/AssemblyToProcess/CopyToRealmTestObjects.cs
+++ b/Tests/Weaver/AssemblyToProcess/CopyToRealmTestObjects.cs
@@ -57,13 +57,13 @@ namespace AssemblyToProcess
     {
         public char? Char { get; set; }
 
-        public byte? Byte { get; set; }
+        public byte? NullableByte { get; set; }
 
-        public short? Int16 { get; set; }
+        public short? NullableInt16 { get; set; }
 
-        public int? Int32 { get; set; }
+        public int? NullableInt32 { get; set; }
 
-        public long? Int64 { get; set; }
+        public long? NullableInt64 { get; set; }
 
         public float? Single { get; set; }
 

--- a/Tests/Weaver/Realm.FakeForWeaverTests/Realm.FakeForWeaverTests.csproj
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/Realm.FakeForWeaverTests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\..\..\Realm\Realm\Attributes\PreserveAttribute.cs" Link="Attributes\PreserveAttribute.cs" />
     <Compile Include="..\..\..\Realm\Realm\Attributes\PrimaryKeyAttribute.cs" Link="Attributes\PrimaryKeyAttribute.cs" />
     <Compile Include="..\..\..\Realm\Realm\Attributes\RequiredAttribute.cs" Link="Attributes\RequiredAttribute.cs" />
+    <Compile Include="..\..\..\Realm\Realm\Schema\PropertyType.cs" Link="PropertyType.cs" />
     <Compile Include="..\..\..\Realm\Realm\Weaving\IRealmObjectHelper.cs" Link="IRealmObjectHelper.cs" />
     <Compile Include="..\..\..\Realm\Realm\Attributes\ExplicitAttribute.cs">
       <Link>Attributes\ExplicitAttribute.cs</Link>

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
@@ -79,7 +79,7 @@ namespace Realms
         }
 
 
-        protected T GetPrimitiveValue<T>(string propertyName)
+        protected T GetPrimitiveValue<T>(string propertyName, PropertyType propertyType)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
             return default(T);

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Realms.Schema;
 
 namespace Realms
 {
@@ -67,6 +68,23 @@ namespace Realms
             }
         }
 
+        protected void SetPrimitiveValue<T>(string propertyName, T value, PropertyType propertyType)
+        {
+            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
+        }
+
+        protected void SetPrimitiveValueUnique<T>(string propertyName, T value, PropertyType propertyType)
+        {
+            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
+        }
+
+
+        protected T GetPrimitiveValue<T>(string propertyName)
+        {
+            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
+            return default(T);
+        }
+
         protected string GetStringValue(string propertyName)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
@@ -79,126 +97,6 @@ namespace Realms
         }
 
         protected void SetStringValueUnique(string propertyName, string value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected char GetCharValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return char.MinValue;
-        }
-
-        protected void SetCharValue(string propertyName, char value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected void SetCharValueUnique(string propertyName, char value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected void SetNullableCharValueUnique(string propertyName, char? value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected float GetSingleValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return 0;
-        }
-
-        protected void SetSingleValue(string propertyName, float value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected double GetDoubleValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return 0;
-        }
-
-        protected void SetDoubleValue(string propertyName, double value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected bool GetBooleanValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return false;
-        }
-
-        protected void SetBooleanValue(string propertyName, bool value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected DateTimeOffset GetDateTimeOffsetValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return DateTimeOffset.MinValue;
-        }
-
-        protected void SetDateTimeOffsetValue(string propertyName, DateTimeOffset value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected DateTimeOffset? GetNullableDateTimeOffsetValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return DateTimeOffset.MinValue;
-        }
-
-        protected void SetNullableDateTimeOffsetValue(string propertyName, DateTimeOffset? value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected char? GetNullableCharValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return char.MinValue;
-        }
-
-        protected void SetNullableCharValue(string propertyName, char? value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected float? GetNullableSingleValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return 0;
-        }
-
-        protected void SetNullableSingleValue(string propertyName, float? value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected double? GetNullableDoubleValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return 0;
-        }
-
-        protected void SetNullableDoubleValue(string propertyName, double? value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected bool? GetNullableBooleanValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return false;
-        }
-
-        protected void SetNullableBooleanValue(string propertyName, bool? value)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
         }

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -95,6 +95,11 @@ namespace RealmWeaver
                 return (type.StartsWith("Nullable") ? "Nullable" : string.Empty) + "RealmInteger";
             }
 
+            if (_primitiveValueTypes.Contains(type))
+            {
+                return "Primitive";
+            }
+
             return type;
         }
 
@@ -110,6 +115,20 @@ namespace RealmWeaver
             "NullableInt16",
             "NullableInt32",
             "NullableInt64"
+        };
+
+        private static readonly IEnumerable<string> _primitiveValueTypes = new[]
+        {
+            "Char",
+            "Single",
+            "Double",
+            "Boolean",
+            "DateTimeOffset",
+            "NullableChar",
+            "NullableSingle",
+            "NullableDouble",
+            "NullableBoolean",
+            "NullableDateTimeOffset",
         };
 
         public enum PropertyChangedWeaver
@@ -610,7 +629,7 @@ namespace RealmWeaver
                                            return new[]
                                            {
                                                "IsManaged",
-                                               $"RealmObject.SetNullable{GetCoreMethodName(p.Name)}Value(propertyName = \"{p.Name}\", value = )"
+                                               $"RealmObject.Set{GetCoreMethodName(p.Name)}Value(propertyName = \"{p.Name}\", value = )"
                                            };
                                        })
                                        .ToList();

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -120,227 +120,221 @@ REALM_EXPORT void query_string_like(Query& query, ColKey column_key, uint16_t* v
     });
 }
 
-REALM_EXPORT void query_bool_equal(Query& query, ColKey column_key, bool value, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_equal(Query& query, ColKey column_key, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        query.equal(column_key, value);
+        if (!primitive.has_value) {
+            throw std::runtime_error("Comparing null values should be done via query_null_equal. If you get this error, please report it to help@realm.io.");
+        }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+        switch (primitive.type) {
+        case realm::PropertyType::Bool:
+        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+            query.equal(column_key, primitive.value.bool_value);
+            break;
+        case realm::PropertyType::Int:
+        case realm::PropertyType::Int | realm::PropertyType::Nullable:
+            query.equal(column_key, primitive.value.int_value);
+            break;
+        case realm::PropertyType::Float:
+        case realm::PropertyType::Float | realm::PropertyType::Nullable:
+            query.equal(column_key, primitive.value.float_value);
+            break;
+        case realm::PropertyType::Double:
+        case realm::PropertyType::Double | realm::PropertyType::Nullable:
+            query.equal(column_key, primitive.value.double_value);
+            break;
+        case realm::PropertyType::Date:
+        case realm::PropertyType::Date | realm::PropertyType::Nullable:
+            query.equal(column_key, from_ticks(primitive.value.int_value));
+            break;
+        default:
+            REALM_UNREACHABLE();
+        }
+#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_bool_not_equal(Query& query, ColKey column_key, bool value, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_not_equal(Query& query, ColKey column_key, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        query.not_equal(column_key, value);
+        if (!primitive.has_value) {
+            throw std::runtime_error("Comparing null values should be done via query_null_not_equal. If you get this error, please report it to help@realm.io.");
+        }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+        switch (primitive.type) {
+        case realm::PropertyType::Bool:
+        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+            query.not_equal(column_key, primitive.value.bool_value);
+            break;
+        case realm::PropertyType::Int:
+        case realm::PropertyType::Int | realm::PropertyType::Nullable:
+            query.not_equal(column_key, primitive.value.int_value);
+            break;
+        case realm::PropertyType::Float:
+        case realm::PropertyType::Float | realm::PropertyType::Nullable:
+            query.not_equal(column_key, primitive.value.float_value);
+            break;
+        case realm::PropertyType::Double:
+        case realm::PropertyType::Double | realm::PropertyType::Nullable:
+            query.not_equal(column_key, primitive.value.double_value);
+            break;
+        case realm::PropertyType::Date:
+        case realm::PropertyType::Date | realm::PropertyType::Nullable:
+            query.not_equal(column_key, from_ticks(primitive.value.int_value));
+            break;
+        default:
+            REALM_UNREACHABLE();
+        }
+#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_int_equal(Query& query, ColKey column_key, size_t value, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less(Query& query, ColKey column_key, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        query.equal(column_key, static_cast<int>(value));
+        if (!primitive.has_value) {
+            throw std::runtime_error("Using primitive_less with null is not supported. If you get this error, please report it to help@realm.io.");
+        }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+        switch (primitive.type) {
+        case realm::PropertyType::Bool:
+        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+            throw std::runtime_error("Using primitive_less with bool value is not supported. If you get this error, please report it to help@realm.io");
+        case realm::PropertyType::Int:
+        case realm::PropertyType::Int | realm::PropertyType::Nullable:
+            query.less(column_key, primitive.value.int_value);
+            break;
+        case realm::PropertyType::Float:
+        case realm::PropertyType::Float | realm::PropertyType::Nullable:
+            query.less(column_key, primitive.value.float_value);
+            break;
+        case realm::PropertyType::Double:
+        case realm::PropertyType::Double | realm::PropertyType::Nullable:
+            query.less(column_key, primitive.value.double_value);
+            break;
+        case realm::PropertyType::Date:
+        case realm::PropertyType::Date | realm::PropertyType::Nullable:
+            query.less(column_key, from_ticks(primitive.value.int_value));
+            break;
+        default:
+            REALM_UNREACHABLE();
+        }
+#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_int_not_equal(Query& query, ColKey column_key, size_t value, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less_equal(Query& query, ColKey column_key, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        query.not_equal(column_key, static_cast<int>(value));
+        if (!primitive.has_value) {
+            throw std::runtime_error("Using primitive_less_equal with null is not supported. If you get this error, please report it to help@realm.io.");
+        }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+        switch (primitive.type) {
+        case realm::PropertyType::Bool:
+        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+            throw std::runtime_error("Using primitive_less_equal with bool value is not supported. If you get this error, please report it to help@realm.io");
+        case realm::PropertyType::Int:
+        case realm::PropertyType::Int | realm::PropertyType::Nullable:
+            query.less_equal(column_key, primitive.value.int_value);
+            break;
+        case realm::PropertyType::Float:
+        case realm::PropertyType::Float | realm::PropertyType::Nullable:
+            query.less_equal(column_key, primitive.value.float_value);
+            break;
+        case realm::PropertyType::Double:
+        case realm::PropertyType::Double | realm::PropertyType::Nullable:
+            query.less_equal(column_key, primitive.value.double_value);
+            break;
+        case realm::PropertyType::Date:
+        case realm::PropertyType::Date | realm::PropertyType::Nullable:
+            query.less_equal(column_key, from_ticks(primitive.value.int_value));
+            break;
+        default:
+            REALM_UNREACHABLE();
+        }
+#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_int_less(Query& query, ColKey column_key, size_t value, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater(Query& query, ColKey column_key, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        query.less(column_key, static_cast<int>(value));
+        if (!primitive.has_value) {
+            throw std::runtime_error("Using primitive_greater with null is not supported. If you get this error, please report it to help@realm.io.");
+        }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+        switch (primitive.type) {
+        case realm::PropertyType::Bool:
+        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+            throw std::runtime_error("Using primitive_greater with bool value is not supported. If you get this error, please report it to help@realm.io");
+        case realm::PropertyType::Int:
+        case realm::PropertyType::Int | realm::PropertyType::Nullable:
+            query.greater(column_key, primitive.value.int_value);
+            break;
+        case realm::PropertyType::Float:
+        case realm::PropertyType::Float | realm::PropertyType::Nullable:
+            query.greater(column_key, primitive.value.float_value);
+            break;
+        case realm::PropertyType::Double:
+        case realm::PropertyType::Double | realm::PropertyType::Nullable:
+            query.greater(column_key, primitive.value.double_value);
+            break;
+        case realm::PropertyType::Date:
+        case realm::PropertyType::Date | realm::PropertyType::Nullable:
+            query.greater(column_key, from_ticks(primitive.value.int_value));
+            break;
+        default:
+            REALM_UNREACHABLE();
+        }
+#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_int_less_equal(Query& query, ColKey column_key, size_t value, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater_equal(Query& query, ColKey column_key, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        query.less_equal(column_key, static_cast<int>(value));
-    });
-}
+        if (!primitive.has_value) {
+            throw std::runtime_error("Using primitive_greater_equal with null is not supported. If you get this error, please report it to help@realm.io.");
+        }
 
-REALM_EXPORT void query_int_greater(Query& query, ColKey column_key, size_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater(column_key, static_cast<int>(value));
-    });
-}
-
-REALM_EXPORT void query_int_greater_equal(Query& query, ColKey column_key, size_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater_equal(column_key, static_cast<int>(value));
-    });
-}
-
-REALM_EXPORT void query_long_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.equal(column_key, value);
-    });
-}
-
-REALM_EXPORT void query_long_not_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.not_equal(column_key, value);
-    });
-}
-
-REALM_EXPORT void query_long_less(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less(column_key, value);
-    });
-}
-
-REALM_EXPORT void query_long_less_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less_equal(column_key, value);
-    });
-}
-
-REALM_EXPORT void query_long_greater(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater(column_key, value);
-    });
-}
-
-REALM_EXPORT void query_long_greater_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater_equal(column_key, value);
-    });
-}
-
-    REALM_EXPORT void query_float_equal(Query& query, ColKey column_key, float value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.equal(column_key, static_cast<float>(value));
-    });
-}
-
-REALM_EXPORT void query_float_not_equal(Query& query, ColKey column_key, float value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.not_equal(column_key, static_cast<float>(value));
-    });
-}
-
-REALM_EXPORT void query_float_less(Query& query, ColKey column_key, float value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less(column_key, static_cast<float>(value));
-    });
-}
-
-REALM_EXPORT void query_float_less_equal(Query& query, ColKey column_key, float value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less_equal(column_key, static_cast<float>(value));
-    });
-}
-
-REALM_EXPORT void query_float_greater(Query& query, ColKey column_key, float value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater(column_key, static_cast<float>(value));
-    });
-}
-
-REALM_EXPORT void query_float_greater_equal(Query& query, ColKey column_key, float value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater_equal(column_key, static_cast<float>(value));
-    });
-}
-
-REALM_EXPORT void query_double_equal(Query& query, ColKey column_key, double value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.equal(column_key, static_cast<double>(value));
-    });
-}
-
-REALM_EXPORT void query_double_not_equal(Query& query, ColKey column_key, double value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.not_equal(column_key, static_cast<double>(value));
-    });
-}
-
-REALM_EXPORT void query_double_less(Query& query, ColKey column_key, double value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less(column_key, static_cast<double>(value));
-    });
-}
-
-REALM_EXPORT void query_double_less_equal(Query& query, ColKey column_key, double value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less_equal(column_key, static_cast<double>(value));
-    });
-}
-
-REALM_EXPORT void query_double_greater(Query& query, ColKey column_key, double value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater(column_key, static_cast<double>(value));
-    });
-}
-
-REALM_EXPORT void query_double_greater_equal(Query& query, ColKey column_key, double value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater_equal(column_key, static_cast<double>(value));
-    });
-}
-
-REALM_EXPORT void query_timestamp_ticks_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.equal(column_key, from_ticks(value));
-    });
-}
-
-REALM_EXPORT void query_timestamp_ticks_not_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.not_equal(column_key, from_ticks(value));
-    });
-}
-
-REALM_EXPORT void query_timestamp_ticks_less(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less(column_key, from_ticks(value));
-    });
-}
-
-REALM_EXPORT void query_timestamp_ticks_less_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.less_equal(column_key, from_ticks(value));
-    });
-}
-
-REALM_EXPORT void query_timestamp_ticks_greater(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater(column_key, from_ticks(value));
-    });
-}
-
-REALM_EXPORT void query_timestamp_ticks_greater_equal(Query& query, ColKey column_key, int64_t value, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.greater_equal(column_key, from_ticks(value));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+        switch (primitive.type) {
+        case realm::PropertyType::Bool:
+        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+            throw std::runtime_error("Using primitive_greater_equal with bool value is not supported. If you get this error, please report it to help@realm.io");
+        case realm::PropertyType::Int:
+        case realm::PropertyType::Int | realm::PropertyType::Nullable:
+            query.greater_equal(column_key, primitive.value.int_value);
+            break;
+        case realm::PropertyType::Float:
+        case realm::PropertyType::Float | realm::PropertyType::Nullable:
+            query.greater_equal(column_key, primitive.value.float_value);
+            break;
+        case realm::PropertyType::Double:
+        case realm::PropertyType::Double | realm::PropertyType::Nullable:
+            query.greater_equal(column_key, primitive.value.double_value);
+            break;
+        case realm::PropertyType::Date:
+        case realm::PropertyType::Date | realm::PropertyType::Nullable:
+            query.greater_equal(column_key, from_ticks(primitive.value.int_value));
+            break;
+        default:
+            REALM_UNREACHABLE();
+        }
+#pragma GCC diagnostic pop
     });
 }
 


### PR DESCRIPTION
This removes RealmObject's methods for getting and setting
- char
- float
- double
- DateTimeOffset
- bool

And replaces them with `PrimitiveValue` (similar to what we're doing with lists/results).