### PR TITLE
Special-case DispatcherSynchronizationContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 * None
 
 ### Fixed
-* None
+* Fixed an issue that would cause using Realm on the main thread in WPF applications to throw an exception with a message "Realm accessed from the incorrect thread". (Issue [#2026](https://github.com/realm/realm-dotnet/issues/2026))
 
 ### Compatibility
 * Realm Object Server: 3.23.1 or later.
 
 ### Internal
 * Using Sync 5.0.21 and Core 6.0.24.
-* Added prerelease nuget feed via [GitHub packages](https://github.com/features/packages). ([#2028](https://github.com/realm/realm-dotnet/pull/2028))
+* Added prerelease nuget feed via [GitHub packages](https://github.com/features/packages). (PR [#2028](https://github.com/realm/realm-dotnet/pull/2028))
 
 ## 5.0.1 (2020-09-10)
 ------------------

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,7 @@ stage('Package') {
         packageVersion = getVersion(packages[0].name);
         echo "Inferred version is ${packageVersion}"
 
-        if (env.CHANGE_BRANCH == 'master') {
+        if (env.BRANCH_NAME == 'master') {
           withCredentials([usernamePassword(credentialsId: 'github-packages-token', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PASSWORD')]) {
             echo "Publishing Realm.Fody.${packageVersion} to github packages"
             bat "dotnet nuget add source https://nuget.pkg.github.com/realm/index.json -n github -u ${env.GITHUB_USERNAME} -p ${env.GITHUB_PASSWORD} & exit 0"

--- a/Realm/Realm/Extensions/SynchronizationContextExtensions.cs
+++ b/Realm/Realm/Extensions/SynchronizationContextExtensions.cs
@@ -1,0 +1,62 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Reflection;
+using System.Threading;
+
+namespace Realms
+{
+    internal static class SynchronizationContextExtensions
+    {
+        private static readonly Lazy<Type> _dispatcherSyncContextType = new Lazy<Type>(() => Type.GetType("System.Windows.Threading.DispatcherSynchronizationContext, WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"));
+        private static readonly Lazy<FieldInfo> _dispatcherFI = new Lazy<FieldInfo>(() => _dispatcherSyncContextType.Value?.GetField("_dispatcher", BindingFlags.NonPublic | BindingFlags.Instance));
+
+        public static bool IsSameAs(this SynchronizationContext first, SynchronizationContext second)
+        {
+            if (first == null || second == null)
+            {
+                return false;
+            }
+
+            if (first == second)
+            {
+                return true;
+            }
+
+            try
+            {
+                if (_dispatcherSyncContextType.Value == null)
+                {
+                    return false;
+                }
+
+                var firstType = first.GetType();
+                var secondType = second.GetType();
+
+                return firstType == _dispatcherSyncContextType.Value &&
+                    secondType == _dispatcherSyncContextType.Value &&
+                    _dispatcherFI.Value.GetValue(first) == _dispatcherFI.Value.GetValue(second);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

This introduces a fallback mechanism where contexts of type `DispatcherSynchronizationContext` will get their thread ids compared for equality. 

Fixes #2026 

##  TODO

* [x] Changelog entry
* [ ] Tests (if applicable)
