### PR TITLE
Only allow x86 and x64 targets for simulator builds

### DIFF
--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -78,6 +78,8 @@ include(CompilerFlags)
 set(REALM_ENABLE_SYNC ON)
 
 if(APPLE)
+  set(CMAKE_XCODE_ATTRIBUTE_VALID_ARCHS[sdk=iphonesimulator*] "i386 x86_64")
+
   find_package(Threads)
   if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set(platform ios)


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

Removes arm64 and arm64e from the list of valid archs for simulator builds. This is needed because core and sync don't include these slices in the prebuilt binaries.