### PR TITLE
Add decimal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 5.0.1 (2020-09-10)
+v10 (TBD)
+------------------
+
+### Breaking Changes
+* We no longer support Realm Cloud (legacy), but instead the new "MongoDB Realm" Cloud. MongoDB Realm is a serverless platform that enables developers to quickly build applications without having to set up server infrastructure. MongoDB Realm is built on top of MongoDB Atlas, automatically integrating the connection to your database. ([#2011](https://github.com/realm/realm-dotnet/pull/2011))
+* Remove support for Query-based sync, including the configuration parameters and the RLMSyncSubscription and SyncSubscription types. ([#2011](https://github.com/realm/realm-dotnet/pull/2011))
+* Remove everything related to sync permissions, including both the path-based permission system and the object-level privileges for query-based sync. ([#2011](https://github.com/realm/realm-dotnet/pull/2011))
+
+### Enhancements
+* Add support for the Decimal128 data type. This is a 128-bit IEEE 754 decimal floating point number. Properties of this type can be declared either as `MongoDB.Bson.Decimal128` type or the built-in `decimal` type. Note that .NET's built-in decimal is 96-bit, so it cannot represent the full range of numbers, representable by `Decimal128`. (PR [#2014](https://github.com/realm/realm-dotnet/pull/2014))
+
+### Fixed
+
+### Compatibility
+
+### Internal
+
+
+vNext(TBD)
 ------------------
 
 NOTE: This version bumps the Realm file format to version 10. It is not possible to downgrade version 9 or earlier. Files created with older versions of Realm will be automatically upgraded. Only [Studio 3.11](https://github.com/realm/realm-studio/releases/tag/v3.11.0) or later will be able to open the new file format.

--- a/Realm/Realm.Fody/Extensions/PropertyDefinitionExtensions.cs
+++ b/Realm/Realm.Fody/Extensions/PropertyDefinitionExtensions.cs
@@ -94,6 +94,16 @@ internal static class PropertyDefinitionExtensions
         return property.PropertyType.FullName == DoubleTypeName;
     }
 
+    internal static bool IsDecimal(this PropertyDefinition property)
+    {
+        return property.PropertyType.FullName == DecimalTypeName;
+    }
+
+    internal static bool IsDecimal128(this PropertyDefinition property)
+    {
+        return property.PropertyType.FullName == Decimal128TypeName;
+    }
+
     internal static bool IsString(this PropertyDefinition property)
     {
         return property.PropertyType.FullName == StringTypeName;

--- a/Realm/Realm.Fody/ImportedReferences.cs
+++ b/Realm/Realm.Fody/ImportedReferences.cs
@@ -47,10 +47,6 @@ namespace RealmWeaver
 
         public MethodReference System_Type_GetTypeFromHandle { get; }
 
-        public TypeReference System_DateTimeOffset { get; }
-
-        public MethodReference System_DateTimeOffset_op_Inequality { get; private set; }
-
         public abstract TypeReference System_Collections_Generic_ListOfT { get; }
 
         public MethodReference System_Collections_Generic_ListOfT_Constructor { get; private set; }
@@ -192,8 +188,6 @@ namespace RealmWeaver
                 Parameters = { new ParameterDefinition(runtimeTypeHandle) }
             };
 
-            System_DateTimeOffset = new TypeReference("System", "DateTimeOffset", Module, Module.TypeSystem.CoreLibrary, valueType: true);
-
             // If the assembly has a reference to PropertyChanged.Fody, let's look up the DoNotNotifyAttribute for use later.
             var PropertyChanged_Fody = Module.AssemblyReferences.SingleOrDefault(a => a.Name == "PropertyChanged");
             if (PropertyChanged_Fody != null)
@@ -218,11 +212,6 @@ namespace RealmWeaver
             {
                 HasThis = true,
                 Parameters = { new ParameterDefinition(Types.Int32Reference) }
-            };
-
-            System_DateTimeOffset_op_Inequality = new MethodReference("op_Inequality", Types.BooleanReference, System_DateTimeOffset)
-            {
-                Parameters = { new ParameterDefinition(System_DateTimeOffset), new ParameterDefinition(System_DateTimeOffset) }
             };
 
             System_Collections_Generic_ListOfT_Constructor = new MethodReference(".ctor", Types.VoidReference, System_Collections_Generic_ListOfT) { HasThis = true };
@@ -346,7 +335,6 @@ namespace RealmWeaver
                 RealmObject_SetPrimitiveValueUnique.Parameters.Add(new ParameterDefinition(T));
                 RealmObject_SetPrimitiveValueUnique.Parameters.Add(new ParameterDefinition(RealmSchema_PropertyType));
             }
-
 
             IRealmObjectHelper = new TypeReference("Realms.Weaving", "IRealmObjectHelper", Module, realmAssembly);
 

--- a/Realm/Realm/Dynamic/MetaRealmObject.cs
+++ b/Realm/Realm/Dynamic/MetaRealmObject.cs
@@ -147,6 +147,8 @@ namespace Realms.Dynamic
                     case PropertyType.Float:
                     case PropertyType.Double:
                     case PropertyType.Date:
+                    case PropertyType.Decimal:
+                    case PropertyType.ObjectId:
                         arguments.Add(Expression.Constant(property.Type));
                         getter = GetGetMethod(DummyHandle.GetPrimitive);
                         break;
@@ -212,6 +214,8 @@ namespace Realms.Dynamic
                 case PropertyType.Float:
                 case PropertyType.Double:
                 case PropertyType.Date:
+                case PropertyType.Decimal:
+                case PropertyType.ObjectId:
                     argumentType = typeof(PrimitiveValue);
                     valueExpression = Expression.Call(CreatePrimitiveMethod.MakeGenericMethod(valueExpression.Type), new[] { valueExpression, Expression.Constant(property.Type) });
                     if (property.IsPrimaryKey)

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -50,7 +50,7 @@ namespace Realms
         {
             var result = new PrimitiveValue
             {
-                type = type
+                Type = type
             };
 
             GetPrimitiveAtIndexCore((IntPtr)index, ref result, out var nativeException);

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -173,7 +173,7 @@ namespace Realms
 
         public PrimitiveValue GetPrimitive(ColumnKey columnKey, PropertyType type)
         {
-            var result = new PrimitiveValue { type = type };
+            var result = new PrimitiveValue { Type = type };
 
             NativeMethods.get_primitive(this, columnKey, ref result, out var nativeException);
             nativeException.ThrowIfNecessary();
@@ -263,7 +263,7 @@ namespace Realms
 
         public void SetPrimitiveUnique(ColumnKey columnKey, PrimitiveValue value)
         {
-            if (!GetPrimitive(columnKey, value.type).Equals(value))
+            if (!GetPrimitive(columnKey, value.Type).Equals(value))
             {
                 throw new InvalidOperationException("Once set, primary key properties may not be modified.");
             }

--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -19,12 +19,19 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using MongoDB.Bson;
 
 namespace Realms.Helpers
 {
     // Heavily based on http://www.yoda.arachsys.com/csharp/miscutil/index.html
     internal static class Operator
     {
+        [Preserve]
+        static Operator()
+        {
+            _ = (decimal)new Decimal128(123);
+        }
+
         public static T Add<T>(T first, T second)
         {
             return GenericOperator<T, T>.Add(first, second);

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -23,6 +23,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using MongoDB.Bson;
 using Realms.Native;
 using Realms.Schema;
 using LazyMethod = System.Lazy<System.Reflection.MethodInfo>;
@@ -807,6 +808,20 @@ namespace Realms
             else if (columnType == typeof(double))
             {
                 action(columnKey, PrimitiveValue.Double((double)Convert.ChangeType(value, typeof(double))));
+            }
+            else if (columnType == typeof(Decimal128))
+            {
+                // This is needed, because Convert.ChangeType will throw if value is Decimal128
+                if (!(value is Decimal128 decimalValue))
+                {
+                    decimalValue = (Decimal128)Convert.ChangeType(value, typeof(Decimal128));
+                }
+
+                action(columnKey, PrimitiveValue.Create(decimalValue, PropertyType.Decimal));
+            }
+            else if (columnType == typeof(decimal))
+            {
+                action(columnKey, PrimitiveValue.Create((decimal)Convert.ChangeType(value, typeof(decimal)), PropertyType.Decimal));
             }
             else
             {

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -817,11 +817,11 @@ namespace Realms
                     decimalValue = (Decimal128)Convert.ChangeType(value, typeof(Decimal128));
                 }
 
-                action(columnKey, PrimitiveValue.Create(decimalValue, PropertyType.Decimal));
+                action(columnKey, PrimitiveValue.Decimal(decimalValue));
             }
             else if (columnType == typeof(decimal))
             {
-                action(columnKey, PrimitiveValue.Create((decimal)Convert.ChangeType(value, typeof(decimal)), PropertyType.Decimal));
+                action(columnKey, PrimitiveValue.Decimal((decimal)Convert.ChangeType(value, typeof(decimal))));
             }
             else
             {

--- a/Realm/Realm/Native/PrimitiveValue.cs
+++ b/Realm/Realm/Native/PrimitiveValue.cs
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Linq;
 using System.Runtime.InteropServices;
 using MongoDB.Bson;
 using Realms.Helpers;
@@ -30,39 +29,39 @@ namespace Realms.Native
     {
         [FieldOffset(0)]
         [MarshalAs(UnmanagedType.U1)]
-        internal PropertyType type;
+        public PropertyType Type;
 
         [FieldOffset(1)]
         [MarshalAs(UnmanagedType.I1)]
-        internal bool has_value;
+        private bool has_value;
 
         [FieldOffset(8)]
         [MarshalAs(UnmanagedType.I1)]
-        internal bool bool_value;
+        private bool bool_value;
 
         [FieldOffset(8)]
-        internal long int_value;
+        private long int_value;
 
         [FieldOffset(8)]
-        internal float float_value;
+        private float float_value;
 
         [FieldOffset(8)]
-        internal double double_value;
+        private double double_value;
 
         [FieldOffset(8)]
-        internal ulong low_bits;
+        private ulong low_bits;
 
         [FieldOffset(16)]
-        internal ulong high_bits;
+        private ulong high_bits;
 
         [FieldOffset(16)]
-        internal uint object_id_remainder;
+        private uint object_id_remainder;
 
         public static PrimitiveValue Bool(bool value)
         {
             return new PrimitiveValue
             {
-                type = PropertyType.Bool,
+                Type = PropertyType.Bool,
                 has_value = true,
                 bool_value = value
             };
@@ -70,192 +69,161 @@ namespace Realms.Native
 
         public static PrimitiveValue NullableBool(bool? value) => new PrimitiveValue
         {
-            type = PropertyType.NullableBool,
+            Type = PropertyType.NullableBool,
             has_value = value.HasValue,
             bool_value = value.GetValueOrDefault()
         };
 
         public static PrimitiveValue Int(long value) => new PrimitiveValue
         {
-            type = PropertyType.Int,
+            Type = PropertyType.Int,
             has_value = true,
             int_value = value
         };
 
         public static PrimitiveValue NullableInt(long? value) => new PrimitiveValue
         {
-            type = PropertyType.NullableInt,
+            Type = PropertyType.NullableInt,
             has_value = value.HasValue,
             int_value = value.GetValueOrDefault()
         };
 
         public static PrimitiveValue Float(float value) => new PrimitiveValue
         {
-            type = PropertyType.Float,
+            Type = PropertyType.Float,
             has_value = true,
             float_value = value
         };
 
         public static PrimitiveValue NullableFloat(float? value) => new PrimitiveValue
         {
-            type = PropertyType.NullableFloat,
+            Type = PropertyType.NullableFloat,
             has_value = value.HasValue,
             float_value = value.GetValueOrDefault()
         };
 
         public static PrimitiveValue Double(double value) => new PrimitiveValue
         {
-            type = PropertyType.Double,
+            Type = PropertyType.Double,
             has_value = true,
             double_value = value
         };
 
         public static PrimitiveValue NullableDouble(double? value) => new PrimitiveValue
         {
-            type = PropertyType.NullableDouble,
+            Type = PropertyType.NullableDouble,
             has_value = value.HasValue,
             double_value = value.GetValueOrDefault()
         };
 
         public static PrimitiveValue Date(DateTimeOffset value) => new PrimitiveValue
         {
-            type = PropertyType.Date,
+            Type = PropertyType.Date,
             has_value = true,
             int_value = value.ToUniversalTime().Ticks
         };
 
         public static PrimitiveValue NullableDate(DateTimeOffset? value) => new PrimitiveValue
         {
-            type = PropertyType.NullableDate,
+            Type = PropertyType.NullableDate,
             has_value = value.HasValue,
             int_value = value.GetValueOrDefault().ToUniversalTime().Ticks
         };
 
+        public static PrimitiveValue Decimal(Decimal128 value) => new PrimitiveValue
+        {
+            Type = PropertyType.Decimal,
+            has_value = true,
+            high_bits = value.GetIEEEHighBits(),
+            low_bits = value.GetIEEELowBits()
+        };
+
+        public static PrimitiveValue NullableDecimal(Decimal128? value) => new PrimitiveValue
+        {
+            Type = PropertyType.NullableDecimal,
+            has_value = value.HasValue,
+            high_bits = value.GetValueOrDefault().GetIEEEHighBits(),
+            low_bits = value.GetValueOrDefault().GetIEEELowBits()
+        };
+
+        public static PrimitiveValue ObjectId(ObjectId value) => throw new NotImplementedException();
+
+        public static PrimitiveValue NullableObjectId(ObjectId? value) => throw new NotImplementedException();
+
         public static PrimitiveValue Create<T>(T value, PropertyType type)
         {
-            var result = new PrimitiveValue
+            return type switch
             {
-                type = type,
-                has_value = true
+                PropertyType.Bool => Bool(Operator.Convert<T, bool>(value)),
+                PropertyType.NullableBool => NullableBool(Operator.Convert<T, bool?>(value)),
+                PropertyType.Int => Int(Operator.Convert<T, long>(value)),
+                PropertyType.NullableInt => NullableInt(Operator.Convert<T, long?>(value)),
+                PropertyType.Float => Float(Operator.Convert<T, float>(value)),
+                PropertyType.NullableFloat => NullableFloat(Operator.Convert<T, float?>(value)),
+                PropertyType.Double => Double(Operator.Convert<T, double>(value)),
+                PropertyType.NullableDouble => NullableDouble(Operator.Convert<T, double?>(value)),
+                PropertyType.Date => Date(Operator.Convert<T, DateTimeOffset>(value)),
+                PropertyType.NullableDate => NullableDate(Operator.Convert<T, DateTimeOffset?>(value)),
+                PropertyType.Decimal => Decimal(Operator.Convert<T, Decimal128>(value)),
+                PropertyType.NullableDecimal => NullableDecimal(Operator.Convert<T, Decimal128?>(value)),
+                PropertyType.ObjectId => ObjectId(Operator.Convert<T, ObjectId>(value)),
+                PropertyType.NullableObjectId => NullableObjectId(Operator.Convert<T, ObjectId?>(value)),
+                _ => throw new NotSupportedException($"PrimitiveType {type} is not supported."),
             };
-
-            switch (type)
-            {
-                case PropertyType.Bool:
-                    result.bool_value = Operator.Convert<T, bool>(value);
-                    break;
-                case PropertyType.NullableBool:
-                    var boolValue = Operator.Convert<T, bool?>(value);
-                    result.has_value = boolValue.HasValue;
-                    result.bool_value = boolValue.GetValueOrDefault();
-                    break;
-                case PropertyType.Int:
-                    result.int_value = Operator.Convert<T, long>(value);
-                    break;
-                case PropertyType.NullableInt:
-                    var longValue = Operator.Convert<T, long?>(value);
-                    result.has_value = longValue.HasValue;
-                    result.int_value = longValue.GetValueOrDefault();
-                    break;
-                case PropertyType.Float:
-                    result.float_value = Operator.Convert<T, float>(value);
-                    break;
-                case PropertyType.NullableFloat:
-                    var floatValue = Operator.Convert<T, float?>(value);
-                    result.has_value = floatValue.HasValue;
-                    result.float_value = floatValue.GetValueOrDefault();
-                    break;
-                case PropertyType.Double:
-                    result.double_value = Operator.Convert<T, double>(value);
-                    break;
-                case PropertyType.NullableDouble:
-                    var doubleValue = Operator.Convert<T, double?>(value);
-                    result.has_value = doubleValue.HasValue;
-                    result.double_value = doubleValue.GetValueOrDefault();
-                    break;
-                case PropertyType.Date:
-                    result.int_value = Operator.Convert<T, DateTimeOffset>(value).ToUniversalTime().Ticks;
-                    break;
-                case PropertyType.NullableDate:
-                    var dateValue = Operator.Convert<T, DateTimeOffset?>(value);
-                    result.has_value = dateValue.HasValue;
-                    result.int_value = dateValue.GetValueOrDefault().ToUniversalTime().Ticks;
-                    break;
-                case PropertyType.Decimal:
-                    var decimalValue = Operator.Convert<T, Decimal128>(value);
-                    result.high_bits = decimalValue.GetIEEEHighBits();
-                    result.low_bits = decimalValue.GetIEEELowBits();
-                    break;
-                case PropertyType.NullableDecimal:
-                    var nullableDecimalValue = Operator.Convert<T, Decimal128?>(value);
-                    result.has_value = nullableDecimalValue.HasValue;
-
-                    var actualValue = nullableDecimalValue.GetValueOrDefault();
-                    result.high_bits = actualValue.GetIEEEHighBits();
-                    result.low_bits = actualValue.GetIEEELowBits();
-                    break;
-                case PropertyType.ObjectId:
-                    var objectIdBytes = Operator.Convert<T, ObjectId>(value).ToByteArray();
-                    result.low_bits = BitConverter.ToUInt64(objectIdBytes, 0);
-                    result.object_id_remainder = BitConverter.ToUInt32(objectIdBytes, 8);
-                    break;
-                case PropertyType.NullableObjectId:
-                    var objectId = Operator.Convert<T, ObjectId?>(value);
-                    result.has_value = objectId.HasValue;
-
-                    var actualObjectIdBytes = objectId.GetValueOrDefault().ToByteArray();
-                    result.low_bits = BitConverter.ToUInt64(actualObjectIdBytes, 0);
-                    result.object_id_remainder = BitConverter.ToUInt32(actualObjectIdBytes, 8);
-                    break;
-                default:
-                    throw new NotSupportedException($"PrimitiveType {type} is not supported.");
-            }
-
-            return result;
         }
+
+        public bool ToBool() => bool_value;
+
+        public bool? ToNullableBool() => has_value ? bool_value : (bool?)null;
+
+        public long ToInt() => int_value;
+
+        public long? ToNullableInt() => has_value ? int_value : (long?)null;
+
+        public T ToIntegral<T>() => Operator.Convert<long, T>(int_value);
+
+        public T ToNullableIntegral<T>() => Operator.Convert<long?, T>(has_value ? int_value : (long?)null);
+
+        public float ToFloat() => float_value;
+
+        public float? ToNullableFloat() => has_value ? float_value : (float?)null;
+
+        public double ToDouble() => double_value;
+
+        public double? ToNullableDouble() => has_value ? double_value : (double?)null;
+
+        public DateTimeOffset ToDate() => new DateTimeOffset(int_value, TimeSpan.Zero);
+
+        public DateTimeOffset? ToNullableDate() => has_value ? new DateTimeOffset(int_value, TimeSpan.Zero) : (DateTimeOffset?)null;
+
+        public Decimal128 ToDecimal() => Decimal128.FromIEEEBits(high_bits, low_bits);
+
+        public Decimal128? ToNullableDecimal() => has_value ? Decimal128.FromIEEEBits(high_bits, low_bits) : (Decimal128?)null;
+
+        public ObjectId ToObjectId() => throw new NotImplementedException();
+
+        public ObjectId? ToNullableObjectId() => has_value ? throw new NotImplementedException() : (ObjectId?)null;
 
         public T Get<T>()
         {
-            switch (type)
+            return Type switch
             {
-                case PropertyType.Bool:
-                    return Operator.Convert<bool, T>(bool_value);
-                case PropertyType.NullableBool:
-                    return Operator.Convert<bool?, T>(has_value ? bool_value : (bool?)null);
-                case PropertyType.Int:
-                    return Operator.Convert<long, T>(int_value);
-                case PropertyType.NullableInt:
-                    return Operator.Convert<long?, T>(has_value ? int_value : (long?)null);
-                case PropertyType.Float:
-                    return Operator.Convert<float, T>(float_value);
-                case PropertyType.NullableFloat:
-                    return Operator.Convert<float?, T>(has_value ? float_value : (float?)null);
-                case PropertyType.Double:
-                    return Operator.Convert<double, T>(double_value);
-                case PropertyType.NullableDouble:
-                    return Operator.Convert<double?, T>(has_value ? double_value : (double?)null);
-                case PropertyType.Date:
-                    return Operator.Convert<DateTimeOffset, T>(new DateTimeOffset(int_value, TimeSpan.Zero));
-                case PropertyType.NullableDate:
-                    return Operator.Convert<DateTimeOffset?, T>(has_value ? new DateTimeOffset(int_value, TimeSpan.Zero) : (DateTimeOffset?)null);
-                case PropertyType.Decimal:
-                    return Operator.Convert<Decimal128, T>(Decimal128.FromIEEEBits(high_bits, low_bits));
-                case PropertyType.NullableDecimal:
-                    return Operator.Convert<Decimal128?, T>(has_value ? Decimal128.FromIEEEBits(high_bits, low_bits) : (Decimal128?)null);
-                case PropertyType.ObjectId:
-                    var bytes = BitConverter.GetBytes(low_bits).Concat(BitConverter.GetBytes(object_id_remainder));
-                    return Operator.Convert<ObjectId, T>(new ObjectId(bytes.ToArray()));
-                case PropertyType.NullableObjectId:
-                    if (has_value)
-                    {
-                        return Operator.Convert<ObjectId?, T>(null);
-                    }
-
-                    var nullableBytes = BitConverter.GetBytes(low_bits).Concat(BitConverter.GetBytes(object_id_remainder));
-                    return Operator.Convert<ObjectId, T>(new ObjectId(nullableBytes.ToArray()));
-                default:
-                    throw new NotSupportedException($"PrimitiveType {type} is not supported.");
-            }
+                PropertyType.Bool => Operator.Convert<bool, T>(ToBool()),
+                PropertyType.NullableBool => Operator.Convert<bool?, T>(ToNullableBool()),
+                PropertyType.Int => ToIntegral<T>(),
+                PropertyType.NullableInt => ToNullableIntegral<T>(),
+                PropertyType.Float => Operator.Convert<float, T>(ToFloat()),
+                PropertyType.NullableFloat => Operator.Convert<float?, T>(ToNullableFloat()),
+                PropertyType.Double => Operator.Convert<double, T>(ToDouble()),
+                PropertyType.NullableDouble => Operator.Convert<double?, T>(ToNullableDouble()),
+                PropertyType.Date => Operator.Convert<DateTimeOffset, T>(ToDate()),
+                PropertyType.NullableDate => Operator.Convert<DateTimeOffset?, T>(ToNullableDate()),
+                PropertyType.Decimal => Operator.Convert<Decimal128, T>(ToDecimal()),
+                PropertyType.NullableDecimal => Operator.Convert<Decimal128?, T>(ToNullableDecimal()),
+                PropertyType.ObjectId => Operator.Convert<ObjectId, T>(ToObjectId()),
+                PropertyType.NullableObjectId => Operator.Convert<ObjectId?, T>(ToNullableObjectId()),
+                _ => throw new NotSupportedException($"PrimitiveType {Type} is not supported."),
+            };
         }
     }
 }

--- a/Realm/Realm/Native/PrimitiveValue.cs
+++ b/Realm/Realm/Native/PrimitiveValue.cs
@@ -54,9 +54,6 @@ namespace Realms.Native
         [FieldOffset(16)]
         private ulong high_bits;
 
-        [FieldOffset(16)]
-        private uint object_id_remainder;
-
         public static PrimitiveValue Bool(bool value)
         {
             return new PrimitiveValue

--- a/Realm/Realm/Native/PrimitiveValue.cs
+++ b/Realm/Realm/Native/PrimitiveValue.cs
@@ -41,7 +41,10 @@ namespace Realms.Native
         private double double_value;
 
         [FieldOffset(0)]
-        private fixed ulong decimal_bits[2];
+        private ulong decimal_low;
+
+        [FieldOffset(8)]
+        private ulong decimal_high;
 
         [FieldOffset(16)]
         [MarshalAs(UnmanagedType.U1)]
@@ -132,8 +135,8 @@ namespace Realms.Native
                 has_value = true
             };
 
-            result.decimal_bits[0] = value.GetIEEELowBits();
-            result.decimal_bits[1] = value.GetIEEEHighBits();
+            result.decimal_low = value.GetIEEELowBits();
+            result.decimal_high = value.GetIEEEHighBits();
 
             return result;
         }
@@ -148,8 +151,8 @@ namespace Realms.Native
 
             if (value.HasValue)
             {
-                result.decimal_bits[0] = value.Value.GetIEEELowBits();
-                result.decimal_bits[1] = value.Value.GetIEEEHighBits();
+                result.decimal_low = value.Value.GetIEEELowBits();
+                result.decimal_high = value.Value.GetIEEEHighBits();
             }
 
             return result;
@@ -205,9 +208,9 @@ namespace Realms.Native
 
         public DateTimeOffset? ToNullableDate() => has_value ? new DateTimeOffset(int_value, TimeSpan.Zero) : (DateTimeOffset?)null;
 
-        public Decimal128 ToDecimal() => Decimal128.FromIEEEBits(decimal_bits[1], decimal_bits[0]);
+        public Decimal128 ToDecimal() => Decimal128.FromIEEEBits(decimal_high, decimal_low);
 
-        public Decimal128? ToNullableDecimal() => has_value ? Decimal128.FromIEEEBits(decimal_bits[1], decimal_bits[0]) : (Decimal128?)null;
+        public Decimal128? ToNullableDecimal() => has_value ? Decimal128.FromIEEEBits(decimal_high, decimal_low) : (Decimal128?)null;
 
         public ObjectId ToObjectId() => throw new NotImplementedException();
 

--- a/Realm/Realm/Native/PrimitiveValue.cs
+++ b/Realm/Realm/Native/PrimitiveValue.cs
@@ -41,10 +41,12 @@ namespace Realms.Native
         private double double_value;
 
         [FieldOffset(0)]
-        private ulong decimal_low;
+        private fixed ulong decimal_bits[2];
 
+        // Without this padding, .NET fails to marshal the decimal_bits array correctly and the second element is always 0.
         [FieldOffset(8)]
-        private ulong decimal_high;
+        [Obsolete("Don't use, please!")]
+        private long dontuse;
 
         [FieldOffset(16)]
         [MarshalAs(UnmanagedType.U1)]
@@ -135,8 +137,8 @@ namespace Realms.Native
                 has_value = true
             };
 
-            result.decimal_low = value.GetIEEELowBits();
-            result.decimal_high = value.GetIEEEHighBits();
+            result.decimal_bits[0] = value.GetIEEELowBits();
+            result.decimal_bits[1] = value.GetIEEEHighBits();
 
             return result;
         }
@@ -151,8 +153,8 @@ namespace Realms.Native
 
             if (value.HasValue)
             {
-                result.decimal_low = value.Value.GetIEEELowBits();
-                result.decimal_high = value.Value.GetIEEEHighBits();
+                result.decimal_bits[0] = value.Value.GetIEEELowBits();
+                result.decimal_bits[1] = value.Value.GetIEEEHighBits();
             }
 
             return result;
@@ -208,9 +210,9 @@ namespace Realms.Native
 
         public DateTimeOffset? ToNullableDate() => has_value ? new DateTimeOffset(int_value, TimeSpan.Zero) : (DateTimeOffset?)null;
 
-        public Decimal128 ToDecimal() => Decimal128.FromIEEEBits(decimal_high, decimal_low);
+        public Decimal128 ToDecimal() => Decimal128.FromIEEEBits(decimal_bits[1], decimal_bits[0]);
 
-        public Decimal128? ToNullableDecimal() => has_value ? Decimal128.FromIEEEBits(decimal_high, decimal_low) : (Decimal128?)null;
+        public Decimal128? ToNullableDecimal() => has_value ? Decimal128.FromIEEEBits(decimal_bits[1], decimal_bits[0]) : (Decimal128?)null;
 
         public ObjectId ToObjectId() => throw new NotImplementedException();
 

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MongoDB.Bson" Version="2.11.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>Realms</RootNamespace>
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Title>Realm</Title>
     <ReleaseNotes>https://realm.io/docs/dotnet/latest/api/CHANGELOG.html</ReleaseNotes>

--- a/Realm/Realm/RealmInteger.cs
+++ b/Realm/Realm/RealmInteger.cs
@@ -98,7 +98,7 @@ namespace Realms
             if (IsManaged)
             {
                 _objectHandle.AddInt64(_columnKey, value.ToLong());
-                var result = _objectHandle.GetPrimitive(_columnKey, Schema.PropertyType.Int).Get<T>();
+                var result = _objectHandle.GetPrimitive(_columnKey, Schema.PropertyType.Int).ToIntegral<T>();
                 return new RealmInteger<T>(result, _objectHandle, _columnKey);
             }
 

--- a/Realm/Realm/RealmObject.cs
+++ b/Realm/Realm/RealmObject.cs
@@ -270,7 +270,7 @@ namespace Realms
             where T : struct, IFormattable, IComparable<T>
         {
             var columnKey = _metadata.ColumnKeys[propertyName];
-            var result = _objectHandle.GetPrimitive(columnKey, PropertyType.Int).Get<T>();
+            var result = _objectHandle.GetPrimitive(columnKey, PropertyType.Int).ToIntegral<T>();
             return new RealmInteger<T>(result, ObjectHandle, columnKey);
         }
 
@@ -278,7 +278,7 @@ namespace Realms
             where T : struct, IFormattable, IComparable<T>
         {
             var columnKey = _metadata.ColumnKeys[propertyName];
-            var result = _objectHandle.GetPrimitive(columnKey, PropertyType.NullableInt).Get<T?>();
+            var result = _objectHandle.GetPrimitive(columnKey, PropertyType.NullableInt).ToNullableIntegral<T?>();
 
             if (result.HasValue)
             {

--- a/Realm/Realm/Schema/PropertyType.cs
+++ b/Realm/Realm/Schema/PropertyType.cs
@@ -76,6 +76,16 @@ namespace Realms.Schema
         LinkingObjects = 8,
 
         /// <summary>
+        /// 96 bit ObjectID property.
+        /// </summary>
+        ObjectId = 10,
+
+        /// <summary>
+        /// 128 bit decimal property.
+        /// </summary>
+        Decimal = 11,
+
+        /// <summary>
         /// A required property. Can be combined with other values.
         /// </summary>
         Required = 0,
@@ -119,5 +129,15 @@ namespace Realms.Schema
         /// A shorthand for PropertyType.Date | PropertyType.Nullable.
         /// </summary>
         NullableDate = Date | Nullable,
+
+        /// <summary>
+        /// A shorthand for PropertyType.ObjectId | PropertyType.Nullable.
+        /// </summary>
+        NullableObjectId = ObjectId | Nullable,
+
+        /// <summary>
+        /// A shorthand for PropertyType.Decimal | PropertyType.Nullable.
+        /// </summary>
+        NullableDecimal = Decimal | Nullable,
     }
 }

--- a/Realm/Realm/Schema/PropertyTypeEx.cs
+++ b/Realm/Realm/Schema/PropertyTypeEx.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using MongoDB.Bson;
 using Realms.Helpers;
 
 namespace Realms.Schema
@@ -76,6 +77,12 @@ namespace Realms.Schema
                 case Type _ when type == typeof(double):
                     return PropertyType.Double | nullabilityModifier;
 
+                case Type _ when type == typeof(decimal) || type == typeof(Decimal128):
+                    return PropertyType.Decimal | nullabilityModifier;
+
+                case Type _ when type == typeof(ObjectId):
+                    return PropertyType.ObjectId | nullabilityModifier;
+
                 case Type _ when type == typeof(RealmObject) || type.GetTypeInfo().BaseType == typeof(RealmObject):
                     objectType = type;
                     return PropertyType.Object | PropertyType.Nullable;
@@ -96,7 +103,7 @@ namespace Realms.Schema
             }
         }
 
-        public static bool IsComputed(this PropertyType propertyType) => propertyType.HasFlag(PropertyType.LinkingObjects);
+        public static bool IsComputed(this PropertyType propertyType) => propertyType == (PropertyType.LinkingObjects | PropertyType.Array);
 
         public static bool IsNullable(this PropertyType propertyType) => propertyType.HasFlag(PropertyType.Nullable);
 

--- a/Tests/Realm.Tests/Database/AccessTests.cs
+++ b/Tests/Realm.Tests/Database/AccessTests.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
+using MongoDB.Bson;
 using NUnit.Framework;
 using Realms.Exceptions;
 
@@ -52,7 +53,9 @@ namespace Realms.Tests.Database
             new object[] { "ByteArrayProperty", new byte[] { 0xde, 0xad, 0xbe, 0xef } },
             new object[] { "ByteArrayProperty", Array.Empty<byte>() },
             new object[] { "StringProperty", "hello" },
-            new object[] { "DateTimeOffsetProperty", new DateTimeOffset(1956, 6, 1, 0, 0, 0, TimeSpan.Zero) }
+            new object[] { "DateTimeOffsetProperty", new DateTimeOffset(1956, 6, 1, 0, 0, 0, TimeSpan.Zero) },
+            new object[] { "DecimalProperty", 123.456M },
+            new object[] { "Decimal128Property", new Decimal128(564.42343424323) },
         };
 
         [TestCaseSource(nameof(SetAndReplaceWithNullCases))]
@@ -86,6 +89,8 @@ namespace Realms.Tests.Database
             new object[] { "NullableSingleProperty", 123.123f },
             new object[] { "NullableDoubleProperty", 123.123 },
             new object[] { "NullableBooleanProperty", true },
+            new object[] { "NullableDecimalProperty", 123.456M },
+            new object[] { "NullableDecimal128Property", new Decimal128(123.456) },
             new object[] { "ByteArrayProperty", new byte[] { 0xde, 0xad, 0xbe, 0xef } },
             new object[] { "ByteArrayProperty", Array.Empty<byte>() },
             new object[] { "StringProperty", "hello" },
@@ -151,6 +156,8 @@ namespace Realms.Tests.Database
             Assert.That(obj.Int16Property, Is.EqualTo(default(short)));
             Assert.That(obj.Int32Property, Is.EqualTo(default(int)));
             Assert.That(obj.Int64Property, Is.EqualTo(default(long)));
+            Assert.That(obj.DecimalProperty, Is.EqualTo(default(decimal)));
+            Assert.That(obj.Decimal128Property, Is.EqualTo(default(Decimal128)));
             Assert.That(obj.NullableBooleanProperty, Is.EqualTo(default(bool?)));
             Assert.That(obj.NullableByteProperty, Is.EqualTo(default(byte?)));
             Assert.That(obj.NullableCharProperty, Is.EqualTo(default(char?)));
@@ -160,6 +167,8 @@ namespace Realms.Tests.Database
             Assert.That(obj.NullableInt16Property, Is.EqualTo(default(short?)));
             Assert.That(obj.NullableInt32Property, Is.EqualTo(default(int?)));
             Assert.That(obj.NullableInt64Property, Is.EqualTo(default(long?)));
+            Assert.That(obj.NullableDecimalProperty, Is.EqualTo(default(decimal?)));
+            Assert.That(obj.NullableDecimal128Property, Is.EqualTo(default(Decimal128?)));
         }
     }
 }

--- a/Tests/Realm.Tests/Database/AccessTests.cs
+++ b/Tests/Realm.Tests/Database/AccessTests.cs
@@ -55,7 +55,17 @@ namespace Realms.Tests.Database
             new object[] { "StringProperty", "hello" },
             new object[] { "DateTimeOffsetProperty", new DateTimeOffset(1956, 6, 1, 0, 0, 0, TimeSpan.Zero) },
             new object[] { "DecimalProperty", 123.456M },
+            new object[] { "DecimalProperty", decimal.MinValue },
+            new object[] { "DecimalProperty", decimal.MaxValue },
+            new object[] { "DecimalProperty", decimal.One },
+            new object[] { "DecimalProperty", decimal.MinusOne },
+            new object[] { "DecimalProperty", decimal.Zero },
             new object[] { "Decimal128Property", new Decimal128(564.42343424323) },
+            new object[] { "Decimal128Property", new Decimal128(decimal.MinValue) },
+            new object[] { "Decimal128Property", new Decimal128(decimal.MaxValue) },
+            new object[] { "Decimal128Property", Decimal128.MinValue },
+            new object[] { "Decimal128Property", Decimal128.MaxValue },
+            new object[] { "Decimal128Property", Decimal128.Zero },
         };
 
         [TestCaseSource(nameof(SetAndReplaceWithNullCases))]

--- a/Tests/Realm.Tests/Database/RealmResults/ConvertTests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/ConvertTests.cs
@@ -18,8 +18,8 @@
 
 using System;
 using System.Linq;
+using MongoDB.Bson;
 using NUnit.Framework;
-using Realms;
 
 namespace Realms.Tests.Database
 {
@@ -31,6 +31,8 @@ namespace Realms.Tests.Database
         private const long LongOne = 1;
         private const float FloatOne = 1;
         private const double DoubleOne = 1;
+        private const decimal DecimalOne = 1;
+        private static readonly Decimal128 Decimal128One = 1;
 
         private static readonly int? NullableOne = 1;
         private static readonly int? NullableZero = 0;
@@ -66,7 +68,11 @@ namespace Realms.Tests.Database
                     NullableInt64Property = 1,
                     NullableSingleProperty = 1,
                     SingleProperty = 1,
-                    RequiredStringProperty = string.Empty
+                    RequiredStringProperty = string.Empty,
+                    DecimalProperty = 1,
+                    Decimal128Property = 1,
+                    NullableDecimalProperty = 1,
+                    NullableDecimal128Property = 1,
                 });
 
                 _realm.Add(new CounterObject());
@@ -113,6 +119,14 @@ namespace Realms.Tests.Database
         public void Equal_WhenUsingBroaderType_Single()
         {
             var singleQuery = _realm.All<AllTypesObject>().Where(o => o.SingleProperty == DoubleOne).ToArray();
+            Assert.That(singleQuery.Length, Is.EqualTo(1));
+            Assert.That(singleQuery[0].DoubleProperty, Is.EqualTo(DoubleOne));
+        }
+
+        [Test]
+        public void Equal_WhenUsingBroaderType_Decimal()
+        {
+            var singleQuery = _realm.All<AllTypesObject>().Where(o => o.DecimalProperty == Decimal128One).ToArray();
             Assert.That(singleQuery.Length, Is.EqualTo(1));
             Assert.That(singleQuery[0].DoubleProperty, Is.EqualTo(DoubleOne));
         }
@@ -170,7 +184,31 @@ namespace Realms.Tests.Database
         {
             var doubleQuery = _realm.All<AllTypesObject>().Where(o => o.DoubleProperty == FloatOne).ToArray();
             Assert.That(doubleQuery.Length, Is.EqualTo(1));
-            Assert.That(doubleQuery[0].SingleProperty, Is.EqualTo(FloatOne));
+            Assert.That(doubleQuery[0].DoubleProperty, Is.EqualTo(1.0));
+        }
+
+        [Test]
+        public void Equal_WhenUsingNarrowerType_Decimal()
+        {
+            var decimalQuery = _realm.All<AllTypesObject>().Where(o => o.DecimalProperty == ByteOne).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].DecimalProperty, Is.EqualTo(DecimalOne));
+        }
+
+        [Test]
+        public void Equal_WhenUsingNarrowerType_Decimal128()
+        {
+            var decimalByDecimalQuery = _realm.All<AllTypesObject>().Where(o => o.Decimal128Property == DecimalOne).ToArray();
+            Assert.That(decimalByDecimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalByDecimalQuery[0].Decimal128Property, Is.EqualTo(Decimal128One));
+
+            var decimalByLongQuery = _realm.All<AllTypesObject>().Where(o => o.Decimal128Property == LongOne).ToArray();
+            Assert.That(decimalByLongQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalByLongQuery[0].Decimal128Property, Is.EqualTo(Decimal128One));
+
+            var decimalByByteQuery = _realm.All<AllTypesObject>().Where(o => o.Decimal128Property == ByteOne).ToArray();
+            Assert.That(decimalByByteQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalByByteQuery[0].Decimal128Property, Is.EqualTo(Decimal128One));
         }
 
         [Test]
@@ -255,6 +293,46 @@ namespace Realms.Tests.Database
             doubleQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDoubleProperty != null).ToArray();
             Assert.That(doubleQuery.Length, Is.EqualTo(1));
             Assert.That(doubleQuery[0].NullableDoubleProperty, Is.EqualTo(1.0));
+        }
+
+        [Test]
+        public void Equal_WhenPropertyIsNullable_Decimal()
+        {
+            var decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimalProperty == DecimalOne).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimalProperty, Is.EqualTo(1));
+
+            decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimalProperty == LongOne).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimalProperty, Is.EqualTo(1));
+
+            decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimalProperty == Decimal128One).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimalProperty, Is.EqualTo(1));
+
+            decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimalProperty != null).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimalProperty, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Equal_WhenPropertyIsNullable_Decimal128()
+        {
+            var decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimal128Property == Decimal128One).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimal128Property, Is.EqualTo(Decimal128One));
+
+            decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimal128Property == DecimalOne).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimal128Property, Is.EqualTo(Decimal128One));
+
+            decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimal128Property == LongOne).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimal128Property, Is.EqualTo(Decimal128One));
+
+            decimalQuery = _realm.All<AllTypesObject>().Where(o => o.NullableDecimal128Property != null).ToArray();
+            Assert.That(decimalQuery.Length, Is.EqualTo(1));
+            Assert.That(decimalQuery[0].NullableDecimal128Property, Is.EqualTo(Decimal128One));
         }
 
         [Test]
@@ -397,6 +475,25 @@ namespace Realms.Tests.Database
             Assert.That(doubleQuery.Length, Is.EqualTo(1));
             Assert.That(doubleQuery[0].DoubleProperty, Is.EqualTo(doubleValue));
         }
+
+        [Test]
+        public void Equal_WhenVariableIsNullable_Decimal()
+        {
+            decimal? decimalValue = 1M;
+            var doubleQuery = _realm.All<AllTypesObject>().Where(o => o.DecimalProperty == decimalValue).ToArray();
+            Assert.That(doubleQuery.Length, Is.EqualTo(1));
+            Assert.That(doubleQuery[0].DecimalProperty, Is.EqualTo(decimalValue));
+        }
+
+        [Test]
+        public void Equal_WhenVariableIsNullable_Decimal128()
+        {
+            Decimal128? decimalValue = 1;
+            var doubleQuery = _realm.All<AllTypesObject>().Where(o => o.Decimal128Property == decimalValue).ToArray();
+            Assert.That(doubleQuery.Length, Is.EqualTo(1));
+            Assert.That(doubleQuery[0].Decimal128Property, Is.EqualTo(decimalValue));
+        }
+
 
         [Test]
         public void Equal_WhenVariableIsNullable_Int16()

--- a/Tests/Realm.Tests/Database/RealmResults/LINQvariableTests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/LINQvariableTests.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System.Linq;
+using MongoDB.Bson;
 using NUnit.Framework;
 
 namespace Realms.Tests.Database
@@ -82,6 +83,42 @@ namespace Realms.Tests.Database
             Assert.That(c0, Is.EqualTo(expectFound));
         }
 
+        [TestCaseSource(nameof(DecimalTestData))]
+        public void DecimalTests(decimal value, int expectGreater, int expectGreaterEqual, int expectLess, int expectLessEqual)
+        {
+            SeedDecimalData();
+
+            var greater = _realm.All<DecimalsObject>().Count(d => d.DecimalValue > value);
+            Assert.That(greater, Is.EqualTo(expectGreater));
+
+            var greaterEqual = _realm.All<DecimalsObject>().Count(d => d.DecimalValue >= value);
+            Assert.That(greaterEqual, Is.EqualTo(expectGreaterEqual));
+
+            var less = _realm.All<DecimalsObject>().Count(d => d.DecimalValue < value);
+            Assert.That(less, Is.EqualTo(expectLess));
+
+            var lessEqual = _realm.All<DecimalsObject>().Count(d => d.DecimalValue <= value);
+            Assert.That(lessEqual, Is.EqualTo(expectLessEqual));
+        }
+
+        [TestCaseSource(nameof(Decimal128TestData))]
+        public void Decimal128Tests(Decimal128 value, int expectGreater, int expectGreaterEqual, int expectLess, int expectLessEqual)
+        {
+            SeedDecimal128Data();
+
+            var greater = _realm.All<DecimalsObject>().Count(d => d.Decimal128Value > value);
+            Assert.That(greater, Is.EqualTo(expectGreater));
+
+            var greaterEqual = _realm.All<DecimalsObject>().Count(d => d.Decimal128Value >= value);
+            Assert.That(greaterEqual, Is.EqualTo(expectGreaterEqual));
+
+            var less = _realm.All<DecimalsObject>().Count(d => d.Decimal128Value < value);
+            Assert.That(less, Is.EqualTo(expectLess));
+
+            var lessEqual = _realm.All<DecimalsObject>().Count(d => d.Decimal128Value <= value);
+            Assert.That(lessEqual, Is.EqualTo(expectLessEqual));
+        }
+
         // The following test cases exercise both Convert and Member RHS expressions
         [TestCase("Peter", 1)]
         [TestCase("Zach", 0)]
@@ -141,6 +178,52 @@ namespace Realms.Tests.Database
 
             var c0 = _realm.All<Person>().Count(p => p.Score > (float)data.Arguments[0] && p.Score <= (float)data.Arguments[1]);
             Assert.That(c0, Is.EqualTo(data.Arguments[2]));
+        }
+
+        public static object[] DecimalTestData =
+        {
+            new object[] { decimal.MinValue, 4, 5, 0, 1 },
+            new object[] { 3.5438693468936346437634743733M, 3, 3, 2, 2 },
+            new object[] { 3.5438693468936346437634743734M, 2, 3, 2, 3 },
+            new object[] { 3.5438693468936346437634743735M, 2, 2, 3, 3 },
+            new object[] { decimal.MaxValue, 0, 1, 4, 5 },
+        };
+
+        public static object[] Decimal128TestData =
+        {
+            new object[] { Decimal128.MinValue, 6, 7, 0, 1 },
+            new object[] { new Decimal128(decimal.MinValue), 5, 6, 1, 2 },
+            new object[] { new Decimal128(3.5438693468936346437634743733M), 4, 4, 3, 3 },
+            new object[] { new Decimal128(3.5438693468936346437634743734M), 3, 4, 3, 4 },
+            new object[] { new Decimal128(3.5438693468936346437634743735M), 3, 3, 4, 4 },
+            new object[] { new Decimal128(decimal.MaxValue), 1, 2, 5, 6 },
+            new object[] { Decimal128.MaxValue, 0, 1, 6, 7 },
+        };
+
+        private void SeedDecimalData()
+        {
+            var decimalSeedData = new decimal[] { decimal.MinValue, 0, 3.5438693468936346437634743734M, 45, decimal.MaxValue };
+
+            _realm.Write(() =>
+            {
+                foreach (var d in decimalSeedData)
+                {
+                    _realm.Add(new DecimalsObject { DecimalValue = d });
+                }
+            });
+        }
+
+        private void SeedDecimal128Data()
+        {
+            var decimal128SeedData = new Decimal128[] { Decimal128.MinValue, decimal.MinValue, 0, 3.5438693468936346437634743734M, 45, decimal.MaxValue, Decimal128.MaxValue };
+
+            _realm.Write(() =>
+            {
+                foreach (var d in decimal128SeedData)
+                {
+                    _realm.Add(new DecimalsObject { Decimal128Value = d });
+                }
+            });
         }
     }
 }

--- a/Tests/Realm.Tests/Database/RealmResults/SortingTests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/SortingTests.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Linq;
+using MongoDB.Bson;
 using NUnit.Framework;
 using TestExplicitAttribute = NUnit.Framework.ExplicitAttribute;
 
@@ -327,6 +328,56 @@ namespace Realms.Tests.Database
             });
             var sortedCities = _realm.All<Cities>().OrderBy(c => c.Name).ToList().Select(c => c.Name);
             Assert.That(sortedCities, Is.EqualTo(new[] { "A-Place", "A Place", "Santo Domingo", "São Paulo", "Shanghai", "Sydney", "Åby" }));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SortsByDecimal(bool ascending)
+        {
+            var data = new[] { 1.23M, 9.123M, 5.323423M, -123.324M, 9.123M, decimal.MinValue, decimal.Zero, decimal.MaxValue };
+            _realm.Write(() =>
+            {
+                foreach (var value in data)
+                {
+                    _realm.Add(new DecimalsObject { DecimalValue = value });
+                }
+            });
+
+            if (ascending)
+            {
+                var sortedDecimals = _realm.All<DecimalsObject>().OrderBy(d => d.DecimalValue).ToArray().Select(d => d.DecimalValue);
+                Assert.That(sortedDecimals, Is.EqualTo(data.OrderBy(d => d)));
+            }
+            else
+            {
+                var sortedDecimals = _realm.All<DecimalsObject>().OrderByDescending(d => d.DecimalValue).ToArray().Select(d => d.DecimalValue);
+                Assert.That(sortedDecimals, Is.EqualTo(data.OrderByDescending(d => d)));
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SortsByDecimal128(bool ascending)
+        {
+            var data = new Decimal128[] { 1.23M, 1, 94, 9.123M, 5.323423M, Decimal128.MinValue, Decimal128.MaxValue, Decimal128.Zero, -123.324M, 9.123M, decimal.MinValue, decimal.Zero, decimal.MaxValue };
+            _realm.Write(() =>
+            {
+                foreach (var value in data)
+                {
+                    _realm.Add(new DecimalsObject { Decimal128Value = value });
+                }
+            });
+
+            if (ascending)
+            {
+                var sortedDecimals = _realm.All<DecimalsObject>().OrderBy(d => d.Decimal128Value).ToArray().Select(d => d.Decimal128Value);
+                Assert.That(sortedDecimals, Is.EqualTo(data.OrderBy(d => d)));
+            }
+            else
+            {
+                var sortedDecimals = _realm.All<DecimalsObject>().OrderByDescending(d => d.Decimal128Value).ToArray().Select(d => d.Decimal128Value);
+                Assert.That(sortedDecimals, Is.EqualTo(data.OrderByDescending(d => d)));
+            }
         }
 
         private void MakeThreeLinkingObjects(

--- a/Tests/Realm.Tests/Database/TestObjects.cs
+++ b/Tests/Realm.Tests/Database/TestObjects.cs
@@ -76,7 +76,13 @@ namespace Realms.Tests.Database
         public decimal? NullableDecimalProperty { get; set; }
 
         public Decimal128? NullableDecimal128Property { get; set; }
+    }
 
+    public class DecimalsObject : RealmObject
+    {
+        public decimal DecimalValue { get; set; }
+
+        public Decimal128 Decimal128Value { get; set; }
     }
 
     public class ListsObject : RealmObject

--- a/Tests/Realm.Tests/Database/TestObjects.cs
+++ b/Tests/Realm.Tests/Database/TestObjects.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using MongoDB.Bson;
 
 namespace Realms.Tests.Database
 {
@@ -42,6 +43,10 @@ namespace Realms.Tests.Database
         public bool BooleanProperty { get; set; }
 
         public DateTimeOffset DateTimeOffsetProperty { get; set; }
+
+        public decimal DecimalProperty { get; set; }
+
+        public Decimal128 Decimal128Property { get; set; }
 
         [Required]
         public string RequiredStringProperty { get; set; }
@@ -67,6 +72,11 @@ namespace Realms.Tests.Database
         public bool? NullableBooleanProperty { get; set; }
 
         public DateTimeOffset? NullableDateTimeOffsetProperty { get; set; }
+
+        public decimal? NullableDecimalProperty { get; set; }
+
+        public Decimal128? NullableDecimal128Property { get; set; }
+
     }
 
     public class ListsObject : RealmObject

--- a/Tests/Weaver/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/Tests/Weaver/AssemblyToProcess/AssemblyToProcess.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Bson" Version="2.11.1" />
+  </ItemGroup>
+
   <ItemGroup Label="References">
     <ProjectReference Include="..\Realm.FakeForWeaverTests\Realm.FakeForWeaverTests.csproj" />
   </ItemGroup>

--- a/Tests/Weaver/AssemblyToProcess/CopyToRealmTestObjects.cs
+++ b/Tests/Weaver/AssemblyToProcess/CopyToRealmTestObjects.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using MongoDB.Bson;
 using Realms;
 
 namespace AssemblyToProcess
@@ -53,6 +54,18 @@ namespace AssemblyToProcess
     }
 
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class DecimalProperty : RealmObject
+    {
+        public decimal Decimal { get; set; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class Decimal128Property : RealmObject
+    {
+        public Decimal128 Decimal128 { get; set; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
     public class NullableProperties : RealmObject
     {
         public char? Char { get; set; }
@@ -70,6 +83,10 @@ namespace AssemblyToProcess
         public double? Double { get; set; }
 
         public DateTimeOffset? DateTimeOffset { get; set; }
+
+        public decimal? Decimal { get; set; }
+
+        public Decimal128? Decimal128 { get; set; }
 
         public bool? Boolean { get; set; }
     }

--- a/Tests/Weaver/AssemblyToProcess/TestObjects.cs
+++ b/Tests/Weaver/AssemblyToProcess/TestObjects.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using MongoDB.Bson;
 using Realms;
 
 namespace AssemblyToProcess
@@ -39,6 +40,10 @@ namespace AssemblyToProcess
         public float SingleProperty { get; set; }
 
         public double DoubleProperty { get; set; }
+
+        public decimal DecimalProperty { get; set; }
+
+        public Decimal128 Decimal128Property { get; set; }
 
         public bool BooleanProperty { get; set; }
 
@@ -61,6 +66,10 @@ namespace AssemblyToProcess
         public double? NullableDoubleProperty { get; set; }
 
         public bool? NullableBooleanProperty { get; set; }
+
+        public decimal? NullableDecimalProperty { get; set; }
+
+        public Decimal128? NullableDecimal128Property { get; set; }
 
         public DateTimeOffset? NullableDateTimeOffsetProperty { get; set; }
 

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using Fody;
+using MongoDB.Bson;
 using NUnit.Framework;
 using Realms;
 using Realms.Weaving;
@@ -124,11 +125,15 @@ namespace RealmWeaver
             "Double",
             "Boolean",
             "DateTimeOffset",
+            "Decimal",
+            "Decimal128",
             "NullableChar",
             "NullableSingle",
             "NullableDouble",
             "NullableBoolean",
             "NullableDateTimeOffset",
+            "NullableDecimal",
+            "NullableDecimal128",
         };
 
         public enum PropertyChangedWeaver
@@ -215,6 +220,8 @@ namespace RealmWeaver
             new object[] { "Double", 123.123, 0.0 },
             new object[] { "Boolean", true, false },
             new object[] { "String", "str", null },
+            new object[] { "Decimal", 123.456M, 0M },
+            new object[] { "Decimal128", new Decimal128(123.456), new Decimal128() },
             new object[] { "NullableChar", '0', null },
             new object[] { "NullableByte", (byte)100, null },
             new object[] { "NullableInt16", (short)100, null },
@@ -223,6 +230,8 @@ namespace RealmWeaver
             new object[] { "NullableSingle", 123.123f, null },
             new object[] { "NullableDouble", 123.123, null },
             new object[] { "NullableBoolean", true, null },
+            new object[] { "NullableDecimal", 123.456M, null },
+            new object[] { "NullableDecimal128", new Decimal128(123.456), null },
             new object[] { "ByteCounter", (RealmInteger<byte>)100, (byte)0 },
             new object[] { "Int16Counter", (RealmInteger<short>)100, (short)0 },
             new object[] { "Int32Counter", (RealmInteger<int>)100, 0 },
@@ -600,11 +609,15 @@ namespace RealmWeaver
         }
 
         [Test]
-        public void WovenCopyToRealm_ShouldAlwaysSetDateTimeOffsetProperties()
+        public void WovenCopyToRealm_ShouldAlwaysSetStructProperties()
         {
             // DateTimeOffset can't be set as a constant
             WovenCopyToRealm_ShouldSetNonDefaultProperties("DateTimeOffset", default(DateTimeOffset), "DateTimeOffsetProperty");
             WovenCopyToRealm_ShouldSetNonDefaultProperties("DateTimeOffset", new DateTimeOffset(1, 1, 1, 1, 1, 1, TimeSpan.Zero), "DateTimeOffsetProperty");
+            WovenCopyToRealm_ShouldSetNonDefaultProperties("Decimal", default(decimal), "DecimalProperty");
+            WovenCopyToRealm_ShouldSetNonDefaultProperties("Decimal", 1234.3225352352M, "DecimalProperty");
+            WovenCopyToRealm_ShouldSetNonDefaultProperties("Decimal128", default(Decimal128), "Decimal128Property");
+            WovenCopyToRealm_ShouldSetNonDefaultProperties("Decimal128", new Decimal128(124.3124214), "Decimal128Property");
         }
 
         [Test]

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -48,6 +48,13 @@ struct PrimitiveValue
     } value2;
 };
 
+inline realm::Decimal128 to_decimal(PrimitiveValue primitive)
+{
+    REALM_ASSERT(primitive.type == realm::PropertyType::Decimal || primitive.type == (realm::PropertyType::Decimal | realm::PropertyType::Nullable));
+
+    return realm::Decimal128(realm::Decimal128::Bid128{ primitive.value.low_bytes, primitive.value2.high_bytes });
+}
+
 struct StringValue
 {
     const char* value;

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -39,7 +39,13 @@ struct PrimitiveValue
         int64_t int_value;
         float float_value;
         double double_value;
+        uint64_t low_bytes;
     } value;
+
+    union {
+        uint64_t high_bytes;
+        uint32_t object_id_remainder;
+    } value2;
 };
 
 struct StringValue

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -30,29 +30,17 @@ namespace binding {
 
 struct PrimitiveValue
 {
-    realm::PropertyType type;
-    bool has_value;
-    char padding[6];
-
     union {
         bool bool_value;
         int64_t int_value;
         float float_value;
         double double_value;
-        uint64_t low_bytes;
+        realm::Decimal128::Bid128 decimal_bits;
     } value;
 
-    union {
-        uint64_t high_bytes;
-    } value2;
+    realm::PropertyType type;
+    bool has_value;
 };
-
-inline realm::Decimal128 to_decimal(PrimitiveValue primitive)
-{
-    REALM_ASSERT(primitive.type == realm::PropertyType::Decimal || primitive.type == (realm::PropertyType::Decimal | realm::PropertyType::Nullable));
-
-    return realm::Decimal128(realm::Decimal128::Bid128{ primitive.value.low_bytes, primitive.value2.high_bytes });
-}
 
 struct StringValue
 {

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -44,7 +44,6 @@ struct PrimitiveValue
 
     union {
         uint64_t high_bytes;
-        uint32_t object_id_remainder;
     } value2;
 };
 

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -207,12 +207,11 @@ extern "C" {
                 object.obj().set(column_key, value.has_value ? from_ticks(value.value.int_value) : Timestamp());
                 break;
             case realm::PropertyType::Decimal: {
-                auto decimal = Decimal128(Decimal128::Bid128{ value.value.low_bytes, value.value2.high_bytes });
-                object.obj().set(column_key, decimal);
+                object.obj().set(column_key, to_decimal(value));
                 break;
             }
             case realm::PropertyType::Decimal | realm::PropertyType::Nullable: {
-                auto decimal = value.has_value ? Decimal128(Decimal128::Bid128{ value.value.low_bytes, value.value2.high_bytes }) : Decimal128(null());
+                auto decimal = value.has_value ? to_decimal(value) : Decimal128(null());
                 object.obj().set(column_key, decimal);
                 break;
             }

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -149,18 +149,17 @@ extern "C" {
                 break;
             }
             case realm::PropertyType::Decimal: {
-                auto result = *object.obj().get<Decimal128>(column_key).raw();
-                value.value.low_bytes = result.w[0];
-                value.value2.high_bytes = result.w[1];
+                auto result = object.obj().get<Decimal128>(column_key);
+                value.value.low_bytes = result.raw()->w[0];
+                value.value2.high_bytes = result.raw()->w[1];
                 break;
             }
             case realm::PropertyType::Decimal | realm::PropertyType::Nullable: {
                 auto result = object.obj().get<Decimal128>(column_key);
                 value.has_value = !result.is_null();
                 if (value.has_value) {
-                    auto dec = *result.raw();
-                    value.value.low_bytes = dec.w[0];
-                    value.value2.high_bytes = dec.w[1];
+                    value.value.low_bytes = result.raw()->w[0];
+                    value.value2.high_bytes = result.raw()->w[1];
                 }
                 break;
             }

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -149,7 +149,7 @@ extern "C" {
                 break;
             }
             case realm::PropertyType::Decimal: {
-                auto& result = *object.obj().get<Decimal128>(column_key).raw();
+                auto result = *object.obj().get<Decimal128>(column_key).raw();
                 value.value.low_bytes = result.w[0];
                 value.value2.high_bytes = result.w[1];
                 break;
@@ -158,7 +158,7 @@ extern "C" {
                 auto result = object.obj().get<Decimal128>(column_key);
                 value.has_value = !result.is_null();
                 if (value.has_value) {
-                    auto& dec = *result.raw();
+                    auto dec = *result.raw();
                     value.value.low_bytes = dec.w[0];
                     value.value2.high_bytes = dec.w[1];
                 }

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -149,7 +149,7 @@ extern "C" {
                 break;
             }
             case realm::PropertyType::Decimal: {
-                auto result = *object.obj().get<Decimal128>(column_key).raw();
+                auto& result = *object.obj().get<Decimal128>(column_key).raw();
                 value.value.low_bytes = result.w[0];
                 value.value2.high_bytes = result.w[1];
                 break;
@@ -158,7 +158,7 @@ extern "C" {
                 auto result = object.obj().get<Decimal128>(column_key);
                 value.has_value = !result.is_null();
                 if (value.has_value) {
-                    auto dec = *result.raw();
+                    auto& dec = *result.raw();
                     value.value.low_bytes = dec.w[0];
                     value.value2.high_bytes = dec.w[1];
                 }

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -150,16 +150,14 @@ extern "C" {
             }
             case realm::PropertyType::Decimal: {
                 auto result = object.obj().get<Decimal128>(column_key);
-                value.value.low_bytes = result.raw()->w[0];
-                value.value2.high_bytes = result.raw()->w[1];
+                value.value.decimal_bits = *result.raw();
                 break;
             }
             case realm::PropertyType::Decimal | realm::PropertyType::Nullable: {
                 auto result = object.obj().get<Decimal128>(column_key);
                 value.has_value = !result.is_null();
                 if (value.has_value) {
-                    value.value.low_bytes = result.raw()->w[0];
-                    value.value2.high_bytes = result.raw()->w[1];
+                    value.value.decimal_bits = *result.raw();
                 }
                 break;
             }
@@ -209,11 +207,11 @@ extern "C" {
                 object.obj().set(column_key, value.has_value ? from_ticks(value.value.int_value) : Timestamp());
                 break;
             case realm::PropertyType::Decimal: {
-                object.obj().set(column_key, to_decimal(value));
+                object.obj().set(column_key, realm::Decimal128(value.value.decimal_bits));
                 break;
             }
             case realm::PropertyType::Decimal | realm::PropertyType::Nullable: {
-                auto decimal = value.has_value ? to_decimal(value) : Decimal128(null());
+                auto decimal = value.has_value ? realm::Decimal128(value.value.decimal_bits) : Decimal128(null());
                 object.obj().set(column_key, decimal);
                 break;
             }

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -150,6 +150,10 @@ REALM_EXPORT void query_primitive_equal(Query& query, ColKey column_key, Primiti
         case realm::PropertyType::Date | realm::PropertyType::Nullable:
             query.equal(column_key, from_ticks(primitive.value.int_value));
             break;
+        case realm::PropertyType::Decimal:
+        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
+            query.equal(column_key, to_decimal(primitive));
+            break;
         default:
             REALM_UNREACHABLE();
         }
@@ -187,6 +191,10 @@ REALM_EXPORT void query_primitive_not_equal(Query& query, ColKey column_key, Pri
         case realm::PropertyType::Date | realm::PropertyType::Nullable:
             query.not_equal(column_key, from_ticks(primitive.value.int_value));
             break;
+        case realm::PropertyType::Decimal:
+        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
+            query.not_equal(column_key, to_decimal(primitive));
+            break;
         default:
             REALM_UNREACHABLE();
         }
@@ -222,6 +230,10 @@ REALM_EXPORT void query_primitive_less(Query& query, ColKey column_key, Primitiv
         case realm::PropertyType::Date:
         case realm::PropertyType::Date | realm::PropertyType::Nullable:
             query.less(column_key, from_ticks(primitive.value.int_value));
+            break;
+        case realm::PropertyType::Decimal:
+        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
+            query.less(column_key, to_decimal(primitive));
             break;
         default:
             REALM_UNREACHABLE();
@@ -259,6 +271,10 @@ REALM_EXPORT void query_primitive_less_equal(Query& query, ColKey column_key, Pr
         case realm::PropertyType::Date | realm::PropertyType::Nullable:
             query.less_equal(column_key, from_ticks(primitive.value.int_value));
             break;
+        case realm::PropertyType::Decimal:
+        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
+            query.less_equal(column_key, to_decimal(primitive));
+            break;
         default:
             REALM_UNREACHABLE();
         }
@@ -295,6 +311,10 @@ REALM_EXPORT void query_primitive_greater(Query& query, ColKey column_key, Primi
         case realm::PropertyType::Date | realm::PropertyType::Nullable:
             query.greater(column_key, from_ticks(primitive.value.int_value));
             break;
+        case realm::PropertyType::Decimal:
+        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
+            query.greater(column_key, to_decimal(primitive));
+            break;
         default:
             REALM_UNREACHABLE();
         }
@@ -330,6 +350,10 @@ REALM_EXPORT void query_primitive_greater_equal(Query& query, ColKey column_key,
         case realm::PropertyType::Date:
         case realm::PropertyType::Date | realm::PropertyType::Nullable:
             query.greater_equal(column_key, from_ticks(primitive.value.int_value));
+            break;
+        case realm::PropertyType::Decimal:
+        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
+            query.greater_equal(column_key, to_decimal(primitive));
             break;
         default:
             REALM_UNREACHABLE();

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -152,7 +152,7 @@ REALM_EXPORT void query_primitive_equal(Query& query, ColKey column_key, Primiti
             break;
         case realm::PropertyType::Decimal:
         case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.equal(column_key, to_decimal(primitive));
+            query.equal(column_key, realm::Decimal128(primitive.value.decimal_bits));
             break;
         default:
             REALM_UNREACHABLE();
@@ -193,7 +193,7 @@ REALM_EXPORT void query_primitive_not_equal(Query& query, ColKey column_key, Pri
             break;
         case realm::PropertyType::Decimal:
         case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.not_equal(column_key, to_decimal(primitive));
+            query.not_equal(column_key, realm::Decimal128(primitive.value.decimal_bits));
             break;
         default:
             REALM_UNREACHABLE();
@@ -233,7 +233,7 @@ REALM_EXPORT void query_primitive_less(Query& query, ColKey column_key, Primitiv
             break;
         case realm::PropertyType::Decimal:
         case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.less(column_key, to_decimal(primitive));
+            query.less(column_key, realm::Decimal128(primitive.value.decimal_bits));
             break;
         default:
             REALM_UNREACHABLE();
@@ -273,7 +273,7 @@ REALM_EXPORT void query_primitive_less_equal(Query& query, ColKey column_key, Pr
             break;
         case realm::PropertyType::Decimal:
         case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.less_equal(column_key, to_decimal(primitive));
+            query.less_equal(column_key, realm::Decimal128(primitive.value.decimal_bits));
             break;
         default:
             REALM_UNREACHABLE();
@@ -313,7 +313,7 @@ REALM_EXPORT void query_primitive_greater(Query& query, ColKey column_key, Primi
             break;
         case realm::PropertyType::Decimal:
         case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.greater(column_key, to_decimal(primitive));
+            query.greater(column_key, realm::Decimal128(primitive.value.decimal_bits));
             break;
         default:
             REALM_UNREACHABLE();
@@ -353,7 +353,7 @@ REALM_EXPORT void query_primitive_greater_equal(Query& query, ColKey column_key,
             break;
         case realm::PropertyType::Decimal:
         case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.greater_equal(column_key, to_decimal(primitive));
+            query.greater_equal(column_key, realm::Decimal128(primitive.value.decimal_bits));
             break;
         default:
             REALM_UNREACHABLE();


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

This adds support for persisting and querying decimal properties. The database stores these values as a 128-bit decimal value, but we're also allowing defining the properties as .NET's built-in `decimal` type, even though it's only 96-bit. We'll automatically convert between the 96 and the 128-bit version where appropriate, but keep in mind that you may lose precision or range when using the built-in type.

Example code:

```csharp
public class MyClassWithDecimals : RealmObject
{
    // Declare decimal properties as usual - with an automatic getter and setter
    public decimal VeryPreciseNumber { get; set; }

    // To use the full range of the native decimal, use Decimal128 from the MongoDB.Bson package.
    // The .NET SDK already pulls that as a dependency, so you don't have to NuGet install it.
    public Decimal128 EvenMorePreciseNumber { get; set; }

    // Nullable decimal or Decimal128 are supported as usual
    public decimal? MaybeDecimal { get; set; }
    public Decimal128? MaybeDecimal128 { get; set; }
}

// To store decimal values:
realm.Write(() =>
{
    myObj.VeryPreciseNumber = 1.234567890123456789M;
    myObj.EvenMorePreciseNumber = Decimal128.Parse("987654321.123456789");

    // Decimal128 implicitly converts from decimal, int, long, etc.
    myOtherObj.EvenMorePreciseNumber = 123.456M;
    myThirdObj.EvenMorePreciseNumber = 6;

    // Decimal128 has explicit constructors that take a float or a double
    myFourthObj.EvenMorePreciseNumber = new Decimal128(9.99999);
});

// To query decimal values:

var largerThanFive = realm.All<MyClassWithDecimals>()
                          .Where(o => o.VeryPreciseNumber > 5)
                          .OrderBy(o => o.EvenMorePreciseNumber);

var smallerThanZero = realm.All<MyClassWithDecimals>()
                           .Where(o => o.EvenMorePreciseNumber < 0)
                           .OrderByDescending(o => o.VeryPreciseNumber);
```


Fixes #1938, RNET-177

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
