### PR TITLE
Phase 1 of ISet support

### DIFF
--- a/Realm/Realm.Fody/Extensions/PropertyDefinitionExtensions.cs
+++ b/Realm/Realm.Fody/Extensions/PropertyDefinitionExtensions.cs
@@ -54,14 +54,37 @@ internal static class PropertyDefinitionExtensions
         return property.IsType("IList`1", "System.Collections.Generic");
     }
 
-    internal static bool IsIList(this PropertyDefinition property, TypeReference elementType)
+    internal static bool IsISet(this PropertyDefinition property)
     {
-        return IsIList(property) && ((GenericInstanceType)property.PropertyType).GenericArguments.Single().IsSameAs(elementType);
+        return property.IsType("ISet`1", "System.Collections.Generic");
     }
 
-    internal static bool IsIList(this PropertyDefinition property, System.Type elementType)
+    internal static bool IsCollection(this PropertyDefinition property, out RealmCollectionType collectionType)
     {
-        return IsIList(property) && ((GenericInstanceType)property.PropertyType).GenericArguments.Single().FullName == elementType.FullName;
+        if (property.IsISet())
+        {
+            collectionType = RealmCollectionType.ISet;
+            return true;
+        }
+
+        if (property.IsIList())
+        {
+            collectionType = RealmCollectionType.IList;
+            return true;
+        }
+
+        collectionType = RealmCollectionType.None;
+        return false;
+    }
+
+    internal static bool IsCollection(this PropertyDefinition property, TypeReference elementType)
+    {
+        return (IsIList(property) || IsISet(property)) && ((GenericInstanceType)property.PropertyType).GenericArguments.Single().IsSameAs(elementType);
+    }
+
+    internal static bool IsCollection(this PropertyDefinition property, System.Type elementType)
+    {
+        return property.IsCollection(out _) && ((GenericInstanceType)property.PropertyType).GenericArguments.Single().FullName == elementType.FullName;
     }
 
     internal static bool IsIQueryable(this PropertyDefinition property)

--- a/Realm/Realm.Fody/ImportedReferences.cs
+++ b/Realm/Realm.Fody/ImportedReferences.cs
@@ -41,6 +41,10 @@ namespace RealmWeaver
 
         public MethodReference IListOfT_get_Item { get; private set; }
 
+        public TypeReference ISetOfT { get; }
+
+        public MethodReference ISetOfT_UnionWith { get; private set; }
+
         public abstract TypeReference IQueryableOfT { get; }
 
         public TypeReference System_Type { get; }
@@ -50,6 +54,10 @@ namespace RealmWeaver
         public abstract TypeReference System_Collections_Generic_ListOfT { get; }
 
         public MethodReference System_Collections_Generic_ListOfT_Constructor { get; private set; }
+
+        public abstract TypeReference System_Collections_Generic_HashSetOfT { get; }
+
+        public MethodReference System_Collections_Generic_HashSetOfT_Constructor { get; private set; }
 
         public abstract TypeReference System_Linq_Enumerable { get; }
 
@@ -75,6 +83,8 @@ namespace RealmWeaver
 
         public MethodReference Realm_Add { get; private set; }
 
+        public MethodReference Realm_AddCollection { get; private set; }
+
         public TypeReference RealmObject { get; private set; }
 
         public TypeReference RealmObjectBase { get; private set; }
@@ -98,6 +108,8 @@ namespace RealmWeaver
         public MethodReference RealmObject_SetObjectValue { get; private set; }
 
         public MethodReference RealmObject_GetListValue { get; private set; }
+
+        public MethodReference RealmObject_GetSetValue { get; private set; }
 
         public MethodReference RealmObject_GetBacklinks { get; private set; }
 
@@ -155,6 +167,9 @@ namespace RealmWeaver
 
             IListOfT = new TypeReference("System.Collections.Generic", "IList`1", Module, Module.TypeSystem.CoreLibrary);
             IListOfT.GenericParameters.Add(new GenericParameter(IListOfT));
+
+            ISetOfT = new TypeReference("System.Collections.Generic", "ISet`1", Module, Module.TypeSystem.CoreLibrary);
+            ISetOfT.GenericParameters.Add(new GenericParameter(ISetOfT));
 
             System_ValueType = new TypeReference("System", "ValueType", Module, Module.TypeSystem.CoreLibrary);
 
@@ -218,7 +233,15 @@ namespace RealmWeaver
                 Parameters = { new ParameterDefinition(Types.Int32Reference) }
             };
 
+            ISetOfT_UnionWith = new MethodReference("UnionWith", Types.VoidReference, ISetOfT)
+            {
+                HasThis = true,
+                Parameters = { new ParameterDefinition(new GenericInstanceType(IEnumerableOfT) { GenericArguments = { ISetOfT.GenericParameters.Single() } }) }
+            };
+
             System_Collections_Generic_ListOfT_Constructor = new MethodReference(".ctor", Types.VoidReference, System_Collections_Generic_ListOfT) { HasThis = true };
+
+            System_Collections_Generic_HashSetOfT_Constructor = new MethodReference(".ctor", Types.VoidReference, System_Collections_Generic_HashSetOfT) { HasThis = true };
 
             {
                 System_Linq_Enumerable_Empty = new MethodReference("Empty", Types.VoidReference, System_Linq_Enumerable);
@@ -275,6 +298,14 @@ namespace RealmWeaver
                 Realm_Add.Parameters.Add(new ParameterDefinition(Types.BooleanReference));
             }
 
+            {
+                Realm_AddCollection = new MethodReference("Add", Types.VoidReference, Realm) { HasThis = true };
+                var T = new GenericParameter(Realm_AddCollection) { Constraints = { new GenericParameterConstraint(RealmObject) } };
+                Realm_AddCollection.GenericParameters.Add(T);
+                Realm_AddCollection.Parameters.Add(new ParameterDefinition(new GenericInstanceType(IEnumerableOfT) { GenericArguments = { T } }));
+                Realm_AddCollection.Parameters.Add(new ParameterDefinition(Types.BooleanReference));
+            }
+
             RealmObject_get_IsManaged = new MethodReference("get_IsManaged", Types.BooleanReference, RealmObjectBase) { HasThis = true };
             RealmObject_get_Realm = new MethodReference("get_Realm", Realm, RealmObjectBase) { HasThis = true };
             RealmObject_RaisePropertyChanged = new MethodReference("RaisePropertyChanged", Types.VoidReference, RealmObjectBase)
@@ -305,6 +336,14 @@ namespace RealmWeaver
                 (RealmObject_GetListValue.ReturnType as GenericInstanceType).GenericArguments.Add(T);
                 RealmObject_GetListValue.GenericParameters.Add(T);
                 RealmObject_GetListValue.Parameters.Add(new ParameterDefinition(Types.StringReference));
+            }
+
+            {
+                RealmObject_GetSetValue = new MethodReference("GetSetValue", new GenericInstanceType(ISetOfT), RealmObjectBase) { HasThis = true };
+                var T = new GenericParameter(RealmObject_GetSetValue);
+                (RealmObject_GetSetValue.ReturnType as GenericInstanceType).GenericArguments.Add(T);
+                RealmObject_GetSetValue.GenericParameters.Add(T);
+                RealmObject_GetSetValue.Parameters.Add(new ParameterDefinition(Types.StringReference));
             }
 
             {
@@ -430,6 +469,8 @@ namespace RealmWeaver
 
             public override TypeReference System_Collections_Generic_ListOfT { get; }
 
+            public override TypeReference System_Collections_Generic_HashSetOfT { get; }
+
             public override TypeReference System_Linq_Enumerable { get; }
 
             public override TypeReference System_Linq_Queryable { get; }
@@ -444,6 +485,9 @@ namespace RealmWeaver
                 System_Collections_Generic_ListOfT = new TypeReference("System.Collections.Generic", "List`1", Module, Module.TypeSystem.CoreLibrary);
                 System_Collections_Generic_ListOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_ListOfT));
 
+                System_Collections_Generic_HashSetOfT = new TypeReference("System.Collections.Generic", "HashSet`1", Module, Module.TypeSystem.CoreLibrary);
+                System_Collections_Generic_HashSetOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_HashSetOfT));
+
                 System_Linq_Enumerable = new TypeReference("System.Linq", "Enumerable", Module, System_Core);
 
                 System_Linq_Queryable = new TypeReference("System.Linq", "Queryable", Module, System_Core);
@@ -455,6 +499,8 @@ namespace RealmWeaver
             public override TypeReference IQueryableOfT { get; }
 
             public override TypeReference System_Collections_Generic_ListOfT { get; }
+
+            public override TypeReference System_Collections_Generic_HashSetOfT { get; }
 
             public override TypeReference System_Linq_Enumerable { get; }
 
@@ -468,6 +514,9 @@ namespace RealmWeaver
                 System_Collections_Generic_ListOfT = new TypeReference("System.Collections.Generic", "List`1", Module, GetOrAddFrameworkReference("System.Collections"));
                 System_Collections_Generic_ListOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_ListOfT));
 
+                System_Collections_Generic_HashSetOfT = new TypeReference("System.Collections.Generic", "HashSet`1", Module, GetOrAddFrameworkReference("System.Collections"));
+                System_Collections_Generic_HashSetOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_HashSetOfT));
+
                 System_Linq_Enumerable = new TypeReference("System.Linq", "Enumerable", Module, GetOrAddFrameworkReference("System.Linq"));
                 System_Linq_Queryable = new TypeReference("System.Linq", "Queryable", Module, GetOrAddFrameworkReference("System.Linq.Queryable"));
             }
@@ -478,6 +527,8 @@ namespace RealmWeaver
             public override TypeReference IQueryableOfT { get; }
 
             public override TypeReference System_Collections_Generic_ListOfT { get; }
+
+            public override TypeReference System_Collections_Generic_HashSetOfT { get; }
 
             public override TypeReference System_Linq_Enumerable { get; }
 
@@ -490,6 +541,9 @@ namespace RealmWeaver
 
                 System_Collections_Generic_ListOfT = new TypeReference("System.Collections.Generic", "List`1", Module, Module.TypeSystem.CoreLibrary);
                 System_Collections_Generic_ListOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_ListOfT));
+
+                System_Collections_Generic_HashSetOfT = new TypeReference("System.Collections.Generic", "HashSet`1", Module, Module.TypeSystem.CoreLibrary);
+                System_Collections_Generic_HashSetOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_HashSetOfT));
 
                 System_Linq_Enumerable = new TypeReference("System.Linq", "Enumerable", Module, Module.TypeSystem.CoreLibrary);
                 System_Linq_Queryable = new TypeReference("System.Linq", "Queryable", Module, Module.TypeSystem.CoreLibrary);

--- a/Realm/Realm.Fody/ImportedReferences.cs
+++ b/Realm/Realm.Fody/ImportedReferences.cs
@@ -41,7 +41,7 @@ namespace RealmWeaver
 
         public MethodReference IListOfT_get_Item { get; private set; }
 
-        public TypeReference ISetOfT { get; }
+        public abstract TypeReference ISetOfT { get; }
 
         public MethodReference ISetOfT_UnionWith { get; private set; }
 
@@ -167,9 +167,6 @@ namespace RealmWeaver
 
             IListOfT = new TypeReference("System.Collections.Generic", "IList`1", Module, Module.TypeSystem.CoreLibrary);
             IListOfT.GenericParameters.Add(new GenericParameter(IListOfT));
-
-            ISetOfT = new TypeReference("System.Collections.Generic", "ISet`1", Module, Module.TypeSystem.CoreLibrary);
-            ISetOfT.GenericParameters.Add(new GenericParameter(ISetOfT));
 
             System_ValueType = new TypeReference("System", "ValueType", Module, Module.TypeSystem.CoreLibrary);
 
@@ -475,22 +472,24 @@ namespace RealmWeaver
 
             public override TypeReference System_Linq_Queryable { get; }
 
+            public override TypeReference ISetOfT { get; }
+
             public NETFramework(ModuleDefinition module, Fody.TypeSystem types, FrameworkName frameworkName) : base(module, types, frameworkName)
             {
-                var System_Core = GetOrAddFrameworkReference("System.Core");
-
-                IQueryableOfT = new TypeReference("System.Linq", "IQueryable`1", Module, System_Core);
+                IQueryableOfT = new TypeReference("System.Linq", "IQueryable`1", Module, GetOrAddFrameworkReference("System.Core"));
                 IQueryableOfT.GenericParameters.Add(new GenericParameter(IQueryableOfT));
+
+                ISetOfT = new TypeReference("System.Collections.Generic", "ISet`1", Module, GetOrAddFrameworkReference("System"));
+                ISetOfT.GenericParameters.Add(new GenericParameter(ISetOfT));
 
                 System_Collections_Generic_ListOfT = new TypeReference("System.Collections.Generic", "List`1", Module, Module.TypeSystem.CoreLibrary);
                 System_Collections_Generic_ListOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_ListOfT));
 
-                System_Collections_Generic_HashSetOfT = new TypeReference("System.Collections.Generic", "HashSet`1", Module, Module.TypeSystem.CoreLibrary);
+                System_Collections_Generic_HashSetOfT = new TypeReference("System.Collections.Generic", "HashSet`1", Module, GetOrAddFrameworkReference("System.Core"));
                 System_Collections_Generic_HashSetOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_HashSetOfT));
 
-                System_Linq_Enumerable = new TypeReference("System.Linq", "Enumerable", Module, System_Core);
-
-                System_Linq_Queryable = new TypeReference("System.Linq", "Queryable", Module, System_Core);
+                System_Linq_Enumerable = new TypeReference("System.Linq", "Enumerable", Module, GetOrAddFrameworkReference("System.Core"));
+                System_Linq_Queryable = new TypeReference("System.Linq", "Queryable", Module, GetOrAddFrameworkReference("System.Core"));
             }
         }
 
@@ -506,10 +505,15 @@ namespace RealmWeaver
 
             public override TypeReference System_Linq_Queryable { get; }
 
+            public override TypeReference ISetOfT { get; }
+
             public NETPortable(ModuleDefinition module, Fody.TypeSystem types, FrameworkName frameworkName) : base(module, types, frameworkName)
             {
                 IQueryableOfT = new TypeReference("System.Linq", "IQueryable`1", Module, GetOrAddFrameworkReference("System.Linq.Expressions"));
                 IQueryableOfT.GenericParameters.Add(new GenericParameter(IQueryableOfT));
+
+                ISetOfT = new TypeReference("System.Collections.Generic", "ISet`1", Module, GetOrAddFrameworkReference("System.Collections"));
+                ISetOfT.GenericParameters.Add(new GenericParameter(ISetOfT));
 
                 System_Collections_Generic_ListOfT = new TypeReference("System.Collections.Generic", "List`1", Module, GetOrAddFrameworkReference("System.Collections"));
                 System_Collections_Generic_ListOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_ListOfT));
@@ -534,10 +538,15 @@ namespace RealmWeaver
 
             public override TypeReference System_Linq_Queryable { get; }
 
+            public override TypeReference ISetOfT { get; }
+
             public NetStandard2(ModuleDefinition module, Fody.TypeSystem types, FrameworkName frameworkName) : base(module, types, frameworkName)
             {
                 IQueryableOfT = new TypeReference("System.Linq", "IQueryable`1", Module, Module.TypeSystem.CoreLibrary);
                 IQueryableOfT.GenericParameters.Add(new GenericParameter(IQueryableOfT));
+
+                ISetOfT = new TypeReference("System.Collections.Generic", "ISet`1", Module, Module.TypeSystem.CoreLibrary);
+                ISetOfT.GenericParameters.Add(new GenericParameter(ISetOfT));
 
                 System_Collections_Generic_ListOfT = new TypeReference("System.Collections.Generic", "List`1", Module, Module.TypeSystem.CoreLibrary);
                 System_Collections_Generic_ListOfT.GenericParameters.Add(new GenericParameter(System_Collections_Generic_ListOfT));

--- a/Realm/Realm.Fody/ImportedReferences.cs
+++ b/Realm/Realm.Fody/ImportedReferences.cs
@@ -512,7 +512,7 @@ namespace RealmWeaver
                 IQueryableOfT = new TypeReference("System.Linq", "IQueryable`1", Module, GetOrAddFrameworkReference("System.Linq.Expressions"));
                 IQueryableOfT.GenericParameters.Add(new GenericParameter(IQueryableOfT));
 
-                ISetOfT = new TypeReference("System.Collections.Generic", "ISet`1", Module, GetOrAddFrameworkReference("System.Collections"));
+                ISetOfT = new TypeReference("System.Collections.Generic", "ISet`1", Module, Module.TypeSystem.CoreLibrary);
                 ISetOfT.GenericParameters.Add(new GenericParameter(ISetOfT));
 
                 System_Collections_Generic_ListOfT = new TypeReference("System.Collections.Generic", "List`1", Module, GetOrAddFrameworkReference("System.Collections"));

--- a/Realm/Realm.Fody/ModuleWeaver.cs
+++ b/Realm/Realm.Fody/ModuleWeaver.cs
@@ -1138,7 +1138,7 @@ Analytics payload
             il.Append(il.Create(OpCodes.Castclass, ModuleDefinition.ImportReference(realmObjectType)));
             il.Append(il.Create(OpCodes.Stloc_0));
 
-            // We'll process collections separately as those require variable acces
+            // We'll process collections separately as those require variable access
             foreach (var prop in properties.Where(p => !p.IsPrimaryKey && !p.Property.IsCollection(out _)))
             {
                 var property = prop.Property;
@@ -1253,7 +1253,7 @@ Analytics payload
                 else
                 {
                     var sequencePoint = property.GetMethod.DebugInformation.SequencePoints.FirstOrDefault();
-                    WriteError($"{realmObjectType.Name}.{property.Name} does not have a setter and is not an IList. This is an error in Realm, so please file a bug report.", sequencePoint);
+                    WriteError($"{realmObjectType.Name}.{property.Name} does not have a setter and is not an IList/ISet. This is an error in Realm, so please file a bug report.", sequencePoint);
                 }
             }
 

--- a/Realm/Realm.Fody/ModuleWeaver.cs
+++ b/Realm/Realm.Fody/ModuleWeaver.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
+using RealmWeaver;
 
 public partial class ModuleWeaver : Fody.BaseModuleWeaver
 {
@@ -335,7 +336,7 @@ Analytics payload
 
         var isRequired = prop.IsRequired(_references);
         if (isRequired &&
-            !prop.IsIList(typeof(string)) &&
+            !prop.IsCollection(typeof(string)) &&
             !prop.IsNullable() &&
             prop.PropertyType.FullName != StringTypeName &&
             prop.PropertyType.FullName != ByteArrayTypeName)
@@ -469,7 +470,7 @@ Analytics payload
             ReplaceRealmIntegerGetter(prop, columnName, accessors.Getter, isNullable, integerType);
             ReplaceRealmIntegerSetter(prop, backingField, columnName, accessors.Setter, isNullable, integerType);
         }
-        else if (prop.IsIList())
+        else if (prop.IsCollection(out var collectionType))
         {
             var elementType = ((GenericInstanceType)prop.PropertyType).GenericArguments.Single();
             if (!elementType.Resolve().IsValidRealmObjectBaseInheritor(_references) &&
@@ -477,25 +478,43 @@ Analytics payload
                 !_typeTable.ContainsKey(elementType.FullName) &&
                 !_primitiveValueTypes.ContainsKey(elementType.FullName))
             {
-                return WeaveResult.Error($"{type.Name}.{prop.Name} is an IList but its generic type is {elementType.Name} which is not supported by Realm.");
+                return WeaveResult.Error($"{type.Name}.{prop.Name} is an {collectionType} but its generic type is {elementType.Name} which is not supported by Realm.");
             }
 
             if (prop.SetMethod != null)
             {
-                return WeaveResult.Error($"{type.Name}.{prop.Name} has a setter but its type is a IList which only supports getters.");
+                return WeaveResult.Error($"{type.Name}.{prop.Name} has a setter but its type is a {collectionType} which only supports getters.");
             }
 
-            var concreteListConstructor = _references.System_Collections_Generic_ListOfT_Constructor.MakeHostInstanceGeneric(elementType);
-
-            // weaves list getter which also sets backing to List<T>, forcing it to accept us setting it post-init
-            if (backingField is FieldDefinition backingDef)
+            switch (collectionType)
             {
-                backingDef.Attributes &= ~FieldAttributes.InitOnly;  // without a set; auto property has this flag we must clear
-            }
+                case RealmCollectionType.IList:
+                    var concreteListConstructor = _references.System_Collections_Generic_ListOfT_Constructor.MakeHostInstanceGeneric(elementType);
 
-            ReplaceListGetter(prop, backingField, columnName,
-                              new GenericInstanceMethod(_references.RealmObject_GetListValue) { GenericArguments = { elementType } },
-                              concreteListConstructor);
+                    // weaves list getter which also sets backing to List<T>, forcing it to accept us setting it post-init
+                    if (backingField is FieldDefinition backingListField)
+                    {
+                        backingListField.Attributes &= ~FieldAttributes.InitOnly;  // without a set; auto property has this flag we must clear
+                    }
+
+                    ReplaceListGetter(prop, backingField, columnName,
+                                        new GenericInstanceMethod(_references.RealmObject_GetListValue) { GenericArguments = { elementType } },
+                                        concreteListConstructor);
+                    break;
+                case RealmCollectionType.ISet:
+                    var concreteSetConstructor = _references.System_Collections_Generic_HashSetOfT_Constructor.MakeHostInstanceGeneric(elementType);
+
+                    // weaves set getter which also sets backing to List<T>, forcing it to accept us setting it post-init
+                    if (backingField is FieldDefinition backingSetField)
+                    {
+                        backingSetField.Attributes &= ~FieldAttributes.InitOnly;  // without a set; auto property has this flag we must clear
+                    }
+
+                    ReplaceSetGetter(prop, backingField, columnName,
+                                        new GenericInstanceMethod(_references.RealmObject_GetSetValue) { GenericArguments = { elementType } },
+                                        concreteSetConstructor);
+                    break;
+            }
         }
         else if (prop.ContainsRealmObject(_references) || prop.ContainsEmbeddedObject(_references))
         {
@@ -521,7 +540,7 @@ Analytics payload
             var inversePropertyName = (string)backlinkAttribute.ConstructorArguments[0].Value;
             var inverseProperty = elementType.Resolve().Properties.SingleOrDefault(p => p.Name == inversePropertyName);
 
-            if (inverseProperty == null || (!inverseProperty.PropertyType.IsSameAs(type) && !inverseProperty.IsIList(type)))
+            if (inverseProperty == null || (!inverseProperty.PropertyType.IsSameAs(type) && !inverseProperty.IsCollection(type)))
             {
                 return WeaveResult.Error($"The property '{elementType.Name}.{inversePropertyName}' does not constitute a link to '{type.Name}' as described by '{type.Name}.{prop.Name}'.");
             }
@@ -708,10 +727,6 @@ Analytics payload
         Debug.Write("[get] ");
     }
 
-    // WARNING
-    // This code setting the backing field only works if the field is settable after init
-    // if you don't have an automatic set; on the property, it shows in the debugger with
-    //         Attributes    Private | InitOnly    Mono.Cecil.FieldAttributes
     private void ReplaceListGetter(PropertyDefinition prop, FieldReference backingField, string columnName, MethodReference getListValueReference, MethodReference listConstructor)
     {
         //// A synthesized property getter looks like this:
@@ -764,6 +779,60 @@ Analytics payload
         // Let Cecil optimize things for us.
         // TODO prop.SetMethod.Body.OptimizeMacros();
         Debug.Write("[get list] ");
+    }
+
+    private void ReplaceSetGetter(PropertyDefinition prop, FieldReference backingField, string columnName, MethodReference getSetValueReference, MethodReference setConstructor)
+    {
+        //// A synthesized property getter looks like this:
+        ////   0: ldarg.0  // load the this pointer
+        ////   1: ldfld <backingField>
+        ////   2: ret
+        //// We want to change it so it looks somewhat like this, in C#
+        ////
+        ////  if (<backingField> == null)
+        ////  {
+        ////     if (IsManaged)
+        ////           <backingField> = GetSetValue<T>(<columnName>);
+        ////     else
+        ////           <backingField> = new HashSet<T>();
+        ////  }
+        ////  // original auto-generated getter starts here
+        ////  return <backingField>; // supplied by the generated getter
+
+        var start = prop.GetMethod.Body.Instructions.First();  // this is a label for return <backingField>;
+        var il = prop.GetMethod.Body.GetILProcessor();
+
+        // if (<backingField>) goto start
+        il.InsertBefore(start, il.Create(OpCodes.Ldarg_0));
+        il.InsertBefore(start, il.Create(OpCodes.Ldfld, backingField));
+        il.InsertBefore(start, il.Create(OpCodes.Brtrue_S, start));
+
+        // if (IsManaged)
+        il.InsertBefore(start, il.Create(OpCodes.Ldarg_0));
+        il.InsertBefore(start, il.Create(OpCodes.Call, _references.RealmObject_get_IsManaged));
+
+        // push in the label then go relative to that - so we can forward-ref the label insert if/else blocks backwards
+        // <backingField> = new HashSet<T>()
+        var unmanagedStart = il.Create(OpCodes.Ldarg_0);
+        il.InsertBefore(start, unmanagedStart);
+        il.InsertBefore(start, il.Create(OpCodes.Newobj, setConstructor));
+        il.InsertBefore(start, il.Create(OpCodes.Stfld, backingField));
+
+        // if (!IsManaged) <backingField> = GetSetValue(<columnName>)
+        il.InsertBefore(unmanagedStart, il.Create(OpCodes.Brfalse_S, unmanagedStart));
+        il.InsertBefore(unmanagedStart, il.Create(OpCodes.Ldarg_0));
+        il.InsertBefore(unmanagedStart, il.Create(OpCodes.Ldarg_0));
+        il.InsertBefore(unmanagedStart, il.Create(OpCodes.Ldstr, columnName));
+        il.InsertBefore(unmanagedStart, il.Create(OpCodes.Call, getSetValueReference));
+        il.InsertBefore(unmanagedStart, il.Create(OpCodes.Stfld, backingField));
+        il.InsertBefore(unmanagedStart, il.Create(OpCodes.Br_S, start));
+
+        // note that we do NOT insert a ret, unlike other weavers, as usual path branches and
+        // FALL THROUGH to return the backing field.
+
+        // Let Cecil optimize things for us.
+        // TODO prop.SetMethod.Body.OptimizeMacros();
+        Debug.Write("[get set] ");
     }
 
     // WARNING
@@ -1031,6 +1100,19 @@ Analytics payload
                         castInstance.Property.Add(list[i]);
                     }
                 }
+
+                *foreach* set woven property in castInstance's schema
+                var set = castInstance.field;
+                castInstance.field = null;
+                if (!skipDefaults)
+                {
+                    castInstance.Property.Clear();
+                }
+                if (set != null)
+                {
+                    castInstance.Realm.Add(set);
+                    castInstance.Property.Union(set);
+                }
             */
 
             var instanceParameter = new ParameterDefinition("instance", ParameterAttributes.None, _references.RealmObjectBase);
@@ -1052,12 +1134,18 @@ Analytics payload
                 copyToRealm.Body.Variables.Add(new VariableDefinition(ModuleDefinition.TypeSystem.Int32));
             }
 
+            foreach (var prop in properties.Where(p => p.Property.IsISet()))
+            {
+                copyToRealm.Body.Variables.Add(new VariableDefinition(ModuleDefinition.ImportReference(prop.Field.FieldType)));
+            }
+
             var il = copyToRealm.Body.GetILProcessor();
             il.Append(il.Create(OpCodes.Ldarg_1));
             il.Append(il.Create(OpCodes.Castclass, ModuleDefinition.ImportReference(realmObjectType)));
             il.Append(il.Create(OpCodes.Stloc_0));
 
-            foreach (var prop in properties.Where(p => !p.Property.IsPrimaryKey(_references)))
+            // We'll process collections separately as those require variable acces
+            foreach (var prop in properties.Where(p => !p.IsPrimaryKey && !p.Property.IsCollection(out _)))
             {
                 var property = prop.Property;
                 var field = prop.Field;
@@ -1162,98 +1250,6 @@ Analytics payload
                         }
                     }
                 }
-                else if (property.IsIList())
-                {
-                    var elementType = ((GenericInstanceType)property.PropertyType).GenericArguments.Single();
-                    var propertyGetterMethodReference = ModuleDefinition.ImportReference(property.GetMethod);
-
-                    var iteratorStLoc = (byte)(currentStloc + 1);
-
-                    // if (!skipDefaults ||
-                    var skipDefaultsCheck = il.Create(OpCodes.Ldarg_3);
-                    il.Append(skipDefaultsCheck);
-
-                    // castInstance.field != null)
-                    il.Append(il.Create(OpCodes.Ldloc_0));
-                    var fieldNullCheck = il.Create(OpCodes.Ldfld, field);
-                    il.Append(fieldNullCheck);
-
-                    // var list = castInstance.field;
-                    // castInstance.field = null;
-                    var setterStart = il.Create(OpCodes.Ldloc_0);
-                    il.Append(setterStart);
-                    il.Append(il.Create(OpCodes.Ldfld, field));
-                    il.Append(il.Create(OpCodes.Stloc_S, currentStloc));
-                    il.Append(il.Create(OpCodes.Ldloc_0));
-                    il.Append(il.Create(OpCodes.Ldnull));
-                    il.Append(il.Create(OpCodes.Stfld, field));
-
-                    // if (!skipDefaults)
-                    var clearSkipPlaceholder = il.Create(OpCodes.Ldarg_3);
-                    il.Append(clearSkipPlaceholder);
-
-                    // castInstance.Property.Clear();
-                    il.Append(il.Create(OpCodes.Ldloc_0));
-                    il.Append(il.Create(OpCodes.Call, propertyGetterMethodReference));
-                    il.Append(il.Create(OpCodes.Callvirt, _references.ICollectionOfT_Clear.MakeHostInstanceGeneric(elementType)));
-
-                    // if (list == null)
-                    var localListVarNullCheck = il.Create(OpCodes.Ldloc_S, currentStloc);
-                    il.Append(localListVarNullCheck);
-
-                    // if (skipDefaults), skip List.Clear and jump to checking the list == null
-                    il.InsertAfter(clearSkipPlaceholder, il.Create(OpCodes.Brtrue_S, localListVarNullCheck));
-
-                    il.Append(il.Create(OpCodes.Ldc_I4_0));
-                    il.Append(il.Create(OpCodes.Stloc_S, iteratorStLoc));
-
-                    var cyclePlaceholder = il.Create(OpCodes.Nop);
-                    il.Append(cyclePlaceholder);
-
-                    var cycleStart = il.Create(OpCodes.Ldloc_0);
-                    il.Append(cycleStart);
-
-                    if (elementType.Resolve().IsRealmObjectInheritor(_references))
-                    {
-                        // castInstance.Realm.Add(list[i], update)
-                        il.Append(il.Create(OpCodes.Call, _references.RealmObject_get_Realm));
-                        il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
-                        il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
-                        il.Append(il.Create(OpCodes.Callvirt, _references.IListOfT_get_Item.MakeHostInstanceGeneric(elementType)));
-                        il.Append(il.Create(OpCodes.Ldarg_2));
-                        il.Append(il.Create(OpCodes.Call, new GenericInstanceMethod(_references.Realm_Add) { GenericArguments = { elementType } }));
-                        il.Append(il.Create(OpCodes.Pop));
-                        il.Append(il.Create(OpCodes.Ldloc_0));
-                    }
-
-                    // castInstance.Property.Add(list[i]);
-                    il.Append(il.Create(OpCodes.Call, propertyGetterMethodReference));
-                    il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
-                    il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
-                    il.Append(il.Create(OpCodes.Callvirt, _references.IListOfT_get_Item.MakeHostInstanceGeneric(elementType)));
-                    il.Append(il.Create(OpCodes.Callvirt, _references.ICollectionOfT_Add.MakeHostInstanceGeneric(elementType)));
-                    il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
-                    il.Append(il.Create(OpCodes.Ldc_I4_1));
-                    il.Append(il.Create(OpCodes.Add));
-                    il.Append(il.Create(OpCodes.Stloc_S, iteratorStLoc));
-
-                    var cycleLabel = il.Create(OpCodes.Nop);
-                    il.Append(cycleLabel);
-                    il.Replace(cyclePlaceholder, il.Create(OpCodes.Br_S, cycleLabel));
-
-                    il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
-                    il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
-                    il.Append(il.Create(OpCodes.Callvirt, _references.ICollectionOfT_get_Count.MakeHostInstanceGeneric(elementType)));
-                    il.Append(il.Create(OpCodes.Blt_S, cycleStart));
-
-                    var setterEnd = il.Create(OpCodes.Nop);
-                    il.Append(setterEnd);
-                    il.InsertAfter(fieldNullCheck, il.Create(OpCodes.Brfalse_S, setterEnd));
-                    il.InsertAfter(localListVarNullCheck, il.Create(OpCodes.Brfalse_S, setterEnd));
-                    il.InsertAfter(skipDefaultsCheck, il.Create(OpCodes.Brfalse_S, setterStart));
-
-                    currentStloc += 2;
-                }
                 else if (property.IsIQueryable())
                 {
                     il.Append(il.Create(OpCodes.Ldloc_0));
@@ -1265,6 +1261,170 @@ Analytics payload
                     var sequencePoint = property.GetMethod.DebugInformation.SequencePoints.FirstOrDefault();
                     WriteError($"{realmObjectType.Name}.{property.Name} does not have a setter and is not an IList. This is an error in Realm, so please file a bug report.", sequencePoint);
                 }
+            }
+
+            foreach (var prop in properties.Where(p => p.Property.IsIList()))
+            {
+                var property = prop.Property;
+                var field = prop.Field;
+
+                var elementType = ((GenericInstanceType)property.PropertyType).GenericArguments.Single();
+                var propertyGetterMethodReference = ModuleDefinition.ImportReference(property.GetMethod);
+
+                var iteratorStLoc = (byte)(currentStloc + 1);
+
+                // if (!skipDefaults ||
+                var skipDefaultsCheck = il.Create(OpCodes.Ldarg_3);
+                il.Append(skipDefaultsCheck);
+
+                // castInstance.field != null)
+                il.Append(il.Create(OpCodes.Ldloc_0));
+                var fieldNullCheck = il.Create(OpCodes.Ldfld, field);
+                il.Append(fieldNullCheck);
+
+                // var list = castInstance.field;
+                // castInstance.field = null;
+                var setterStart = il.Create(OpCodes.Ldloc_0);
+                il.Append(setterStart);
+                il.Append(il.Create(OpCodes.Ldfld, field));
+                il.Append(il.Create(OpCodes.Stloc_S, currentStloc));
+                il.Append(il.Create(OpCodes.Ldloc_0));
+                il.Append(il.Create(OpCodes.Ldnull));
+                il.Append(il.Create(OpCodes.Stfld, field));
+
+                // if (!skipDefaults)
+                var clearSkipPlaceholder = il.Create(OpCodes.Ldarg_3);
+                il.Append(clearSkipPlaceholder);
+
+                // castInstance.Property.Clear();
+                il.Append(il.Create(OpCodes.Ldloc_0));
+                il.Append(il.Create(OpCodes.Call, propertyGetterMethodReference));
+                il.Append(il.Create(OpCodes.Callvirt, _references.ICollectionOfT_Clear.MakeHostInstanceGeneric(elementType)));
+
+                // if (list == null)
+                var localListVarNullCheck = il.Create(OpCodes.Ldloc_S, currentStloc);
+                il.Append(localListVarNullCheck);
+
+                // if (skipDefaults), skip List.Clear and jump to checking the list == null
+                il.InsertAfter(clearSkipPlaceholder, il.Create(OpCodes.Brtrue_S, localListVarNullCheck));
+
+                il.Append(il.Create(OpCodes.Ldc_I4_0));
+                il.Append(il.Create(OpCodes.Stloc_S, iteratorStLoc));
+
+                var cyclePlaceholder = il.Create(OpCodes.Nop);
+                il.Append(cyclePlaceholder);
+
+                var cycleStart = il.Create(OpCodes.Ldloc_0);
+                il.Append(cycleStart);
+
+                if (elementType.Resolve().IsRealmObjectInheritor(_references))
+                {
+                    // castInstance.Realm.Add(list[i], update)
+                    il.Append(il.Create(OpCodes.Call, _references.RealmObject_get_Realm));
+                    il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
+                    il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
+                    il.Append(il.Create(OpCodes.Callvirt, _references.IListOfT_get_Item.MakeHostInstanceGeneric(elementType)));
+                    il.Append(il.Create(OpCodes.Ldarg_2));
+                    il.Append(il.Create(OpCodes.Call, new GenericInstanceMethod(_references.Realm_Add) { GenericArguments = { elementType } }));
+                    il.Append(il.Create(OpCodes.Pop));
+                    il.Append(il.Create(OpCodes.Ldloc_0));
+                }
+
+                // castInstance.Property.Add(list[i]);
+                il.Append(il.Create(OpCodes.Call, propertyGetterMethodReference));
+                il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
+                il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
+                il.Append(il.Create(OpCodes.Callvirt, _references.IListOfT_get_Item.MakeHostInstanceGeneric(elementType)));
+                il.Append(il.Create(OpCodes.Callvirt, _references.ICollectionOfT_Add.MakeHostInstanceGeneric(elementType)));
+                il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
+                il.Append(il.Create(OpCodes.Ldc_I4_1));
+                il.Append(il.Create(OpCodes.Add));
+                il.Append(il.Create(OpCodes.Stloc_S, iteratorStLoc));
+
+                var cycleLabel = il.Create(OpCodes.Nop);
+                il.Append(cycleLabel);
+                il.Replace(cyclePlaceholder, il.Create(OpCodes.Br_S, cycleLabel));
+
+                il.Append(il.Create(OpCodes.Ldloc_S, iteratorStLoc));
+                il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
+                il.Append(il.Create(OpCodes.Callvirt, _references.ICollectionOfT_get_Count.MakeHostInstanceGeneric(elementType)));
+                il.Append(il.Create(OpCodes.Blt_S, cycleStart));
+
+                var setterEnd = il.Create(OpCodes.Nop);
+                il.Append(setterEnd);
+                il.InsertAfter(fieldNullCheck, il.Create(OpCodes.Brfalse_S, setterEnd));
+                il.InsertAfter(localListVarNullCheck, il.Create(OpCodes.Brfalse_S, setterEnd));
+                il.InsertAfter(skipDefaultsCheck, il.Create(OpCodes.Brfalse_S, setterStart));
+
+                currentStloc += 2;
+            }
+
+            foreach (var prop in properties.Where(p => p.Property.IsISet()))
+            {
+                var property = prop.Property;
+                var field = prop.Field;
+
+                var elementType = ((GenericInstanceType)property.PropertyType).GenericArguments.Single();
+                var propertyGetterMethodReference = ModuleDefinition.ImportReference(property.GetMethod);
+
+                // if (!skipDefaults ||
+                var skipDefaultsCheck = il.Create(OpCodes.Ldarg_3);
+                il.Append(skipDefaultsCheck);
+
+                // castInstance.field != null)
+                il.Append(il.Create(OpCodes.Ldloc_0));
+                var fieldNullCheck = il.Create(OpCodes.Ldfld, field);
+                il.Append(fieldNullCheck);
+
+                // var set = castInstance.field;
+                // castInstance.field = null;
+                var setterStart = il.Create(OpCodes.Ldloc_0);
+                il.Append(setterStart);
+                il.Append(il.Create(OpCodes.Ldfld, field));
+                il.Append(il.Create(OpCodes.Stloc_S, currentStloc));
+                il.Append(il.Create(OpCodes.Ldloc_0));
+                il.Append(il.Create(OpCodes.Ldnull));
+                il.Append(il.Create(OpCodes.Stfld, field));
+
+                // if (!skipDefaults)
+                var clearSkipPlaceholder = il.Create(OpCodes.Ldarg_3);
+                il.Append(clearSkipPlaceholder);
+
+                // castInstance.Property.Clear();
+                il.Append(il.Create(OpCodes.Ldloc_0));
+                il.Append(il.Create(OpCodes.Call, propertyGetterMethodReference));
+                il.Append(il.Create(OpCodes.Callvirt, _references.ICollectionOfT_Clear.MakeHostInstanceGeneric(elementType)));
+
+                // if (set == null)
+                var localSetVarNullCheck = il.Create(OpCodes.Ldloc_S, currentStloc);
+                il.Append(localSetVarNullCheck);
+
+                // if (skipDefaults), skip Set.Clear and jump to checking the set == null
+                il.InsertAfter(clearSkipPlaceholder, il.Create(OpCodes.Brtrue_S, localSetVarNullCheck));
+
+                if (elementType.Resolve().IsRealmObjectInheritor(_references))
+                {
+                    // castInstance.Realm.Add(set, update)
+                    il.Append(il.Create(OpCodes.Ldloc_0));
+                    il.Append(il.Create(OpCodes.Call, _references.RealmObject_get_Realm));
+                    il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
+                    il.Append(il.Create(OpCodes.Ldarg_2));
+                    il.Append(il.Create(OpCodes.Call, new GenericInstanceMethod(_references.Realm_AddCollection) { GenericArguments = { elementType } }));
+                }
+
+                // castInstance.Property.UnionWith(set)
+                il.Append(il.Create(OpCodes.Ldloc_0));
+                il.Append(il.Create(OpCodes.Call, propertyGetterMethodReference));
+                il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
+                il.Append(il.Create(OpCodes.Callvirt, _references.ISetOfT_UnionWith));
+
+                var setterEnd = il.Create(OpCodes.Nop);
+                il.Append(setterEnd);
+                il.InsertAfter(fieldNullCheck, il.Create(OpCodes.Brfalse_S, setterEnd));
+                il.InsertAfter(localSetVarNullCheck, il.Create(OpCodes.Brfalse_S, setterEnd));
+                il.InsertAfter(skipDefaultsCheck, il.Create(OpCodes.Brfalse_S, setterStart));
+
+                currentStloc++;
             }
 
             il.Emit(OpCodes.Ret);

--- a/Realm/Realm.Fody/ModuleWeaver.cs
+++ b/Realm/Realm.Fody/ModuleWeaver.cs
@@ -648,7 +648,7 @@ Analytics payload
         il.InsertBefore(start, il.Create(OpCodes.Ldstr, columnName)); // [stack = this | name ]
         if (propertyTypeRef != null)
         {
-            il.InsertBefore(start, il.Create(OpCodes.Ldc_I4, (int)(byte)propertyTypeRef.Resolve().Constant));
+            il.InsertBefore(start, il.Create(OpCodes.Ldc_I4, (ushort)propertyTypeRef.Resolve().Constant));
         }
 
         il.InsertBefore(start, il.Create(OpCodes.Call, getValueReference));
@@ -956,7 +956,7 @@ Analytics payload
         il.Append(il.Create(OpCodes.Ldarg_1));
         if (propertyTypeRef != null)
         {
-            il.Append(il.Create(OpCodes.Ldc_I4, (int)(byte)propertyTypeRef.Resolve().Constant));
+            il.Append(il.Create(OpCodes.Ldc_I4, (ushort)propertyTypeRef.Resolve().Constant));
         }
 
         il.Append(il.Create(OpCodes.Call, setValueReference));

--- a/Realm/Realm.Fody/RealmCollectionType.cs
+++ b/Realm/Realm.Fody/RealmCollectionType.cs
@@ -1,6 +1,6 @@
 ﻿////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2020 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,25 +16,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-using System.Collections.Generic;
-
-namespace Realms
+namespace RealmWeaver
 {
-    public class Realm
+    internal enum RealmCollectionType
     {
-        public T Add<T>(T obj, bool update) where T : RealmObject
-        {
-            return default(T);
-        }
-
-        public RealmObject Add(RealmObject obj, bool update)
-        {
-            return null;
-        }
-
-        public void Add<T>(IEnumerable<T> objs, bool update = false)
-            where T : RealmObject
-        {
-        }
+        None,
+        IList,
+        ISet,
     }
 }

--- a/Realm/Realm/Dynamic/MetaRealmObject.cs
+++ b/Realm/Realm/Dynamic/MetaRealmObject.cs
@@ -142,6 +142,79 @@ namespace Realms.Dynamic
                         break;
                 }
             }
+            else if (property.Type.IsSet())
+            {
+                arguments.Add(Expression.Field(GetLimitedSelf(), RealmObjectRealmField));
+                arguments.Add(Expression.Constant(_metadata.PropertyIndices[property.Name]));
+                arguments.Add(Expression.Constant(property.ObjectType, typeof(string)));
+                switch (property.Type.UnderlyingType())
+                {
+                    case PropertyType.Int:
+                        if (property.Type.IsNullable())
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<long?>);
+                        }
+                        else
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<long>);
+                        }
+
+                        break;
+                    case PropertyType.Bool:
+                        if (property.Type.IsNullable())
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<bool?>);
+                        }
+                        else
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<bool>);
+                        }
+
+                        break;
+                    case PropertyType.Float:
+                        if (property.Type.IsNullable())
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<float?>);
+                        }
+                        else
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<float>);
+                        }
+
+                        break;
+                    case PropertyType.Double:
+                        if (property.Type.IsNullable())
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<double?>);
+                        }
+                        else
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<double>);
+                        }
+
+                        break;
+                    case PropertyType.String:
+                        getter = GetGetMethod(DummyHandle.GetSet<string>);
+                        break;
+                    case PropertyType.Data:
+                        getter = GetGetMethod(DummyHandle.GetSet<byte[]>);
+                        break;
+                    case PropertyType.Date:
+                        if (property.Type.IsNullable())
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<DateTimeOffset?>);
+                        }
+                        else
+                        {
+                            getter = GetGetMethod(DummyHandle.GetSet<DateTimeOffset>);
+                        }
+
+                        break;
+                    case PropertyType.Object:
+                        getter = IsTargetEmbedded(property) ? GetGetMethod(DummyHandle.GetSet<DynamicEmbeddedObject>) : GetGetMethod(DummyHandle.GetSet<DynamicRealmObject>);
+                        break;
+                }
+            }
             else
             {
                 arguments.Add(Expression.Constant(_metadata.PropertyIndices[property.Name]));
@@ -206,7 +279,7 @@ namespace Realms.Dynamic
 
         public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
         {
-            if (!_metadata.Schema.TryFindProperty(binder.Name, out var property) || property.Type.IsArray())
+            if (!_metadata.Schema.TryFindProperty(binder.Name, out var property) || property.Type.IsArray() || property.Type.IsSet())
             {
                 return base.BindSetMember(binder, value);
             }
@@ -314,6 +387,7 @@ namespace Realms.Dynamic
         private static MethodInfo GetGetMethod<TResult>(Func<IntPtr, PropertyType, TResult> @delegate) => @delegate.GetMethodInfo();
 
         // GetList(realm, propertyIndex, objectType)
+        // GetSet(realm, propertyIndex, objectType)
         // GetObject(realm, propertyIndex, objectType)
         private static MethodInfo GetGetMethod<TResult>(Func<Realm, IntPtr, string, TResult> @delegate) => @delegate.GetMethodInfo();
 

--- a/Realm/Realm/Dynamic/MetaRealmSet.cs
+++ b/Realm/Realm/Dynamic/MetaRealmSet.cs
@@ -1,0 +1,50 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq.Expressions;
+
+namespace Realms.Dynamic
+{
+    internal class MetaRealmSet : DynamicMetaObject
+    {
+        internal MetaRealmSet(Expression expression, object value) : base(expression, BindingRestrictions.Empty, value)
+        {
+        }
+
+        public override DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)
+        {
+            if (Value is IRealmCollection<EmbeddedObject>)
+            {
+                switch (binder.Name)
+                {
+                    case nameof(ISet<EmbeddedObject>.Add):
+                        throw new NotSupportedException("Can't add embedded objects directly. Instead use Realm.DynamicApi.AddEmbeddedObjectToSet.");
+
+                    case nameof(ISet<EmbeddedObject>.UnionWith):
+                    case nameof(ISet<EmbeddedObject>.SymmetricExceptWith):
+                        throw new NotSupportedException("Set methods that may result in adding embedded objects to a managed collection are not supported.");
+                }
+            }
+
+            return base.BindInvokeMember(binder, args);
+        }
+    }
+}

--- a/Realm/Realm/Dynamic/MetaRealmSet.cs
+++ b/Realm/Realm/Dynamic/MetaRealmSet.cs
@@ -1,6 +1,6 @@
 ﻿////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2020 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Realm/Realm/Extensions/CollectionExtensions.cs
+++ b/Realm/Realm/Extensions/CollectionExtensions.cs
@@ -29,7 +29,7 @@ namespace Realms
     /// A set of extensions methods exposing notification-related functionality over collections.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class CollectionNotificationsExtensions
+    public static class CollectionExtensions
     {
         /// <summary>
         /// A convenience method that casts <see cref="IQueryable{T}"/> to <see cref="IRealmCollection{T}"/> which

--- a/Realm/Realm/Extensions/FrozenObjectsExtensions.cs
+++ b/Realm/Realm/Extensions/FrozenObjectsExtensions.cs
@@ -37,8 +37,8 @@ namespace Realms
         /// original object is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
         /// object will be closed as well.
         /// <para/>
-        /// Frozen objects can be queried as normal, but trying to mutate it in any way or attempting to register a listener will
-        /// throw a <see cref="Exceptions.RealmFrozenException"/>.
+        /// Frozen objects can be queried as normal, but trying to mutate it in any way or attempting to subscribe for notifications will
+        /// throw a <see cref="RealmFrozenException"/>.
         /// <para/>
         /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
         /// of the Realm. In order to avoid such a situation it is possible to set <see cref="RealmConfigurationBase.MaxNumberOfActiveVersions"/>.
@@ -69,7 +69,7 @@ namespace Realms
         /// original list is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
         /// list will be closed as well.
         /// <para/>
-        /// Frozen lists can be read and iterated as normal, but trying to mutate it in any way or attempting to register a listener will
+        /// Frozen lists can be read and iterated as normal, but trying to mutate it in any way or attempting to subscribe for notifications will
         /// throw a <see cref="RealmFrozenException"/>.
         /// <para/>
         /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
@@ -98,7 +98,7 @@ namespace Realms
         /// original query is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
         /// query will be closed as well.
         /// <para/>
-        /// Frozen queries can be read and iterated as normal, but trying to mutate it in any way or attempting to register a listener will
+        /// Frozen queries can be read and iterated as normal, but trying to mutate it in any way or attempting to subscribe for notifications will
         /// throw a <see cref="RealmFrozenException"/>.
         /// <para/>
         /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
@@ -118,6 +118,35 @@ namespace Realms
             }
 
             throw new RealmException("Unmanaged queries cannot be frozen.");
+        }
+
+        /// <summary>
+        /// Creates a frozen snapshot of this set. The frozen copy can be read from any thread. If the set is
+        /// not managed, a <see cref="RealmException"/> will be thrown.
+        /// <para/>
+        /// Freezing a set also creates a frozen Realm which has its own lifecycle, but if the live Realm that spawned the
+        /// original set is fully closed (i.e. all instances across all threads are closed), the frozen Realm and
+        /// set will be closed as well.
+        /// <para/>
+        /// Frozen sets can be read and iterated as normal, but trying to mutate it in any way or attempting to subscribe for notifications will
+        /// throw a <see cref="RealmFrozenException"/>.
+        /// <para/>
+        /// Note: Keeping a large number of frozen objects with different versions alive can have a negative impact on the filesize
+        /// of the Realm. In order to avoid such a situation it is possible to set <see cref="RealmConfigurationBase.MaxNumberOfActiveVersions"/>.
+        /// </summary>
+        /// <param name="set">The set you want to create a frozen copy of.</param>
+        /// <typeparam name="T">The type of the <see cref="RealmObject"/>/<see cref="EmbeddedObject"/> in the set.</typeparam>
+        /// <returns>A frozen copy of this set.</returns>
+        public static ISet<T> Freeze<T>(this ISet<T> set)
+        {
+            Argument.NotNull(set, nameof(set));
+
+            if (set is RealmSet<T> realmSet)
+            {
+                return (RealmSet<T>)realmSet.Freeze();
+            }
+
+            throw new RealmException("Unmanaged sets cannot be frozen.");
         }
     }
 }

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -72,5 +72,7 @@ namespace Realms
         public abstract ResultsHandle GetFilteredResults(string query);
 
         public abstract CollectionHandleBase Freeze(SharedRealmHandle frozenRealmHandle);
+
+        public abstract void Clear();
     }
 }

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -70,5 +70,7 @@ namespace Realms
         public abstract ResultsHandle Snapshot();
 
         public abstract ResultsHandle GetFilteredResults(string query);
+
+        public abstract CollectionHandleBase Freeze(SharedRealmHandle frozenRealmHandle);
     }
 }

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -363,7 +363,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public void Clear()
+        public override void Clear()
         {
             NativeMethods.clear(this, out var nativeException);
             nativeException.ThrowIfNecessary();

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -39,8 +39,7 @@ namespace Realms
             public static extern void add_primitive(ListHandle listHandle, IntPtr value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLength,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
+            public static extern void add_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLength, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_binary", CallingConvention = CallingConvention.Cdecl)]
             public static extern void add_binary(ListHandle listHandle, IntPtr buffer, IntPtr bufferLength,
@@ -63,7 +62,7 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_string(ListHandle listHandle, IntPtr targetIndex, [MarshalAs(UnmanagedType.LPWStr)] string value,
-                IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
+                IntPtr valueLen, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_binary", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_binary(ListHandle listHandle, IntPtr targetIndex, IntPtr buffer, IntPtr bufferLength,
@@ -86,7 +85,7 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern void insert_string(ListHandle listHandle, IntPtr targetIndex, [MarshalAs(UnmanagedType.LPWStr)] string value,
-                IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
+                IntPtr valueLen, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_binary", CallingConvention = CallingConvention.Cdecl)]
             public static extern void insert_binary(ListHandle listHandle, IntPtr targetIndex, IntPtr buffer, IntPtr bufferLength,
@@ -126,8 +125,7 @@ namespace Realms
             public static extern IntPtr find_primitive(ListHandle listHandle, IntPtr value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr find_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
+            public static extern IntPtr find_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_binary", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr find_binary(ListHandle listHandle, IntPtr buffer, IntPtr bufsize,
@@ -231,7 +229,7 @@ namespace Realms
 
         public void Add(string value)
         {
-            NativeMethods.add_string(this, value, (IntPtr)(value?.Length ?? 0), value != null, out var nativeException);
+            NativeMethods.add_string(this, value, value.IntPtrLength(), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
@@ -267,9 +265,7 @@ namespace Realms
 
         public void Set(int targetIndex, string value)
         {
-            var hasValue = value != null;
-            value = value ?? string.Empty;
-            NativeMethods.set_string(this, (IntPtr)targetIndex, value, (IntPtr)value.Length, hasValue, out var nativeException);
+            NativeMethods.set_string(this, (IntPtr)targetIndex, value, value.IntPtrLength(), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
@@ -305,9 +301,7 @@ namespace Realms
 
         public void Insert(int targetIndex, string value)
         {
-            var hasValue = value != null;
-            value = value ?? string.Empty;
-            NativeMethods.insert_string(this, (IntPtr)targetIndex, value, (IntPtr)value.Length, hasValue, out var nativeException);
+            NativeMethods.insert_string(this, (IntPtr)targetIndex, value, value.IntPtrLength(), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
@@ -345,9 +339,7 @@ namespace Realms
 
         public int Find(string value)
         {
-            var hasValue = value != null;
-            value = value ?? string.Empty;
-            var result = NativeMethods.find_string(this, value, (IntPtr)value.Length, hasValue, out var nativeException);
+            var result = NativeMethods.find_string(this, value, value.IntPtrLength(), out var nativeException);
             nativeException.ThrowIfNecessary();
             return (int)result;
         }
@@ -428,7 +420,7 @@ namespace Realms
             }
         }
 
-        public ListHandle Freeze(SharedRealmHandle frozenRealmHandle)
+        public override CollectionHandleBase Freeze(SharedRealmHandle frozenRealmHandle)
         {
             var result = NativeMethods.freeze(this, frozenRealmHandle, out var nativeException);
             nativeException.ThrowIfNecessary();

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -73,6 +73,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_list", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_list(ObjectHandle handle, IntPtr propertyIndex, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_set", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr get_set(ObjectHandle handle, IntPtr propertyIndex, out NativeException ex);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_set_null", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_null(ObjectHandle handle, IntPtr propertyIndex, out NativeException ex);
 
@@ -247,9 +250,16 @@ namespace Realms
             return true;
         }
 
-        public IntPtr GetLinklist(IntPtr propertyIndex)
+        public IntPtr GetLinkList(IntPtr propertyIndex)
         {
             var result = NativeMethods.get_list(this, propertyIndex, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public IntPtr GetLinkSet(IntPtr propertyIndex)
+        {
+            var result = NativeMethods.get_set(this, propertyIndex, out var nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }
@@ -297,9 +307,16 @@ namespace Realms
 
         public RealmList<T> GetList<T>(Realm realm, IntPtr propertyIndex, string objectType)
         {
-            var listHandle = new ListHandle(Root, GetLinklist(propertyIndex));
+            var listHandle = new ListHandle(Root, GetLinkList(propertyIndex));
             var metadata = objectType == null ? null : realm.Metadata[objectType];
             return new RealmList<T>(realm, listHandle, metadata);
+        }
+
+        public RealmSet<T> GetSet<T>(Realm realm, IntPtr propertyIndex, string objectType)
+        {
+            var setHandle = new SetHandle(Root, GetLinkSet(propertyIndex));
+            var metadata = objectType == null ? null : realm.Metadata[objectType];
+            return new RealmSet<T>(realm, setHandle, metadata);
         }
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -245,7 +245,7 @@ namespace Realms
             }
         }
 
-        public ResultsHandle Freeze(SharedRealmHandle frozenRealmHandle)
+        public override CollectionHandleBase Freeze(SharedRealmHandle frozenRealmHandle)
         {
             var result = NativeMethods.freeze(this, frozenRealmHandle, out var nativeException);
             nativeException.ThrowIfNecessary();

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -251,5 +251,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
             return new ResultsHandle(frozenRealmHandle, result);
         }
+
+        public override void Clear() => throw new NotSupportedException();
     }
 }

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2020 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -28,9 +28,6 @@ namespace Realms
         {
 #pragma warning disable IDE1006 // Naming Styles
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_erase", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void erase(SetHandle handle, IntPtr rowIndex, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_clear", CallingConvention = CallingConvention.Cdecl)]
             public static extern void clear(SetHandle handle, out NativeException ex);
 
@@ -78,6 +75,78 @@ namespace Realms
 
             #endregion
 
+            #region add
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_object", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool add_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
+
+            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
+            // that causes incorrect marshalling of the struct.
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_primitive", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool add_primitive(SetHandle handle, IntPtr value, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_string", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool add_string(SetHandle handle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLength, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_binary", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool add_binary(SetHandle handle, IntPtr buffer, IntPtr bufferLength,
+                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_embedded", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern IntPtr add_embedded(SetHandle handle, out NativeException ex);
+
+            #endregion
+
+            #region find
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_object", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool contains_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
+
+            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
+            // that causes incorrect marshalling of the struct.
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_primitive", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool contains_primitive(SetHandle handle, IntPtr value, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_string", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool contains_string(SetHandle handle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_binary", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool contains_binary(SetHandle handle, IntPtr buffer, IntPtr bufsize,
+                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
+
+            #endregion
+
+            #region find
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_object", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool remove_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
+
+            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
+            // that causes incorrect marshalling of the struct.
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_primitive", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool remove_primitive(SetHandle handle, IntPtr value, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_string", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool remove_string(SetHandle handle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_binary", CallingConvention = CallingConvention.Cdecl)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool remove_binary(SetHandle handle, IntPtr buffer, IntPtr bufsize,
+                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
+
+            #endregion
 #pragma warning restore IDE1006 // Naming Styles
         }
 
@@ -100,13 +169,7 @@ namespace Realms
             NativeMethods.destroy(handle);
         }
 
-        public void Erase(IntPtr rowIndex)
-        {
-            NativeMethods.erase(this, rowIndex, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void Clear()
+        public override void Clear()
         {
             NativeMethods.clear(this, out var nativeException);
             nativeException.ThrowIfNecessary();
@@ -185,5 +248,120 @@ namespace Realms
         }
 
         #endregion
+
+        #region Add
+
+        public bool Add(ObjectHandle objectHandle)
+        {
+            var result = NativeMethods.add_object(this, objectHandle, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public unsafe bool Add(PrimitiveValue value)
+        {
+            PrimitiveValue* valuePtr = &value;
+            var result = NativeMethods.add_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public bool Add(string value)
+        {
+            var result = NativeMethods.add_string(this, value, value.IntPtrLength(), out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public unsafe bool Add(byte[] value)
+        {
+            var result = false;
+            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
+                result = NativeMethods.add_binary(this, buffer, bufferSize, hasValue, out ex));
+
+            return result;
+        }
+
+        public ObjectHandle AddEmbedded()
+        {
+            var result = NativeMethods.add_embedded(this, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return new ObjectHandle(Root, result);
+        }
+
+        #endregion
+
+        #region Find
+
+        public bool Contains(ObjectHandle objectHandle)
+        {
+            var result = NativeMethods.contains_object(this, objectHandle, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public unsafe bool Contains(PrimitiveValue value)
+        {
+            PrimitiveValue* valuePtr = &value;
+            var result = NativeMethods.contains_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public bool Contains(string value)
+        {
+            var result = NativeMethods.contains_string(this, value, value.IntPtrLength(), out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public unsafe bool Contains(byte[] value)
+        {
+            var result = false;
+            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
+            {
+                result = NativeMethods.contains_binary(this, buffer, bufferSize, hasValue, out ex);
+            });
+
+            return result;
+        }
+
+        #endregion
+
+        #region Remove
+
+        public bool Remove(ObjectHandle objectHandle)
+        {
+            var result = NativeMethods.remove_object(this, objectHandle, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public unsafe bool Remove(PrimitiveValue value)
+        {
+            PrimitiveValue* valuePtr = &value;
+            var result = NativeMethods.remove_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public bool Remove(string value)
+        {
+            var result = NativeMethods.remove_string(this, value, value.IntPtrLength(), out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public unsafe bool Remove(byte[] value)
+        {
+            var result = false;
+            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
+                result = NativeMethods.remove_binary(this, buffer, bufferSize, hasValue, out ex));
+
+            return result;
+        }
+
+        #endregion
+
     }
 }

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -125,7 +125,7 @@ namespace Realms
 
             #endregion
 
-            #region find
+            #region remove
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_object", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -147,6 +147,7 @@ namespace Realms
                 [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
 
             #endregion
+
 #pragma warning restore IDE1006 // Naming Styles
         }
 
@@ -362,6 +363,5 @@ namespace Realms
         }
 
         #endregion
-
     }
 }

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -121,6 +121,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_resolve_query_reference", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr resolve_query_reference(SharedRealmHandle sharedRealm, ThreadSafeReferenceHandle referenceHandle, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_resolve_set_reference", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr resolve_set_reference(SharedRealmHandle sharedRealm, ThreadSafeReferenceHandle referenceHandle, out NativeException ex);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_resolve_realm_reference", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr resolve_realm_reference(ThreadSafeReferenceHandle referenceHandle, out NativeException ex);
 
@@ -335,6 +338,10 @@ namespace Realms
 
                 case ThreadSafeReference.Type.Query:
                     result = NativeMethods.resolve_query_reference(this, reference.Handle, out nativeException);
+                    break;
+
+                case ThreadSafeReference.Type.Set:
+                    result = NativeMethods.resolve_set_reference(this, reference.Handle, out nativeException);
                     break;
 
                 default:

--- a/Realm/Realm/Linq/IRealmCollection.cs
+++ b/Realm/Realm/Linq/IRealmCollection.cs
@@ -140,8 +140,8 @@ namespace Realms
         /// A subscription token. It must be kept alive for as long as you want to receive change notifications.
         /// To stop receiving notifications, call <see cref="IDisposable.Dispose" />.
         /// </returns>
-        /// <seealso cref="CollectionNotificationsExtensions.SubscribeForNotifications{T}(IList{T}, NotificationCallbackDelegate{T})"/>
-        /// <seealso cref="CollectionNotificationsExtensions.SubscribeForNotifications{T}(System.Linq.IQueryable{T}, NotificationCallbackDelegate{T})"/>
+        /// <seealso cref="CollectionExtensions.SubscribeForNotifications{T}(IList{T}, NotificationCallbackDelegate{T})"/>
+        /// <seealso cref="CollectionExtensions.SubscribeForNotifications{T}(System.Linq.IQueryable{T}, NotificationCallbackDelegate{T})"/>
         IDisposable SubscribeForNotifications(NotificationCallbackDelegate<T> callback);
     }
 }

--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -72,8 +72,6 @@ namespace Realms
             return qv.MakeResultsForQuery();
         }
 
-        #region IList members
-
         public override int IndexOf(T value)
         {
             Argument.NotNull(value, nameof(value));
@@ -91,8 +89,6 @@ namespace Realms
 
             return ResultsHandle.Find(obj.ObjectHandle);
         }
-
-        #endregion IList members
     }
 
     /// <summary>

--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -42,20 +42,22 @@ namespace Realms
             Expression = expression ?? Expression.Constant(this);
         }
 
-        internal RealmResults(Realm realm, RealmObjectBase.Metadata metadata, ResultsHandle handle = null)
+        internal RealmResults(Realm realm, ResultsHandle handle, RealmObjectBase.Metadata metadata)
             : this(realm, metadata, new RealmResultsProvider(realm, metadata), null)
         {
-            _handle = handle ?? metadata.Table.CreateResults(realm.SharedRealmHandle);
+            _handle = handle;
+        }
+
+        internal RealmResults(Realm realm, RealmObjectBase.Metadata metadata)
+            : this(realm, metadata.Table.CreateResults(realm.SharedRealmHandle), metadata)
+        {
         }
 
         public QueryHandle GetQuery() => ResultsHandle.GetQuery();
 
         public SortDescriptorHandle GetSortDescriptor() => ResultsHandle.GetSortDescriptor();
 
-        internal override RealmCollectionBase<T> CreateCollection(Realm realm, CollectionHandleBase handle)
-        {
-            return new RealmResults<T>(realm, Metadata, (ResultsHandle)handle);
-        }
+        internal override RealmCollectionBase<T> CreateCollection(Realm realm, CollectionHandleBase handle) => new RealmResults<T>(realm, (ResultsHandle)handle, Metadata);
 
         internal override CollectionHandleBase CreateHandle()
         {

--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -52,16 +52,9 @@ namespace Realms
 
         public SortDescriptorHandle GetSortDescriptor() => ResultsHandle.GetSortDescriptor();
 
-        public override IRealmCollection<T> Freeze()
+        internal override RealmCollectionBase<T> CreateCollection(Realm realm, CollectionHandleBase handle)
         {
-            if (IsFrozen)
-            {
-                return this;
-            }
-
-            var frozenRealm = Realm.Freeze();
-            var frozenHandle = ResultsHandle.Freeze(frozenRealm.SharedRealmHandle);
-            return new RealmResults<T>(frozenRealm, Metadata, frozenHandle);
+            return new RealmResults<T>(realm, Metadata, (ResultsHandle)handle);
         }
 
         internal override CollectionHandleBase CreateHandle()

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -859,7 +859,8 @@ namespace Realms
                     memberExpression.Expression.NodeType != ExpressionType.Parameter ||
                     !(memberExpression.Member is PropertyInfo) ||
                     !_metadata.Schema.TryFindProperty(name, out var property) ||
-                    property.Type.HasFlag(PropertyType.Array))
+                    property.Type.HasFlag(PropertyType.Array) ||
+                    property.Type.HasFlag(PropertyType.Set))
                 {
                     throw new NotSupportedException($"The left-hand side of the {parentType} operator must be a direct access to a persisted property in Realm.\nUnable to process '{memberExpression}'.");
                 }

--- a/Realm/Realm/MarshalHelpers.cs
+++ b/Realm/Realm/MarshalHelpers.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Realms.Exceptions;
 

--- a/Realm/Realm/Native/PrimitiveValue.cs
+++ b/Realm/Realm/Native/PrimitiveValue.cs
@@ -52,10 +52,10 @@ namespace Realms.Native
         private long dontuse;
 
         [FieldOffset(16)]
-        [MarshalAs(UnmanagedType.U1)]
+        [MarshalAs(UnmanagedType.U2)]
         public PropertyType Type;
 
-        [FieldOffset(17)]
+        [FieldOffset(18)]
         [MarshalAs(UnmanagedType.U1)]
         private bool has_value;
 

--- a/Realm/Realm/Native/SchemaProperty.cs
+++ b/Realm/Realm/Native/SchemaProperty.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System.Runtime.InteropServices;
+using Realms.Schema;
 
 namespace Realms.Native
 {
@@ -28,8 +29,8 @@ namespace Realms.Native
         [MarshalAs(UnmanagedType.LPStr)]
         internal string name;
 
-        [MarshalAs(UnmanagedType.U1)]
-        internal Realms.Schema.PropertyType type;
+        [MarshalAs(UnmanagedType.U2)]
+        internal PropertyType type;
 
         [MarshalAs(UnmanagedType.LPStr)]
         internal string object_type;

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -988,6 +988,31 @@ namespace Realms
         }
 
         /// <summary>
+        /// Returns the same collection as the one referenced when the <see cref="ThreadSafeReference.Set{T}"/> was first created,
+        /// but resolved for the current Realm for this thread.
+        /// </summary>
+        /// <param name="reference">The thread-safe reference to the thread-confined <see cref="ISet{T}"/> to resolve in this <see cref="Realm"/>.</param>
+        /// <typeparam name="T">The type of the objects, contained in the collection.</typeparam>
+        /// <returns>
+        /// A thread-confined instance of the original <see cref="ISet{T}"/> resolved for the current thread or <c>null</c>
+        /// if the set's parent object has been deleted after the reference was created.
+        /// </returns>
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The Set instance will own its handle.")]
+        public ISet<T> ResolveReference<T>(ThreadSafeReference.Set<T> reference)
+        {
+            Argument.NotNull(reference, nameof(reference));
+
+            var setPtr = SharedRealmHandle.ResolveReference(reference);
+            var setHandle = new SetHandle(SharedRealmHandle, setPtr);
+            if (!setHandle.IsValid)
+            {
+                return null;
+            }
+
+            return new RealmSet<T>(this, setHandle, reference.Metadata);
+        }
+
+        /// <summary>
         /// Returns the same query as the one referenced when the <see cref="ThreadSafeReference.Query{T}"/> was first created,
         /// but resolved for the current Realm for this thread.
         /// </summary>

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -25,7 +25,9 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Realms.Exceptions;
 using Realms.Helpers;
+using Realms.Native;
 using Realms.Schema;
 
 namespace Realms
@@ -404,6 +406,34 @@ namespace Realms
 
         #region IList
 
+        public bool IsReadOnly => (Realm?.Config as RealmConfiguration)?.IsReadOnly == true;
+
+        public void Clear() => Handle.Value.Clear();
+
+        public int IndexOf(object value)
+        {
+            if (value != null && !(value is T))
+            {
+                throw new ArgumentException($"value must be of type {typeof(T).FullName}, but got {value?.GetType().FullName}", nameof(value));
+            }
+
+            return IndexOf((T)value);
+        }
+
+        public bool Contains(object value)
+        {
+            if (value != null && !(value is T))
+            {
+                throw new ArgumentException($"value must be of type {typeof(T).FullName}, but got {value?.GetType().FullName}", nameof(value));
+            }
+
+            return Contains((T)value);
+        }
+
+        public virtual bool Contains(T value) => IndexOf(value) > -1;
+
+        public abstract int IndexOf(T value);
+
         public void CopyTo(T[] array, int arrayIndex)
         {
             Argument.NotNull(array, nameof(array));
@@ -421,59 +451,6 @@ namespace Realms
             foreach (var obj in this)
             {
                 array[arrayIndex++] = obj;
-            }
-        }
-
-        public bool IsFixedSize => false;
-
-        public bool IsReadOnly => (Realm?.Config as RealmConfiguration)?.IsReadOnly == true;
-
-        public bool IsSynchronized => false;
-
-        public object SyncRoot => null;
-
-        public virtual int Add(object value) => throw new NotSupportedException();
-
-        public virtual void Clear() => throw new NotSupportedException();
-
-        public bool Contains(object value) => IndexOf(value) > -1;
-
-        public int IndexOf(object value)
-        {
-            if (value != null && !(value is T))
-            {
-                throw new ArgumentException($"value must be of type {typeof(T).FullName}, but got {value?.GetType().FullName}", nameof(value));
-            }
-
-            return IndexOf((T)value);
-        }
-
-        public abstract int IndexOf(T value);
-
-        public virtual void Insert(int index, object value) => throw new NotSupportedException();
-
-        public virtual void Remove(object value) => throw new NotSupportedException();
-
-        public virtual void RemoveAt(int index) => throw new NotSupportedException();
-
-        public void CopyTo(Array array, int index)
-        {
-            Argument.NotNull(array, nameof(array));
-
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
-
-            if (index + Count > array.Length)
-            {
-                throw new ArgumentException($"Specified array doesn't have enough capacity to perform the copy. Needed: {index + Count}, available: {array.Length}", nameof(array));
-            }
-
-            var list = (IList)array;
-            foreach (var obj in this)
-            {
-                list[index++] = obj;
             }
         }
 

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -187,13 +187,13 @@ namespace Realms
         public RealmCollectionBase<T> Snapshot()
         {
             var handle = Handle.Value.Snapshot();
-            return new RealmResults<T>(Realm, Metadata, handle);
+            return new RealmResults<T>(Realm, handle, Metadata);
         }
 
         internal RealmResults<T> GetFilteredResults(string query)
         {
             var handle = Handle.Value.GetFilteredResults(query);
-            return new RealmResults<T>(Realm, Metadata, handle);
+            return new RealmResults<T>(Realm, handle, Metadata);
         }
 
         public IDisposable SubscribeForNotifications(NotificationCallbackDelegate<T> callback)
@@ -404,9 +404,29 @@ namespace Realms
 
         #region IList
 
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            Argument.NotNull(array, nameof(array));
+
+            if (arrayIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+            }
+
+            if (arrayIndex + Count > array.Length)
+            {
+                throw new ArgumentException($"Specified array doesn't have enough capacity to perform the copy. Needed: {arrayIndex + Count}, available: {array.Length}", nameof(array));
+            }
+
+            foreach (var obj in this)
+            {
+                array[arrayIndex++] = obj;
+            }
+        }
+
         public bool IsFixedSize => false;
 
-        public virtual bool IsReadOnly => true;
+        public bool IsReadOnly => (Realm?.Config as RealmConfiguration)?.IsReadOnly == true;
 
         public bool IsSynchronized => false;
 

--- a/Realm/Realm/RealmList.cs
+++ b/Realm/Realm/RealmList.cs
@@ -45,28 +45,20 @@ namespace Realms
     [DebuggerDisplay("Count = {Count}")]
     public class RealmList<T> : RealmCollectionBase<T>, IList<T>, IDynamicMetaObjectProvider, IRealmList
     {
-        private readonly Realm _realm;
-
         private readonly ListHandle _listHandle;
 
         internal RealmList(Realm realm, ListHandle adoptedList, RealmObjectBase.Metadata metadata) : base(realm, metadata)
         {
-            _realm = realm;
             _listHandle = adoptedList;
         }
 
-        internal override CollectionHandleBase CreateHandle()
-        {
-            return _listHandle;
-        }
+        internal override CollectionHandleBase CreateHandle() => _listHandle;
 
         ListHandle IRealmList.NativeHandle => _listHandle;
 
         RealmObjectBase.Metadata IRealmList.Metadata => Metadata;
 
         #region implementing IList properties
-
-        public override bool IsReadOnly => (_realm?.Config as RealmConfiguration)?.IsReadOnly == true;
 
         [IndexerName("Item")]
         public new T this[int index]
@@ -118,26 +110,6 @@ namespace Realms
         }
 
         public bool Contains(T item) => IndexOf(item) > -1;
-
-        public void CopyTo(T[] array, int arrayIndex)
-        {
-            Argument.NotNull(array, nameof(array));
-
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
-            }
-
-            if (arrayIndex + Count > array.Length)
-            {
-                throw new ArgumentException($"Specified array doesn't have enough capacity to perform the copy. Needed: {arrayIndex + Count}, available: {array.Length}", nameof(array));
-            }
-
-            foreach (var obj in this)
-            {
-                array[arrayIndex++] = obj;
-            }
-        }
 
         public override int IndexOf(T value)
         {
@@ -222,10 +194,7 @@ namespace Realms
             _listHandle.Move((IntPtr)sourceIndex, (IntPtr)targetIndex);
         }
 
-        internal override RealmCollectionBase<T> CreateCollection(Realm realm, CollectionHandleBase handle)
-        {
-            return new RealmList<T>(realm, (ListHandle)handle, Metadata);
-        }
+        internal override RealmCollectionBase<T> CreateCollection(Realm realm, CollectionHandleBase handle) => new RealmList<T>(realm, (ListHandle)handle, Metadata);
 
         DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression expression) => new MetaRealmList(expression, this);
 
@@ -246,7 +215,7 @@ namespace Realms
                         case RealmObject realmObj:
                             if (!realmObj.IsManaged)
                             {
-                                _realm.Add(realmObj);
+                                Realm.Add(realmObj);
                             }
 
                             objectHandler(realmObj);

--- a/Realm/Realm/RealmList.cs
+++ b/Realm/Realm/RealmList.cs
@@ -46,10 +46,56 @@ namespace Realms
     public class RealmList<T> : RealmCollectionBase<T>, IList<T>, IDynamicMetaObjectProvider, IRealmList
     {
         private readonly ListHandle _listHandle;
+        private readonly Action<T> _add;
+        private readonly Action<int, T> _set;
+        private readonly Action<int, T> _insert;
+        private readonly Func<T, int> _indexOf;
 
         internal RealmList(Realm realm, ListHandle adoptedList, RealmObjectBase.Metadata metadata) : base(realm, metadata)
         {
             _listHandle = adoptedList;
+
+            switch (_argumentType)
+            {
+                case PropertyType.Object | PropertyType.Nullable:
+                    _add = GetObjectExecutor(_listHandle.Add, _listHandle.AddEmbedded);
+                    _set = GetObjectExecutor(_listHandle.Set, _listHandle.SetEmbedded);
+                    _insert = GetObjectExecutor(_listHandle.Insert, _listHandle.InsertEmbedded);
+                    _indexOf = (value) =>
+                    {
+                        Argument.NotNull(value, nameof(value));
+
+                        var obj = Operator.Convert<T, RealmObjectBase>(value);
+                        if (!obj.IsManaged)
+                        {
+                            throw new ArgumentException("Value does not belong to a realm", nameof(value));
+                        }
+
+                        return _listHandle.Find(obj.ObjectHandle);
+                    };
+
+                    break;
+                case PropertyType.String:
+                case PropertyType.String | PropertyType.Nullable:
+                    _add = (item) => _listHandle.Add(Operator.Convert<T, string>(item));
+                    _set = (index, item) => _listHandle.Set(index, Operator.Convert<T, string>(item));
+                    _insert = (index, item) => _listHandle.Insert(index, Operator.Convert<T, string>(item));
+                    _indexOf = (value) => _listHandle.Find(Operator.Convert<T, string>(value));
+                    break;
+                case PropertyType.Data:
+                case PropertyType.Data | PropertyType.Nullable:
+                    _add = (item) => _listHandle.Add(Operator.Convert<T, byte[]>(item));
+                    _set = (index, item) => _listHandle.Set(index, Operator.Convert<T, byte[]>(item));
+                    _insert = (index, item) => _listHandle.Insert(index, Operator.Convert<T, byte[]>(item));
+                    _indexOf = (value) => _listHandle.Find(Operator.Convert<T, byte[]>(value));
+                    break;
+                default:
+                    _add = (item) => _listHandle.Add(PrimitiveValue.Create(item, _argumentType));
+                    _set = (index, item) => _listHandle.Set(index, PrimitiveValue.Create(item, _argumentType));
+                    _insert = (index, item) => _listHandle.Insert(index, PrimitiveValue.Create(item, _argumentType));
+                    _indexOf = (value) => _listHandle.Find(PrimitiveValue.Create(value, _argumentType));
+                    break;
+            }
         }
 
         internal override CollectionHandleBase CreateHandle() => _listHandle;
@@ -75,12 +121,7 @@ namespace Realms
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
-                Execute(value,
-                    obj => _listHandle.Set(index, obj.ObjectHandle),
-                    () => _listHandle.SetEmbedded(index),
-                    v => _listHandle.Set(index, v),
-                    v => _listHandle.Set(index, v),
-                    v => _listHandle.Set(index, v));
+                _set(index, value);
             }
         }
 
@@ -88,53 +129,9 @@ namespace Realms
 
         #region implementing IList members
 
-        public void Add(T item)
-        {
-            Execute(item,
-                obj => _listHandle.Add(obj.ObjectHandle),
-                () => _listHandle.AddEmbedded(),
-                _listHandle.Add,
-                _listHandle.Add,
-                _listHandle.Add);
-        }
+        public void Add(T item) => _add(item);
 
-        public override int Add(object value)
-        {
-            Add((T)value);
-            return Count;
-        }
-
-        public override void Clear()
-        {
-            _listHandle.Clear();
-        }
-
-        public bool Contains(T item) => IndexOf(item) > -1;
-
-        public override int IndexOf(T value)
-        {
-            switch (_argumentType)
-            {
-                case PropertyType.Object | PropertyType.Nullable:
-                    Argument.NotNull(value, nameof(value));
-
-                    var obj = Operator.Convert<T, RealmObjectBase>(value);
-                    if (!obj.IsManaged)
-                    {
-                        throw new ArgumentException("Value does not belong to a realm", nameof(value));
-                    }
-
-                    return _listHandle.Find(obj.ObjectHandle);
-                case PropertyType.String:
-                case PropertyType.String | PropertyType.Nullable:
-                    return _listHandle.Find(Operator.Convert<T, string>(value));
-                case PropertyType.Data:
-                case PropertyType.Data | PropertyType.Nullable:
-                    return _listHandle.Find(Operator.Convert<T, byte[]>(value));
-                default:
-                    return _listHandle.Find(PrimitiveValue.Create(value, _argumentType));
-            }
-        }
+        public override int IndexOf(T value) => _indexOf(value);
 
         public void Insert(int index, T item)
         {
@@ -143,15 +140,8 @@ namespace Realms
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            Execute(item,
-                obj => _listHandle.Insert(index, obj.ObjectHandle),
-                () => _listHandle.InsertEmbedded(index),
-                value => _listHandle.Insert(index, value),
-                value => _listHandle.Insert(index, value),
-                value => _listHandle.Insert(index, value));
+            _insert(index, item);
         }
-
-        public override void Insert(int index, object value) => Insert(index, (T)value);
 
         public bool Remove(T item)
         {
@@ -165,9 +155,7 @@ namespace Realms
             return true;
         }
 
-        public override void Remove(object value) => Remove((T)value);
-
-        public override void RemoveAt(int index)
+        public void RemoveAt(int index)
         {
             if (index < 0)
             {
@@ -198,54 +186,66 @@ namespace Realms
 
         DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression expression) => new MetaRealmList(expression, this);
 
-        private void Execute(T item,
-            Action<RealmObject> objectHandler,
-            Func<ObjectHandle> embeddedHandler,
-            Action<PrimitiveValue> primitiveHandler,
-            Action<string> stringHandler,
-            Action<byte[]> binaryHandler)
+        private Action<T> GetObjectExecutor(Action<ObjectHandle> objectHandler, Func<ObjectHandle> embeddedHandler)
         {
-            switch (_argumentType)
+            return (item) =>
             {
-                case PropertyType.Object | PropertyType.Nullable:
-                    switch (item)
-                    {
-                        case null:
-                            throw new NotSupportedException("Adding, setting, or inserting <null> in a list of objects is not supported.");
-                        case RealmObject realmObj:
-                            if (!realmObj.IsManaged)
-                            {
-                                Realm.Add(realmObj);
-                            }
+                switch (item)
+                {
+                    case null:
+                        throw new NotSupportedException("Adding, setting, or inserting <null> in a list of objects is not supported.");
+                    case RealmObject realmObj:
+                        if (!realmObj.IsManaged)
+                        {
+                            Realm.Add(realmObj);
+                        }
 
-                            objectHandler(realmObj);
-                            break;
-                        case EmbeddedObject embeddedObj:
-                            if (embeddedObj.IsManaged)
-                            {
-                                throw new RealmException("Can't add, set, or insert an embedded object that is already managed.");
-                            }
+                        objectHandler(realmObj.ObjectHandle);
+                        break;
+                    case EmbeddedObject embeddedObj:
+                        if (embeddedObj.IsManaged)
+                        {
+                            throw new RealmException("Can't add, set, or insert an embedded object that is already managed.");
+                        }
 
-                            var handle = embeddedHandler();
-                            Realm.ManageEmbedded(embeddedObj, handle);
-                            break;
-                        default:
-                            throw new NotSupportedException($"Adding, setting, or inserting {item.GetType()} in a list of objects is not supported, because it doesn't inherit from RealmObject or EmbeddedObject.");
-                    }
+                        var handle = embeddedHandler();
+                        Realm.ManageEmbedded(embeddedObj, handle);
+                        break;
+                    default:
+                        throw new NotSupportedException($"Adding, setting, or inserting {item.GetType()} in a list of objects is not supported, because it doesn't inherit from RealmObject or EmbeddedObject.");
+                }
+            };
+        }
 
-                    break;
-                case PropertyType.String:
-                case PropertyType.String | PropertyType.Nullable:
-                    stringHandler(Operator.Convert<T, string>(item));
-                    break;
-                case PropertyType.Data:
-                case PropertyType.Data | PropertyType.Nullable:
-                    binaryHandler(Operator.Convert<T, byte[]>(item));
-                    break;
-                default:
-                    primitiveHandler(PrimitiveValue.Create(item, _argumentType));
-                    break;
-            }
+        private Action<int, T> GetObjectExecutor(Action<int, ObjectHandle> objectHandler, Func<int, ObjectHandle> embeddedHandler)
+        {
+            return (index, item) =>
+            {
+                switch (item)
+                {
+                    case null:
+                        throw new NotSupportedException("Adding, setting, or inserting <null> in a list of objects is not supported.");
+                    case RealmObject realmObj:
+                        if (!realmObj.IsManaged)
+                        {
+                            Realm.Add(realmObj);
+                        }
+
+                        objectHandler(index, realmObj.ObjectHandle);
+                        break;
+                    case EmbeddedObject embeddedObj:
+                        if (embeddedObj.IsManaged)
+                        {
+                            throw new RealmException("Can't add, set, or insert an embedded object that is already managed.");
+                        }
+
+                        var handle = embeddedHandler(index);
+                        Realm.ManageEmbedded(embeddedObj, handle);
+                        break;
+                    default:
+                        throw new NotSupportedException($"Adding, setting, or inserting {item.GetType()} in a list of objects is not supported, because it doesn't inherit from RealmObject or EmbeddedObject.");
+                }
+            };
         }
     }
 

--- a/Realm/Realm/RealmList.cs
+++ b/Realm/Realm/RealmList.cs
@@ -117,7 +117,7 @@ namespace Realms
             _listHandle.Clear();
         }
 
-        public bool Contains(T item) => Contains((object)item);
+        public bool Contains(T item) => IndexOf(item) > -1;
 
         public void CopyTo(T[] array, int arrayIndex)
         {
@@ -222,16 +222,9 @@ namespace Realms
             _listHandle.Move((IntPtr)sourceIndex, (IntPtr)targetIndex);
         }
 
-        public override IRealmCollection<T> Freeze()
+        internal override RealmCollectionBase<T> CreateCollection(Realm realm, CollectionHandleBase handle)
         {
-            if (IsFrozen)
-            {
-                return this;
-            }
-
-            var frozenRealm = Realm.Freeze();
-            var frozenHandle = _listHandle.Freeze(frozenRealm.SharedRealmHandle);
-            return new RealmList<T>(frozenRealm, frozenHandle, Metadata);
+            return new RealmList<T>(realm, (ListHandle)handle, Metadata);
         }
 
         DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression expression) => new MetaRealmList(expression, this);

--- a/Realm/Realm/RealmObjectBase.cs
+++ b/Realm/Realm/RealmObjectBase.cs
@@ -267,7 +267,7 @@ namespace Realms
             _metadata.Schema.TryFindProperty(propertyName, out var property);
             var relatedMeta = _realm.Metadata[property.ObjectType];
 
-            return new RealmResults<T>(_realm, relatedMeta, resultsHandle);
+            return new RealmResults<T>(_realm, resultsHandle, relatedMeta);
         }
 
         protected RealmInteger<T> GetRealmIntegerValue<T>(string propertyName)
@@ -391,10 +391,10 @@ namespace Realms
             var resultsHandle = ObjectHandle.GetBacklinksForType(relatedMeta.Table, relatedMeta.PropertyIndices[property]);
             if (relatedMeta.Schema.IsEmbedded)
             {
-                return new RealmResults<EmbeddedObject>(Realm, relatedMeta, resultsHandle);
+                return new RealmResults<EmbeddedObject>(Realm, resultsHandle, relatedMeta);
             }
 
-            return new RealmResults<RealmObject>(Realm, relatedMeta, resultsHandle);
+            return new RealmResults<RealmObject>(Realm, resultsHandle, relatedMeta);
         }
 
         /// <inheritdoc/>

--- a/Realm/Realm/RealmObjectBase.cs
+++ b/Realm/Realm/RealmObjectBase.cs
@@ -230,6 +230,14 @@ namespace Realms
             return _objectHandle.GetList<T>(_realm, _metadata.PropertyIndices[propertyName], property.ObjectType);
         }
 
+        protected internal ISet<T> GetSetValue<T>(string propertyName)
+        {
+            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
+
+            _metadata.Schema.TryFindProperty(propertyName, out var property);
+            return _objectHandle.GetSet<T>(_realm, _metadata.PropertyIndices[propertyName], property.ObjectType);
+        }
+
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
         protected T GetObjectValue<T>(string propertyName)
             where T : RealmObjectBase

--- a/Realm/Realm/RealmSet.cs
+++ b/Realm/Realm/RealmSet.cs
@@ -1,6 +1,6 @@
 ﻿////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2020 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ namespace Realms
                 case PropertyType.Data | PropertyType.Nullable:
                     _add = (item) => _setHandle.Add(Operator.Convert<T, byte[]>(item));
                     _remove = (item) => _setHandle.Remove(Operator.Convert<T, byte[]>(item));
-                    _contains = (item) => _setHandle.Contains(Operator.Convert<T, string>(item));
+                    _contains = (item) => _setHandle.Contains(Operator.Convert<T, byte[]>(item));
                     break;
                 default:
                     _add = (item) => _setHandle.Add(PrimitiveValue.Create(item, _argumentType));

--- a/Realm/Realm/RealmSet.cs
+++ b/Realm/Realm/RealmSet.cs
@@ -1,0 +1,352 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Realms.Helpers;
+
+namespace Realms
+{
+    [Preserve(AllMembers = true)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This should not be directly accessed by users.")]
+    [DebuggerDisplay("Count = {Count}")]
+    public class RealmSet<T> : RealmCollectionBase<T>, ISet<T>
+    {
+        private readonly SetHandle _setHandle;
+
+        internal RealmSet(Realm realm, SetHandle adoptedSet, RealmObjectBase.Metadata metadata)
+            : base(realm, metadata)
+        {
+            _setHandle = adoptedSet;
+        }
+
+        public bool Add(T item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        void ICollection<T>.Add(T item) => Add(item);
+
+        public bool Remove(T item)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Contains(T item) => IndexOf(item) > -1;
+
+        public override int IndexOf(T value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        internal override RealmCollectionBase<T> CreateCollection(Realm realm, CollectionHandleBase handle) => new RealmSet<T>(realm, (SetHandle)handle, Metadata);
+
+        internal override CollectionHandleBase CreateHandle() => _setHandle;
+
+        #region Set methods
+
+        public void ExceptWith(IEnumerable<T> other)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call ExceptWith in native
+                throw new NotImplementedException();
+            }
+
+            if (Count == 0)
+            {
+                return;
+            }
+
+            foreach (var item in other)
+            {
+                Remove(item);
+            }
+        }
+
+        public void IntersectWith(IEnumerable<T> other)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call IntersectWith in native
+                throw new NotImplementedException();
+            }
+
+            // intersection of anything with empty set is empty set, so return if count is 0
+            if (Count == 0)
+            {
+                return;
+            }
+
+            var otherSet = GetCollection(other);
+
+            // Special case for when other is empty - just clear the set.
+            if (otherSet.Count == 0)
+            {
+                Clear();
+                return;
+            }
+
+            foreach (var item in this)
+            {
+                if (!otherSet.Contains(item))
+                {
+                    Remove(item);
+                }
+            }
+        }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) => IsSubsetCore(other, proper: true);
+
+        public bool IsSubsetOf(IEnumerable<T> other) => IsSubsetCore(other, proper: false);
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) => IsSupersetCore(other, proper: true);
+
+        public bool IsSupersetOf(IEnumerable<T> other) => IsSupersetCore(other, proper: false);
+
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call Overlaps in native
+                throw new NotImplementedException();
+            }
+
+            // Special case - empty set doesn't overlap with anything.
+            if (Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var item in other)
+            {
+                if (Contains(item))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call Overlaps in native
+                throw new NotImplementedException();
+            }
+
+            var otherSet = GetSet(other);
+            if (otherSet.Count != Count)
+            {
+                return false;
+            }
+
+            foreach (var item in other)
+            {
+                if (!Contains(item))
+                {
+                    return false;
+                }
+            }
+
+            // We already know that counts are the same
+            return true;
+        }
+
+        public void SymmetricExceptWith(IEnumerable<T> other)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call Overlaps in native
+                throw new NotImplementedException();
+            }
+
+            var otherSet = GetSet(other);
+
+            // Special case - this is a no-op
+            if (otherSet.Count == 0)
+            {
+                return;
+            }
+
+            // Special case - SymmetricExceptWith for empty set is equivalent to Union
+            if (Count == 0)
+            {
+                foreach (var item in other)
+                {
+                    Add(item);
+                }
+
+                return;
+            }
+
+            foreach (var item in this)
+            {
+                if (otherSet.Contains(item))
+                {
+                    Remove(item);
+                    otherSet.Remove(item);
+                }
+            }
+
+            // We removed all duplicates, just add the remainder
+            foreach (var item in otherSet)
+            {
+                Add(item);
+            }
+        }
+
+        public void UnionWith(IEnumerable<T> other)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call UnionWith in native
+                return;
+            }
+
+            foreach (var item in other)
+            {
+                Add(item);
+            }
+        }
+
+        private bool IsSubsetCore(IEnumerable<T> other, bool proper)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call IsSubsetOf in native
+                throw new NotImplementedException();
+            }
+
+            // The empty set is a subset of any set.
+            if (Count == 0)
+            {
+                return true;
+            }
+
+            var otherSet = GetSet(other);
+
+            var maximumCount = otherSet.Count;
+            if (proper)
+            {
+                // Proper subset means at least one element in addition to the subset
+                maximumCount--;
+            }
+
+            // Special case - we can't have a subset if we have more elements than the max count.
+            if (Count > maximumCount)
+            {
+                return false;
+            }
+
+            foreach (var item in this)
+            {
+                if (!otherSet.Contains(item))
+                {
+                    return false;
+                }
+            }
+
+            // We've already established that we have less than the max element count, so we're a subset.
+            return true;
+        }
+
+        private bool IsSupersetCore(IEnumerable<T> other, bool proper)
+        {
+            Argument.NotNull(other, nameof(other));
+
+            if (other is RealmCollectionBase<T> realmCollection)
+            {
+                // Call IsSupersetOf in native
+                throw new NotImplementedException();
+            }
+
+            // The empty set is a subset of any set.
+            if (Count == 0)
+            {
+                return true;
+            }
+
+            var otherSet = GetSet(other);
+
+            var maximumCount = Count;
+            if (proper)
+            {
+                // Proper subset means at least one element in addition to the subset
+                maximumCount--;
+            }
+
+            // Special case - we can't have a subset if we have more elements than the max count.
+            if (otherSet.Count > maximumCount)
+            {
+                return false;
+            }
+
+            foreach (var item in otherSet)
+            {
+                if (!Contains(item))
+                {
+                    return false;
+                }
+            }
+
+            // We've already established that we have less than the max element count, so we're a subset.
+            return true;
+        }
+
+        private static ISet<T> GetSet(IEnumerable<T> enumerable)
+        {
+            if (enumerable is ISet<T> set)
+            {
+                return set;
+            }
+
+            return new HashSet<T>(enumerable);
+        }
+
+        private static ICollection<T> GetCollection(IEnumerable<T> enumerable)
+        {
+            if (enumerable is ICollection<T> collection)
+            {
+                return collection;
+            }
+
+            return new List<T>(enumerable);
+        }
+
+        #endregion
+    }
+}

--- a/Realm/Realm/Schema/PropertyType.cs
+++ b/Realm/Realm/Schema/PropertyType.cs
@@ -28,7 +28,7 @@ namespace Realms.Schema
     [SuppressMessage("Naming", "CA1714:Flags enums should have plural names", Justification = "Would be a breaking change to rename.")]
     [SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "This is by design - the enum represents types.")]
     [SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "The native values are duplicated.")]
-    public enum PropertyType : byte
+    public enum PropertyType : ushort
     {
         /// <summary>
         /// Integer property, combining all integral types.
@@ -101,9 +101,14 @@ namespace Realms.Schema
         Array = 128,
 
         /// <summary>
+        /// A collection of unique values. Can be combined with other values.
+        /// </summary>
+        Set = 256,
+
+        /// <summary>
         /// Metadata flags.
         /// </summary>
-        Flags = Nullable | Array,
+        Flags = Nullable | Array | Set,
 
         /// <summary>
         /// A shorthand for PropertyType.Int | PropertyType.Nullable.

--- a/Realm/Realm/Schema/PropertyTypeEx.cs
+++ b/Realm/Realm/Schema/PropertyTypeEx.cs
@@ -87,16 +87,26 @@ namespace Realms.Schema
                     return PropertyType.Object | PropertyType.Nullable;
 
                 case Type _ when type.IsClosedGeneric(typeof(IList<>), out var typeArguments):
-                    var result = PropertyType.Array | typeArguments.Single().ToPropertyType(out objectType);
+                    var listResult = PropertyType.Array | typeArguments.Single().ToPropertyType(out objectType);
 
-                    if (result.HasFlag(PropertyType.Object))
+                    if (listResult.HasFlag(PropertyType.Object))
                     {
                         // List<Object> can't contain nulls
-                        result &= ~PropertyType.Nullable;
+                        listResult &= ~PropertyType.Nullable;
                     }
 
-                    return result;
+                    return listResult;
 
+                case Type _ when type.IsClosedGeneric(typeof(ISet<>), out var typeArguments):
+                    var setResult = PropertyType.Set | typeArguments.Single().ToPropertyType(out objectType);
+
+                    if (setResult.HasFlag(PropertyType.Object))
+                    {
+                        // Set<Object> can't contain nulls
+                        setResult &= ~PropertyType.Nullable;
+                    }
+
+                    return setResult;
                 default:
                     throw new ArgumentException($"The property type {type.Name} cannot be expressed as a Realm schema type", nameof(type));
             }
@@ -107,6 +117,8 @@ namespace Realms.Schema
         public static bool IsNullable(this PropertyType propertyType) => propertyType.HasFlag(PropertyType.Nullable);
 
         public static bool IsArray(this PropertyType propertyType) => propertyType.HasFlag(PropertyType.Array);
+
+        public static bool IsSet(this PropertyType propertyType) => propertyType.HasFlag(PropertyType.Set);
 
         public static PropertyType UnderlyingType(this PropertyType propertyType) => propertyType & ~PropertyType.Flags;
     }

--- a/Realm/Realm/Thread Handover/ThreadSafeReference.cs
+++ b/Realm/Realm/Thread Handover/ThreadSafeReference.cs
@@ -80,7 +80,7 @@ namespace Realms
         /// obtained by calling <see cref="Realm.All"/> or a subsequent LINQ query.
         /// </param>
         /// <typeparam name="T">The type of the <see cref="RealmObject"/> or <see cref="EmbeddedObject"/> contained in the query.</typeparam>
-        /// <returns>A <see cref="ThreadSafeReference"/> that can be passed to <c>Realm.ResolveReference(ThreadSafeReference.Query)</c> on a different thread.</returns>
+        /// <returns>A <see cref="ThreadSafeReference"/> that can be passed to <see cref="Realm.ResolveReference{T}(Query{T})"/> on a different thread.</returns>
         public static Query<T> Create<T>(IQueryable<T> value)
             where T : RealmObjectBase
         {
@@ -92,7 +92,7 @@ namespace Realms
         /// </summary>
         /// <param name="value">The thread-confined <see cref="RealmObject"/> or <see cref="EmbeddedObject"/> to create a thread-safe reference to.</param>
         /// <typeparam name="T">The type of the <see cref="RealmObject"/>/<see cref="EmbeddedObject"/>.</typeparam>
-        /// <returns>A <see cref="ThreadSafeReference"/> that can be passed to <c>Realm.ResolveReference(ThreadSafeReference.Object)</c> on a different thread.</returns>
+        /// <returns>A <see cref="ThreadSafeReference"/> that can be passed to <see cref="Realm.ResolveReference{T}(Object{T})"/> on a different thread.</returns>
         public static Object<T> Create<T>(T value)
             where T : RealmObjectBase
         {
@@ -104,13 +104,27 @@ namespace Realms
         /// </summary>
         /// <param name="value">
         /// The thread-confined <see cref="IList{T}"/> to create a thread-safe reference to. It must be a collection
-        /// that is a managed property of a <see cref="RealmObject"/> or a <see cref="EmbeddedObject"/>.
+        /// that is a managed property of a <see cref="RealmObject"/> or an <see cref="EmbeddedObject"/>.
         /// </param>
         /// <typeparam name="T">The type of the objects contained in the list.</typeparam>
-        /// <returns>A <see cref="ThreadSafeReference"/> that can be passed to <c>Realm.ResolveReference(ThreadSafeReference.List)</c> on a different thread.</returns>
+        /// <returns>A <see cref="ThreadSafeReference"/> that can be passed to <see cref="Realm.ResolveReference{T}(List{T})"/> on a different thread.</returns>
         public static List<T> Create<T>(IList<T> value)
         {
             return new List<T>(value);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Set{T}"/> class.
+        /// </summary>
+        /// <param name="value">
+        /// The thread-confined <see cref="ISet{T}"/> to create a thread-safe reference to. It must be a collection
+        /// that is a managed property of a <see cref="RealmObject"/> or an <see cref="EmbeddedObject"/>.
+        /// </param>
+        /// <typeparam name="T">The type of the objects contained in the set.</typeparam>
+        /// <returns>A <see cref="ThreadSafeReference"/> that can be passed to <see cref="Realm.ResolveReference{T}(Set{T})"/> on a different thread.</returns>
+        public static Set<T> Create<T>(ISet<T> value)
+        {
+            return new Set<T>(value);
         }
 
         #endregion
@@ -121,7 +135,7 @@ namespace Realms
         /// A reference to a <see cref="IQueryable{T}"/> intended to be passed between threads.
         /// <para/>
         /// To resolve a thread-safe reference on a target <see cref="Realm"/> on a different thread, pass it to
-        /// <c>Realm.ResolveReference(ThreadSafeReference.Query)</c>.
+        /// <see cref="Realm.ResolveReference{T}(Query{T})"/>.
         /// </summary>
         /// <remarks>
         /// A <see cref="ThreadSafeReference"/> object must be resolved at most once.
@@ -145,7 +159,7 @@ namespace Realms
         /// A reference to a <see cref="RealmObject"/> or an <see cref="EmbeddedObject"/> intended to be passed between threads.
         /// <para/>
         /// To resolve a thread-safe reference on a target <see cref="Realm"/> on a different thread, pass it to
-        /// <c>Realm.ResolveReference(ThreadSafeReference.Object)</c>.
+        /// <see cref="Realm.ResolveReference{T}(Object{T})"/>.
         /// </summary>
         /// <remarks>
         /// A <see cref="ThreadSafeReference"/> object must be resolved at most once.
@@ -171,7 +185,7 @@ namespace Realms
         /// A reference to a <see cref="IList{T}"/> intended to be passed between threads.
         /// <para/>
         /// To resolve a thread-safe reference on a target <see cref="Realm"/> on a different thread, pass it to
-        /// <c>Realm.ResolveReference(ThreadSafeReference.List)</c>.
+        /// <see cref="Realm.ResolveReference{T}(List{T})"/>.
         /// </summary>
         /// <remarks>
         /// A <see cref="ThreadSafeReference"/> object must be resolved at most once.
@@ -190,13 +204,38 @@ namespace Realms
             }
         }
 
+        /// <summary>
+        /// A reference to a <see cref="ISet{T}"/> intended to be passed between threads.
+        /// <para/>
+        /// To resolve a thread-safe reference on a target <see cref="Realm"/> on a different thread, pass it to
+        /// <see cref="Realm.ResolveReference{T}(Set{T})"/>.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="ThreadSafeReference"/> object must be resolved at most once.
+        /// <para/>
+        /// Failing to resolve a <see cref="ThreadSafeReference"/> will result in the source version of the
+        /// Realm being pinned until the reference is deallocated.
+        /// <para/>
+        /// Prefer short-lived <see cref="ThreadSafeReference"/>s as the data for the version of the source Realm
+        /// will be retained until all references have been resolved or deallocated.
+        /// </remarks>
+        /// <typeparam name="T">The type of the objects contained in the set.</typeparam>
+        [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "A nested class with generic argument is unlikely to be confused with a property setter.")]
+        public class Set<T> : ThreadSafeReference
+        {
+            internal Set(ISet<T> value) : base((RealmSet<T>)value, Type.Set)
+            {
+            }
+        }
+
         #endregion
 
         internal enum Type
         {
             Object,
             List,
-            Query
+            Query,
+            Set
         }
     }
 }

--- a/Tests/Realm.Tests/Database/ListOfPrimitivesTests.cs
+++ b/Tests/Realm.Tests/Database/ListOfPrimitivesTests.cs
@@ -275,14 +275,12 @@ namespace Realms.Tests.Database
             }
         }
 
-        private static ObjectId GenerateRepetitiveObjectId(byte value) => new ObjectId(Enumerable.Range(0, 12).Select(_ => value).ToArray());
-
         private static readonly IEnumerable<ObjectId?[]> _objectIdValues = new[]
         {
             new ObjectId?[] { new ObjectId("5f651b09f6cddff534c3cddf") },
             new ObjectId?[] { null },
-            new ObjectId?[] { ObjectId.Empty, GenerateRepetitiveObjectId(0), GenerateRepetitiveObjectId(byte.MaxValue) },
-            new ObjectId?[] { new ObjectId("5f651b2930643efeef987e5d"), GenerateRepetitiveObjectId(byte.MaxValue), null, new ObjectId("5f651c4cf755604f2fbf7440") }
+            new ObjectId?[] { ObjectId.Empty, TestHelpers.GenerateRepetitiveObjectId(0), TestHelpers.GenerateRepetitiveObjectId(byte.MaxValue) },
+            new ObjectId?[] { new ObjectId("5f651b2930643efeef987e5d"), TestHelpers.GenerateRepetitiveObjectId(byte.MaxValue), null, new ObjectId("5f651c4cf755604f2fbf7440") }
         };
 
         public static IEnumerable<object> ObjectIdTestValues()

--- a/Tests/Realm.Tests/Database/RealmSetTests.cs
+++ b/Tests/Realm.Tests/Database/RealmSetTests.cs
@@ -1,0 +1,248 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Realms.Tests.Database
+{
+    [TestFixture, Preserve(AllMembers = true)]
+    public class RealmSetTests : RealmInstanceTest
+    {
+        [TestCaseSource(nameof(Int64TestValues))]
+        public void RealmSet_WhenUnmanaged_Int64(TestCaseData<long> testData)
+        {
+            RunUnmanagedTests(o => o.Int64Set, testData);
+        }
+
+        [TestCaseSource(nameof(Int64TestValues))]
+        public void RealmSet_WhenUnmanaged_Int64Counter(TestCaseData<long> testData)
+        {
+            RunUnmanagedTests(o => o.Int64CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableInt64TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt64(TestCaseData<long?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt64Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableInt64TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt64Counter(TestCaseData<long?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt64CounterSet, ToInteger(testData));
+        }
+
+        private static void RunUnmanagedTests<T>(Func<SetsObject, ISet<T>> accessor, TestCaseData<T> testData)
+        {
+            var testObject = new SetsObject();
+            var set = accessor(testObject);
+
+            testData.AssertCount(set);
+            testData.AssertExceptWith(set);
+            testData.AssertIntersectWith(set);
+            testData.AssertIsProperSubsetOf(set);
+            testData.AssertIsProperSupersetOf(set);
+            testData.AssertIsSubsetOf(set);
+            testData.AssertIsSupersetOf(set);
+            testData.AssertOverlaps(set);
+            testData.AssertSymmetricExceptWith(set);
+            testData.AssertUnionWith(set);
+        }
+
+        private static TestCaseData<RealmInteger<T>> ToInteger<T>(TestCaseData<T> data)
+            where T : struct, IComparable<T>, IFormattable
+        {
+            return new TestCaseData<RealmInteger<T>>(data.InitialValues.ToInteger(), data.OtherCollection.ToInteger());
+        }
+
+        private static TestCaseData<RealmInteger<T>?> ToInteger<T>(TestCaseData<T?> data)
+            where T : struct, IComparable<T>, IFormattable
+        {
+            return new TestCaseData<RealmInteger<T>?>(data.InitialValues.ToInteger(), data.OtherCollection.ToInteger());
+        }
+
+        public static IEnumerable<TestCaseData<long>> Int64TestValues()
+        {
+            yield return new TestCaseData<long>(new long[] { 1, 2, 3 }, new long[] { 4, 5, 6 });
+            yield return new TestCaseData<long>(new long[] { 1, 2, 3 }, new long[] { 1, 2, 3 });
+            yield return new TestCaseData<long>(new long[] { long.MinValue, long.MaxValue }, new long[] { 0 });
+            yield return new TestCaseData<long>(new long[] { -1, 0, 1 }, Array.Empty<long>());
+            yield return new TestCaseData<long>(Array.Empty<long>(), new long[] { 0 });
+            yield return new TestCaseData<long>(new long[] { 4, 6, 8 }, new long[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<long>(new long[] { 1, 1, 1, 1, 1, 1, 1 }, new long[] { 1, 1, 1 });
+            yield return new TestCaseData<long>(new long[] { 1, 1, 1, 1, 1, 1, 1 }, new long[] { 1, 2, 1 });
+            yield return new TestCaseData<long>(new long[] { 1, 2, 2, 1, 1, 1, 1 }, new long[] { 1, 1, 1 });
+        }
+
+        public static IEnumerable<TestCaseData<long?>> NullableInt64TestValues()
+        {
+            yield return new TestCaseData<long?>(new long?[] { 1, 2, 3 }, new long?[] { 4, 5, 6 });
+            yield return new TestCaseData<long?>(new long?[] { 1, 2, 3, null }, new long?[] { 1, 2, 3, null });
+            yield return new TestCaseData<long?>(new long?[] { long.MinValue, long.MaxValue }, new long?[] { 0 });
+            yield return new TestCaseData<long?>(new long?[] { -1, 0, 1 }, Array.Empty<long?>());
+            yield return new TestCaseData<long?>(Array.Empty<long?>(), new long?[] { 0 });
+            yield return new TestCaseData<long?>(new long?[] { 4, 6, 8 }, new long?[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<long?>(new long?[] { 1, 1, 1, 1, 1, 1, 1 }, new long?[] { 1, 1, 1 });
+            yield return new TestCaseData<long?>(new long?[] { 1, 1, 1, 1, 1, 1, 1 }, new long?[] { 1, 2, 1 });
+            yield return new TestCaseData<long?>(new long?[] { 1, 2, 2, 1, 1, 1, 1 }, new long?[] { 1, 1, 1 });
+            yield return new TestCaseData<long?>(new long?[] { 1, 2, 2, 1, null, null, null }, new long?[] { 1, 1, 1, null });
+            yield return new TestCaseData<long?>(new long?[] { null }, new long?[] { null, null });
+            yield return new TestCaseData<long?>(new long?[] { null, null }, new long?[] { null, 6 });
+        }
+
+        public class TestCaseData<T>
+        {
+            public T[] InitialValues { get; }
+
+            public T[] OtherCollection { get; }
+
+            public TestCaseData(IEnumerable<T> initialValues, IEnumerable<T> otherCollection)
+            {
+                InitialValues = initialValues.ToArray();
+                OtherCollection = otherCollection.ToArray();
+            }
+
+            public override string ToString()
+            {
+                return $"{typeof(T).Name}: {{{string.Join(",", InitialValues)}}} - {{{string.Join(",", OtherCollection)}}}";
+            }
+
+            public void AssertCount(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                Assert.That(target.Count, Is.EqualTo(reference.Count));
+                Assert.That(target, Is.EquivalentTo(reference));
+            }
+
+            public void AssertUnionWith(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                target.UnionWith(OtherCollection);
+                reference.UnionWith(OtherCollection);
+
+                Assert.That(target, Is.EquivalentTo(reference));
+            }
+
+            public void AssertExceptWith(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                target.ExceptWith(OtherCollection);
+                reference.ExceptWith(OtherCollection);
+
+                Assert.That(target, Is.EquivalentTo(reference));
+            }
+
+            public void AssertIntersectWith(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                target.IntersectWith(OtherCollection);
+                reference.IntersectWith(OtherCollection);
+
+                Assert.That(target, Is.EquivalentTo(reference));
+            }
+
+            public void AssertIsProperSubsetOf(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                var targetResult = target.IsProperSubsetOf(OtherCollection);
+                var referenceResult = reference.IsProperSubsetOf(OtherCollection);
+
+                Assert.That(targetResult, Is.EqualTo(referenceResult));
+            }
+
+            public void AssertIsProperSupersetOf(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                var targetResult = target.IsProperSupersetOf(OtherCollection);
+                var referenceResult = reference.IsProperSupersetOf(OtherCollection);
+
+                Assert.That(targetResult, Is.EqualTo(referenceResult));
+            }
+
+            public void AssertIsSubsetOf(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                var targetResult = target.IsSubsetOf(OtherCollection);
+                var referenceResult = reference.IsSubsetOf(OtherCollection);
+
+                Assert.That(targetResult, Is.EqualTo(referenceResult));
+            }
+
+            public void AssertIsSupersetOf(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                var targetResult = target.IsSupersetOf(OtherCollection);
+                var referenceResult = reference.IsSupersetOf(OtherCollection);
+
+                Assert.That(targetResult, Is.EqualTo(referenceResult));
+            }
+
+            public void AssertOverlaps(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                var targetResult = target.Overlaps(OtherCollection);
+                var referenceResult = reference.Overlaps(OtherCollection);
+
+                Assert.That(targetResult, Is.EqualTo(referenceResult));
+            }
+
+            public void AssertSymmetricExceptWith(ISet<T> target)
+            {
+                Seed(target);
+                var reference = GetReferenceSet();
+
+                target.SymmetricExceptWith(OtherCollection);
+                reference.SymmetricExceptWith(OtherCollection);
+
+                Assert.That(target, Is.EquivalentTo(reference));
+            }
+
+            private void Seed(ISet<T> target)
+            {
+                target.Clear();
+                foreach (var item in InitialValues)
+                {
+                    target.Add(item);
+                }
+            }
+
+            private ISet<T> GetReferenceSet() => new HashSet<T>(InitialValues);
+        }
+    }
+}

--- a/Tests/Realm.Tests/Database/RealmSetTests.cs
+++ b/Tests/Realm.Tests/Database/RealmSetTests.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
 using NUnit.Framework;
+using Realms.Exceptions;
 
 namespace Realms.Tests.Database
 {
@@ -637,11 +638,13 @@ namespace Realms.Tests.Database
 
         #endregion
 
-
         private static void RunUnmanagedTests<T>(Func<SetsObject, ISet<T>> accessor, TestCaseData<T> testData)
         {
             var testObject = new SetsObject();
             var set = accessor(testObject);
+
+            // We can't freeze unmanaged sets.
+            Assert.Throws<RealmException>(() => set.Freeze());
 
             testData.AssertCount(set);
             testData.AssertExceptWith(set);

--- a/Tests/Realm.Tests/Database/RealmSetTests.cs
+++ b/Tests/Realm.Tests/Database/RealmSetTests.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Bson;
 using NUnit.Framework;
 
 namespace Realms.Tests.Database
@@ -26,58 +27,220 @@ namespace Realms.Tests.Database
     [TestFixture, Preserve(AllMembers = true)]
     public class RealmSetTests : RealmInstanceTest
     {
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void RealmSet_WhenUnmanaged_Int64(TestCaseData<long> testData)
+        #region Boolean
+
+        public static IEnumerable<TestCaseData<bool>> BoolTestValues()
         {
-            RunUnmanagedTests(o => o.Int64Set, testData);
+            yield return new TestCaseData<bool>(new bool[] { true }, new bool[] { false });
+            yield return new TestCaseData<bool>(new bool[] { true, false }, new bool[] { true, false });
+            yield return new TestCaseData<bool>(new bool[] { true }, Array.Empty<bool>());
+            yield return new TestCaseData<bool>(Array.Empty<bool>(), new bool[] { false });
+            yield return new TestCaseData<bool>(new bool[] { true, true, true, true, true }, new bool[] { true });
+            yield return new TestCaseData<bool>(new bool[] { true, true, true, true }, new bool[] { true, false });
+            yield return new TestCaseData<bool>(new bool[] { true, true, true, true, true, true, false, false, true }, new bool[] { false });
         }
 
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void RealmSet_WhenUnmanaged_Int64Counter(TestCaseData<long> testData)
+        public static IEnumerable<TestCaseData<bool?>> NullableBoolTestValues()
         {
-            RunUnmanagedTests(o => o.Int64CounterSet, ToInteger(testData));
+            yield return new TestCaseData<bool?>(new bool?[] { true }, new bool?[] { false });
+            yield return new TestCaseData<bool?>(new bool?[] { true, false, null }, new bool?[] { true, false, null });
+            yield return new TestCaseData<bool?>(new bool?[] { true }, Array.Empty<bool?>());
+            yield return new TestCaseData<bool?>(Array.Empty<bool?>(), new bool?[] { null });
+            yield return new TestCaseData<bool?>(new bool?[] { true, true, true }, new bool?[] { false, true, false, true, false });
+            yield return new TestCaseData<bool?>(new bool?[] { true, true, true, true, true }, new bool?[] { true, true });
+            yield return new TestCaseData<bool?>(new bool?[] { true, true, true, true, true, true }, new bool?[] { true, true, false });
+            yield return new TestCaseData<bool?>(new bool?[] { true, true, true, true, true, true, false, false, true }, new bool?[] { true, true });
+            yield return new TestCaseData<bool?>(new bool?[] { true, true, false, true, null, null, null }, new bool?[] { true, null });
+            yield return new TestCaseData<bool?>(new bool?[] { null }, new bool?[] { null, null });
+            yield return new TestCaseData<bool?>(new bool?[] { null, null }, new bool?[] { null, false });
         }
 
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void RealmSet_WhenUnmanaged_NullableInt64(TestCaseData<long?> testData)
+        [TestCaseSource(nameof(BoolTestValues))]
+        public void RealmSet_WhenUnmanaged_Bool(TestCaseData<bool> testData)
         {
-            RunUnmanagedTests(o => o.NullableInt64Set, testData);
+            RunUnmanagedTests(o => o.BooleanSet, testData);
         }
 
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void RealmSet_WhenUnmanaged_NullableInt64Counter(TestCaseData<long?> testData)
+        [TestCaseSource(nameof(NullableBoolTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableBool(TestCaseData<bool?> testData)
         {
-            RunUnmanagedTests(o => o.NullableInt64CounterSet, ToInteger(testData));
+            RunUnmanagedTests(o => o.NullableBooleanSet, testData);
         }
 
-        private static void RunUnmanagedTests<T>(Func<SetsObject, ISet<T>> accessor, TestCaseData<T> testData)
-        {
-            var testObject = new SetsObject();
-            var set = accessor(testObject);
+        #endregion
 
-            testData.AssertCount(set);
-            testData.AssertExceptWith(set);
-            testData.AssertIntersectWith(set);
-            testData.AssertIsProperSubsetOf(set);
-            testData.AssertIsProperSupersetOf(set);
-            testData.AssertIsSubsetOf(set);
-            testData.AssertIsSupersetOf(set);
-            testData.AssertOverlaps(set);
-            testData.AssertSymmetricExceptWith(set);
-            testData.AssertUnionWith(set);
+        #region Byte
+
+        public static IEnumerable<TestCaseData<byte>> ByteTestValues()
+        {
+            yield return new TestCaseData<byte>(new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6 });
+            yield return new TestCaseData<byte>(new byte[] { 1, 2, 3 }, new byte[] { 1, 2, 3 });
+            yield return new TestCaseData<byte>(new byte[] { byte.MinValue, byte.MaxValue }, new byte[] { 0 });
+            yield return new TestCaseData<byte>(new byte[] { 2, 0, 1 }, Array.Empty<byte>());
+            yield return new TestCaseData<byte>(Array.Empty<byte>(), new byte[] { 0 });
+            yield return new TestCaseData<byte>(new byte[] { 4, 6, 8 }, new byte[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<byte>(new byte[] { 1, 1, 1, 1, 1, 1, 1 }, new byte[] { 1, 1, 1 });
+            yield return new TestCaseData<byte>(new byte[] { 1, 1, 1, 1, 1, 1, 1 }, new byte[] { 1, 2, 1 });
+            yield return new TestCaseData<byte>(new byte[] { 1, 2, 2, 1, 1, 1, 1 }, new byte[] { 1, 1, 1 });
         }
 
-        private static TestCaseData<RealmInteger<T>> ToInteger<T>(TestCaseData<T> data)
-            where T : struct, IComparable<T>, IFormattable
+        public static IEnumerable<TestCaseData<byte?>> NullableByteTestValues()
         {
-            return new TestCaseData<RealmInteger<T>>(data.InitialValues.ToInteger(), data.OtherCollection.ToInteger());
+            yield return new TestCaseData<byte?>(new byte?[] { 1, 2, 3 }, new byte?[] { 4, 5, 6 });
+            yield return new TestCaseData<byte?>(new byte?[] { 1, 2, 3, null }, new byte?[] { 1, 2, 3, null });
+            yield return new TestCaseData<byte?>(new byte?[] { byte.MinValue, byte.MaxValue }, new byte?[] { 0 });
+            yield return new TestCaseData<byte?>(new byte?[] { 2, 0, 1 }, Array.Empty<byte?>());
+            yield return new TestCaseData<byte?>(Array.Empty<byte?>(), new byte?[] { 0 });
+            yield return new TestCaseData<byte?>(new byte?[] { 4, 6, 8 }, new byte?[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<byte?>(new byte?[] { 1, 1, 1, 1, 1, 1, 1 }, new byte?[] { 1, 1, 1 });
+            yield return new TestCaseData<byte?>(new byte?[] { 1, 1, 1, 1, 1, 1, 1 }, new byte?[] { 1, 2, 1 });
+            yield return new TestCaseData<byte?>(new byte?[] { 1, 2, 2, 1, 1, 1, 1 }, new byte?[] { 1, 1, 1 });
+            yield return new TestCaseData<byte?>(new byte?[] { 1, 2, 2, 1, null, null, null }, new byte?[] { 1, 1, 1, null });
+            yield return new TestCaseData<byte?>(new byte?[] { null }, new byte?[] { null, null });
+            yield return new TestCaseData<byte?>(new byte?[] { null, null }, new byte?[] { null, 6 });
         }
 
-        private static TestCaseData<RealmInteger<T>?> ToInteger<T>(TestCaseData<T?> data)
-            where T : struct, IComparable<T>, IFormattable
+        [TestCaseSource(nameof(ByteTestValues))]
+        public void RealmSet_WhenUnmanaged_Byte(TestCaseData<byte> testData)
         {
-            return new TestCaseData<RealmInteger<T>?>(data.InitialValues.ToInteger(), data.OtherCollection.ToInteger());
+            RunUnmanagedTests(o => o.ByteSet, testData);
         }
+
+        [TestCaseSource(nameof(ByteTestValues))]
+        public void RealmSet_WhenUnmanaged_ByteCounter(TestCaseData<byte> testData)
+        {
+            RunUnmanagedTests(o => o.ByteCounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableByteTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableByte(TestCaseData<byte?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableByteSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableByteTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableByteCounter(TestCaseData<byte?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableByteCounterSet, ToInteger(testData));
+        }
+
+        #endregion
+
+        #region Int16
+
+        public static IEnumerable<TestCaseData<short>> Int16TestValues()
+        {
+            yield return new TestCaseData<short>(new short[] { 1, 2, 3 }, new short[] { 4, 5, 6 });
+            yield return new TestCaseData<short>(new short[] { 1, 2, 3 }, new short[] { 1, 2, 3 });
+            yield return new TestCaseData<short>(new short[] { short.MinValue, short.MaxValue }, new short[] { 0 });
+            yield return new TestCaseData<short>(new short[] { -1, 0, 1 }, Array.Empty<short>());
+            yield return new TestCaseData<short>(Array.Empty<short>(), new short[] { 0 });
+            yield return new TestCaseData<short>(new short[] { 4, 6, 8 }, new short[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<short>(new short[] { 1, 1, 1, 1, 1, 1, 1 }, new short[] { 1, 1, 1 });
+            yield return new TestCaseData<short>(new short[] { 1, 1, 1, 1, 1, 1, 1 }, new short[] { 1, 2, 1 });
+            yield return new TestCaseData<short>(new short[] { 1, 2, 2, 1, 1, 1, 1 }, new short[] { 1, 1, 1 });
+        }
+
+        public static IEnumerable<TestCaseData<short?>> NullableInt16TestValues()
+        {
+            yield return new TestCaseData<short?>(new short?[] { 1, 2, 3 }, new short?[] { 4, 5, 6 });
+            yield return new TestCaseData<short?>(new short?[] { 1, 2, 3, null }, new short?[] { 1, 2, 3, null });
+            yield return new TestCaseData<short?>(new short?[] { short.MinValue, short.MaxValue }, new short?[] { 0 });
+            yield return new TestCaseData<short?>(new short?[] { -1, 0, 1 }, Array.Empty<short?>());
+            yield return new TestCaseData<short?>(Array.Empty<short?>(), new short?[] { 0 });
+            yield return new TestCaseData<short?>(new short?[] { 4, 6, 8 }, new short?[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<short?>(new short?[] { 1, 1, 1, 1, 1, 1, 1 }, new short?[] { 1, 1, 1 });
+            yield return new TestCaseData<short?>(new short?[] { 1, 1, 1, 1, 1, 1, 1 }, new short?[] { 1, 2, 1 });
+            yield return new TestCaseData<short?>(new short?[] { 1, 2, 2, 1, 1, 1, 1 }, new short?[] { 1, 1, 1 });
+            yield return new TestCaseData<short?>(new short?[] { 1, 2, 2, 1, null, null, null }, new short?[] { 1, 1, 1, null });
+            yield return new TestCaseData<short?>(new short?[] { null }, new short?[] { null, null });
+            yield return new TestCaseData<short?>(new short?[] { null, null }, new short?[] { null, 6 });
+        }
+
+        [TestCaseSource(nameof(Int16TestValues))]
+        public void RealmSet_WhenUnmanaged_Int16(TestCaseData<short> testData)
+        {
+            RunUnmanagedTests(o => o.Int16Set, testData);
+        }
+
+        [TestCaseSource(nameof(Int16TestValues))]
+        public void RealmSet_WhenUnmanaged_Int16Counter(TestCaseData<short> testData)
+        {
+            RunUnmanagedTests(o => o.Int16CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableInt16TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt16(TestCaseData<short?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt16Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableInt16TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt16Counter(TestCaseData<short?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt16CounterSet, ToInteger(testData));
+        }
+
+        #endregion
+
+        #region Int32
+
+        public static IEnumerable<TestCaseData<int>> Int32TestValues()
+        {
+            yield return new TestCaseData<int>(new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 });
+            yield return new TestCaseData<int>(new int[] { 1, 2, 3 }, new int[] { 1, 2, 3 });
+            yield return new TestCaseData<int>(new int[] { int.MinValue, int.MaxValue }, new int[] { 0 });
+            yield return new TestCaseData<int>(new int[] { -1, 0, 1 }, Array.Empty<int>());
+            yield return new TestCaseData<int>(Array.Empty<int>(), new int[] { 0 });
+            yield return new TestCaseData<int>(new int[] { 4, 6, 8 }, new int[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<int>(new int[] { 1, 1, 1, 1, 1, 1, 1 }, new int[] { 1, 1, 1 });
+            yield return new TestCaseData<int>(new int[] { 1, 1, 1, 1, 1, 1, 1 }, new int[] { 1, 2, 1 });
+            yield return new TestCaseData<int>(new int[] { 1, 2, 2, 1, 1, 1, 1 }, new int[] { 1, 1, 1 });
+        }
+
+        public static IEnumerable<TestCaseData<int?>> NullableInt32TestValues()
+        {
+            yield return new TestCaseData<int?>(new int?[] { 1, 2, 3 }, new int?[] { 4, 5, 6 });
+            yield return new TestCaseData<int?>(new int?[] { 1, 2, 3, null }, new int?[] { 1, 2, 3, null });
+            yield return new TestCaseData<int?>(new int?[] { int.MinValue, int.MaxValue }, new int?[] { 0 });
+            yield return new TestCaseData<int?>(new int?[] { -1, 0, 1 }, Array.Empty<int?>());
+            yield return new TestCaseData<int?>(Array.Empty<int?>(), new int?[] { 0 });
+            yield return new TestCaseData<int?>(new int?[] { 4, 6, 8 }, new int?[] { 12, 43, 2, 5, 6, 4, 8 });
+            yield return new TestCaseData<int?>(new int?[] { 1, 1, 1, 1, 1, 1, 1 }, new int?[] { 1, 1, 1 });
+            yield return new TestCaseData<int?>(new int?[] { 1, 1, 1, 1, 1, 1, 1 }, new int?[] { 1, 2, 1 });
+            yield return new TestCaseData<int?>(new int?[] { 1, 2, 2, 1, 1, 1, 1 }, new int?[] { 1, 1, 1 });
+            yield return new TestCaseData<int?>(new int?[] { 1, 2, 2, 1, null, null, null }, new int?[] { 1, 1, 1, null });
+            yield return new TestCaseData<int?>(new int?[] { null }, new int?[] { null, null });
+            yield return new TestCaseData<int?>(new int?[] { null, null }, new int?[] { null, 6 });
+        }
+
+        [TestCaseSource(nameof(Int32TestValues))]
+        public void RealmSet_WhenUnmanaged_Int32(TestCaseData<int> testData)
+        {
+            RunUnmanagedTests(o => o.Int32Set, testData);
+        }
+
+        [TestCaseSource(nameof(Int32TestValues))]
+        public void RealmSet_WhenUnmanaged_Int32Counter(TestCaseData<int> testData)
+        {
+            RunUnmanagedTests(o => o.Int32CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableInt32TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt32(TestCaseData<int?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt32Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableInt32TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt32Counter(TestCaseData<int?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt32CounterSet, ToInteger(testData));
+        }
+
+        #endregion
+
+        #region Int64
 
         public static IEnumerable<TestCaseData<long>> Int64TestValues()
         {
@@ -106,6 +269,402 @@ namespace Realms.Tests.Database
             yield return new TestCaseData<long?>(new long?[] { 1, 2, 2, 1, null, null, null }, new long?[] { 1, 1, 1, null });
             yield return new TestCaseData<long?>(new long?[] { null }, new long?[] { null, null });
             yield return new TestCaseData<long?>(new long?[] { null, null }, new long?[] { null, 6 });
+        }
+
+        [TestCaseSource(nameof(Int64TestValues))]
+        public void RealmSet_WhenUnmanaged_Int64(TestCaseData<long> testData)
+        {
+            RunUnmanagedTests(o => o.Int64Set, testData);
+        }
+
+        [TestCaseSource(nameof(Int64TestValues))]
+        public void RealmSet_WhenUnmanaged_Int64Counter(TestCaseData<long> testData)
+        {
+            RunUnmanagedTests(o => o.Int64CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableInt64TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt64(TestCaseData<long?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt64Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableInt64TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableInt64Counter(TestCaseData<long?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableInt64CounterSet, ToInteger(testData));
+        }
+
+        #endregion
+
+        #region Float
+
+        public static IEnumerable<TestCaseData<float>> FloatTestValues()
+        {
+            yield return new TestCaseData<float>(new float[] { 1.1f, 2.2f, 3.3f }, new float[] { 4.4f, 5.5f, 6.6f });
+            yield return new TestCaseData<float>(new float[] { 1, 2.3f, 3 }, new float[] { 1, 2.3f, 3 });
+            yield return new TestCaseData<float>(new float[] { float.MinValue, float.MaxValue }, new float[] { 0 });
+            yield return new TestCaseData<float>(new float[] { -1, 0, 1.5f }, Array.Empty<float>());
+            yield return new TestCaseData<float>(Array.Empty<float>(), new float[] { 0 });
+            yield return new TestCaseData<float>(new float[] { 4, 6.6f, 8 }, new float[] { 12, 43, 2.2f, 5, 6.6f, 4, 8 });
+            yield return new TestCaseData<float>(new float[] { 1, 1, 1, 1, 1, 1, 1.0f }, new float[] { 1, 1, 1 });
+            yield return new TestCaseData<float>(new float[] { 1, 1, 1, 1, 1, 1, 1 }, new float[] { 1.0f, 2, 1.0f });
+            yield return new TestCaseData<float>(new float[] { 1, 2f, 2f, 1, 1, 1, 1 }, new float[] { 1, 1f, 1 });
+        }
+
+        public static IEnumerable<TestCaseData<float?>> NullableFloatTestValues()
+        {
+            yield return new TestCaseData<float?>(new float?[] { 1.1f, 2.2f, 3.3f }, new float?[] { 1.1f, 2.2f, 3.3f });
+            yield return new TestCaseData<float?>(new float?[] { 1, 2.3f, 3, null }, new float?[] { 1, 2.3f, 3, null });
+            yield return new TestCaseData<float?>(new float?[] { float.MinValue, float.MaxValue }, new float?[] { 0 });
+            yield return new TestCaseData<float?>(new float?[] { -1, 0, 1.5f }, Array.Empty<float?>());
+            yield return new TestCaseData<float?>(Array.Empty<float?>(), new float?[] { 0 });
+            yield return new TestCaseData<float?>(new float?[] { 4, 6.6f, 8 }, new float?[] { 12, 43, 2.2f, 5, 6.6f, 4, 8 });
+            yield return new TestCaseData<float?>(new float?[] { 1, 1, 1, 1, 1, 1, 1.0f }, new float?[] { 1, 1, 1 });
+            yield return new TestCaseData<float?>(new float?[] { 1, 1, 1, 1, 1, 1, 1 }, new float?[] { 1.0f, 2, 1.0f });
+            yield return new TestCaseData<float?>(new float?[] { 1, 2, 2, 1, 1, 1, 1 }, new float?[] { 1f, 1f, 1f });
+            yield return new TestCaseData<float?>(new float?[] { 1, 2, 2, 1, null, null, null }, new float?[] { 1.0f, 1.0f, 1.0f, null });
+            yield return new TestCaseData<float?>(new float?[] { null }, new float?[] { null, null });
+            yield return new TestCaseData<float?>(new float?[] { null, null }, new float?[] { null, 6 });
+        }
+
+        [TestCaseSource(nameof(FloatTestValues))]
+        public void RealmSet_WhenUnmanaged_Float(TestCaseData<float> testData)
+        {
+            RunUnmanagedTests(o => o.SingleSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableFloatTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableFloat(TestCaseData<float?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableSingleSet, testData);
+        }
+
+        #endregion
+
+        #region Double
+
+        public static IEnumerable<TestCaseData<double>> DoubleTestValues()
+        {
+            yield return new TestCaseData<double>(new double[] { 1.1, 2.2, 3.3 }, new double[] { 4.4, 5.5, 6.6 });
+            yield return new TestCaseData<double>(new double[] { 1, 2.3, 3 }, new double[] { 1, 2.3, 3 });
+            yield return new TestCaseData<double>(new double[] { double.MinValue, double.MaxValue }, new double[] { 0 });
+            yield return new TestCaseData<double>(new double[] { -1, 0, 1.5 }, Array.Empty<double>());
+            yield return new TestCaseData<double>(Array.Empty<double>(), new double[] { 0 });
+            yield return new TestCaseData<double>(new double[] { 4, 6.6, 8 }, new double[] { 12, 43, 2.2, 5, 6.6, 4, 8 });
+            yield return new TestCaseData<double>(new double[] { 1, 1, 1, 1, 1, 1, 1.0 }, new double[] { 1, 1, 1 });
+            yield return new TestCaseData<double>(new double[] { 1, 1, 1, 1, 1, 1, 1 }, new double[] { 1.0, 2, 1.0 });
+            yield return new TestCaseData<double>(new double[] { 1, 2, 2, 1, 1, 1, 1 }, new double[] { 1, 1, 1 });
+        }
+
+        public static IEnumerable<TestCaseData<double?>> NullableDoubleTestValues()
+        {
+            yield return new TestCaseData<double?>(new double?[] { 1.1, 2.2, 3.3 }, new double?[] { 1.1, 2.2, 3.3 });
+            yield return new TestCaseData<double?>(new double?[] { 1, 2.3, 3, null }, new double?[] { 1, 2.3, 3, null });
+            yield return new TestCaseData<double?>(new double?[] { double.MinValue, double.MaxValue }, new double?[] { 0 });
+            yield return new TestCaseData<double?>(new double?[] { -1, 0, 1.5 }, Array.Empty<double?>());
+            yield return new TestCaseData<double?>(Array.Empty<double?>(), new double?[] { 0 });
+            yield return new TestCaseData<double?>(new double?[] { 4, 6.6, 8 }, new double?[] { 12, 43, 2.2, 5, 6.6, 4, 8 });
+            yield return new TestCaseData<double?>(new double?[] { 1, 1, 1, 1, 1, 1, 1.0 }, new double?[] { 1, 1, 1 });
+            yield return new TestCaseData<double?>(new double?[] { 1, 1, 1, 1, 1, 1, 1 }, new double?[] { 1.0, 2, 1.0 });
+            yield return new TestCaseData<double?>(new double?[] { 1, 2, 2, 1, 1, 1, 1 }, new double?[] { 1, 1, 1 });
+            yield return new TestCaseData<double?>(new double?[] { 1, 2, 2, 1, null, null, null }, new double?[] { 1.0, 1.0, 1.0, null });
+            yield return new TestCaseData<double?>(new double?[] { null }, new double?[] { null, null });
+            yield return new TestCaseData<double?>(new double?[] { null, null }, new double?[] { null, 6 });
+        }
+
+        [TestCaseSource(nameof(DoubleTestValues))]
+        public void RealmSet_WhenUnmanaged_Double(TestCaseData<double> testData)
+        {
+            RunUnmanagedTests(o => o.DoubleSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDoubleTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableDouble(TestCaseData<double?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableDoubleSet, testData);
+        }
+
+        #endregion
+
+        #region Decimal
+
+        public static IEnumerable<TestCaseData<decimal>> DecimalTestValues()
+        {
+            yield return new TestCaseData<decimal>(new decimal[] { 1.1m, 2.2m, 3.3m }, new decimal[] { 4.4m, 5.5m, 6.6m });
+            yield return new TestCaseData<decimal>(new decimal[] { 1, 2.3m, 3 }, new decimal[] { 1, 2.3m, 3 });
+            yield return new TestCaseData<decimal>(new decimal[] { decimal.MinValue, decimal.MaxValue }, new decimal[] { 0 });
+            yield return new TestCaseData<decimal>(new decimal[] { -1, 0, 1.5m }, Array.Empty<decimal>());
+            yield return new TestCaseData<decimal>(Array.Empty<decimal>(), new decimal[] { 0 });
+            yield return new TestCaseData<decimal>(new decimal[] { 4, 6.6m, 8 }, new decimal[] { 12, 43, 2.2m, 5, 6.6m, 4, 8 });
+            yield return new TestCaseData<decimal>(new decimal[] { 1, 1, 1, 1, 1, 1, 1.0m }, new decimal[] { 1, 1, 1 });
+            yield return new TestCaseData<decimal>(new decimal[] { 1, 1, 1, 1, 1, 1, 1 }, new decimal[] { 1.0m, 2, 1.0m });
+            yield return new TestCaseData<decimal>(new decimal[] { 1, 2, 2, 1, 1, 1, 1 }, new decimal[] { 1, 1, 1 });
+            yield return new TestCaseData<decimal>(new decimal[] { 1.9357683758257382523m }, new decimal[] { 1.9357683758257382524m, 1.9357683758257382522m });
+            yield return new TestCaseData<decimal>(new decimal[] { 1.9357683758257382523m, 3.5743857348m, 8.75878832943928m }, new decimal[] { 1.9357683758257382523m, 8.75878832943928m });
+        }
+
+        public static IEnumerable<TestCaseData<decimal?>> NullableDecimalTestValues()
+        {
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1.1m, 2.2m, 3.3m }, new decimal?[] { 4.4m, 5.5m, 6.6m });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1, 2.3m, 3, null }, new decimal?[] { 1, 2.3m, 3, null });
+            yield return new TestCaseData<decimal?>(new decimal?[] { decimal.MinValue, decimal.MaxValue }, new decimal?[] { 0 });
+            yield return new TestCaseData<decimal?>(new decimal?[] { -1, 0, 1.5m }, Array.Empty<decimal?>());
+            yield return new TestCaseData<decimal?>(Array.Empty<decimal?>(), new decimal?[] { 0 });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 4, 6.6m, 8 }, new decimal?[] { 12, 43, 2.2m, 5, 6.6m, 4, 8 });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1, 1, 1, 1, 1, 1, 1.0m }, new decimal?[] { 1, 1, 1 });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1, 1, 1, 1, 1, 1, 1 }, new decimal?[] { 1.0m, 2, 1.0m });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1, 2, 2, 1, 1, 1, 1 }, new decimal?[] { 1, 1, 1 });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1, 2, 2, 1, null, null, null }, new decimal?[] { 1.0m, 1.0m, 1.0m, null });
+            yield return new TestCaseData<decimal?>(new decimal?[] { null }, new decimal?[] { null, null });
+            yield return new TestCaseData<decimal?>(new decimal?[] { null, null }, new decimal?[] { null, 6 });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1.9357683758257382523m }, new decimal?[] { 1.9357683758257382524m, 1.9357683758257382522m });
+            yield return new TestCaseData<decimal?>(new decimal?[] { 1.9357683758257382523m, null, 8.75878832943928m }, new decimal?[] { 1.9357683758257382523m, 8.75878832943928m });
+        }
+
+        [TestCaseSource(nameof(DecimalTestValues))]
+        public void RealmSet_WhenUnmanaged_Decimal(TestCaseData<decimal> testData)
+        {
+            RunUnmanagedTests(o => o.DecimalSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDecimalTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableDecimal(TestCaseData<decimal?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableDecimalSet, testData);
+        }
+
+        #endregion
+
+        #region Decimal128
+
+        public static IEnumerable<TestCaseData<Decimal128>> Decimal128TestValues()
+        {
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1.1m, 2.2m, 3.3m }, new Decimal128[] { 4.4m, 5.5m, 6.6m });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 2.3m, 3 }, new Decimal128[] { 1, 2.3m, 3 });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { Decimal128.MinValue, Decimal128.MaxValue }, new Decimal128[] { 0 });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { -1, 0, 1.5m }, Array.Empty<Decimal128>());
+            yield return new TestCaseData<Decimal128>(Array.Empty<Decimal128>(), new Decimal128[] { 0 });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 4, 6.6m, 8 }, new Decimal128[] { 12, 43, 2.2m, 5, 6.6m, 4, 8 });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1.0m }, new Decimal128[] { 1, 1, 1 });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128[] { 1.0m, 2, 1.0m });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 2, 2, 1, 1, 1, 1 }, new Decimal128[] { 1, 1, 1 });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1.9357683758257382523m }, new Decimal128[] { 1.9357683758257382524m, 1.9357683758257382522m });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1.9357683758257382523m, 3.5743857348m, 8.75878832943928m }, new Decimal128[] { 1.9357683758257382523m, 8.75878832943928m });
+        }
+
+        public static IEnumerable<TestCaseData<Decimal128?>> NullableDecimal128TestValues()
+        {
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1.1m, 2.2m, 3.3m }, new Decimal128?[] { 4.4m, 5.5m, 6.6m });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 2.3m, 3, null }, new Decimal128?[] { 1, 2.3m, 3, null });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { Decimal128.MinValue, Decimal128.MaxValue }, new Decimal128?[] { 0 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { -1, 0, 1.5m }, Array.Empty<Decimal128?>());
+            yield return new TestCaseData<Decimal128?>(Array.Empty<Decimal128?>(), new Decimal128?[] { 0 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 4, 6.6m, 8 }, new Decimal128?[] { 12, 43, 2.2m, 5, 6.6m, 4, 8 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1.0m }, new Decimal128?[] { 1, 1, 1 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128?[] { 1.0m, 2, 1.0m });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 2, 2, 1, 1, 1, 1 }, new Decimal128?[] { 1, 1, 1 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 2, 2, 1, null, null, null }, new Decimal128?[] { 1.0m, 1.0m, 1.0m, null });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { null }, new Decimal128?[] { null, null });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { null, null }, new Decimal128?[] { null, 6 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1.9357683758257382523m }, new Decimal128?[] { 1.9357683758257382524m, 1.9357683758257382522m });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1.9357683758257382523m, null, 8.75878832943928m }, new Decimal128?[] { 1.9357683758257382523m, 8.75878832943928m });
+        }
+
+        [TestCaseSource(nameof(Decimal128TestValues))]
+        public void RealmSet_WhenUnmanaged_Decimal128(TestCaseData<Decimal128> testData)
+        {
+            RunUnmanagedTests(o => o.Decimal128Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDecimal128TestValues))]
+        public void RealmSet_WhenUnmanaged_NullableDecimal128(TestCaseData<Decimal128?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableDecimal128Set, testData);
+        }
+
+        #endregion
+
+        #region ObjectId
+
+        private static readonly ObjectId ObjectId0 = TestHelpers.GenerateRepetitiveObjectId(0);
+        private static readonly ObjectId ObjectId1 = TestHelpers.GenerateRepetitiveObjectId(1);
+        private static readonly ObjectId ObjectId2 = TestHelpers.GenerateRepetitiveObjectId(2);
+        private static readonly ObjectId ObjectId3 = TestHelpers.GenerateRepetitiveObjectId(3);
+        private static readonly ObjectId ObjectId4 = TestHelpers.GenerateRepetitiveObjectId(4);
+        private static readonly ObjectId ObjectId5 = TestHelpers.GenerateRepetitiveObjectId(5);
+        private static readonly ObjectId ObjectId6 = TestHelpers.GenerateRepetitiveObjectId(6);
+        private static readonly ObjectId ObjectIdMax = TestHelpers.GenerateRepetitiveObjectId(3);
+
+        public static IEnumerable<TestCaseData<ObjectId>> ObjectIdTestValues()
+        {
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectId1, ObjectId2, ObjectId3 }, new ObjectId[] { ObjectId4, ObjectId5, ObjectId6 });
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectId1, ObjectId2, ObjectId3 }, new ObjectId[] { ObjectId1, ObjectId2, ObjectId3 });
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectIdMax }, new ObjectId[] { ObjectId0 });
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectId0, ObjectId1, ObjectIdMax }, Array.Empty<ObjectId>());
+            yield return new TestCaseData<ObjectId>(Array.Empty<ObjectId>(), new ObjectId[] { ObjectId0 });
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectId1, ObjectId2 }, new ObjectId[] { ObjectIdMax, ObjectId.GenerateNewId(), ObjectId1, ObjectId2, ObjectId3, ObjectId2 });
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1 }, new ObjectId[] { ObjectId1, ObjectId1 });
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1 }, new ObjectId[] { ObjectId1, ObjectId2 });
+            yield return new TestCaseData<ObjectId>(new ObjectId[] { ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId2, ObjectId2 }, new ObjectId[] { ObjectId1, ObjectId1 });
+        }
+
+        public static IEnumerable<TestCaseData<ObjectId?>> NullableObjectIdTestValues()
+        {
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId1, ObjectId2, ObjectId3 }, new ObjectId?[] { ObjectId4, ObjectId5, ObjectId6 });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId1, ObjectId2, ObjectId3, null }, new ObjectId?[] { ObjectId1, ObjectId2, ObjectId3, null });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectIdMax }, new ObjectId?[] { ObjectId0 });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId0, ObjectId1, ObjectIdMax }, Array.Empty<ObjectId?>());
+            yield return new TestCaseData<ObjectId?>(Array.Empty<ObjectId?>(), new ObjectId?[] { ObjectId0 });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId1, ObjectId2 }, new ObjectId?[] { ObjectIdMax, ObjectId.GenerateNewId(), ObjectId1, ObjectId2, ObjectId3, ObjectId2 });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1 }, new ObjectId?[] { ObjectId1, ObjectId1 });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId1 }, new ObjectId?[] { ObjectId1, ObjectId2 });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId1, ObjectId1, ObjectId1, ObjectId1, ObjectId2, ObjectId2 }, new ObjectId?[] { ObjectId1, ObjectId1 });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { ObjectId1, ObjectId2, ObjectId1, ObjectId2, null, null, null }, new ObjectId?[] { ObjectId1, ObjectId1, null });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { null }, new ObjectId?[] { null, null });
+            yield return new TestCaseData<ObjectId?>(new ObjectId?[] { null, null }, new ObjectId?[] { null, ObjectId6 });
+        }
+
+        [TestCaseSource(nameof(ObjectIdTestValues))]
+        public void RealmSet_WhenUnmanaged_ObjectId(TestCaseData<ObjectId> testData)
+        {
+            RunUnmanagedTests(o => o.ObjectIdSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableObjectIdTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableObjectId(TestCaseData<ObjectId?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableObjectIdSet, testData);
+        }
+
+        #endregion
+
+        #region DateTimeOffset
+
+        private static readonly DateTimeOffset Date0 = new DateTimeOffset(0, TimeSpan.Zero);
+        private static readonly DateTimeOffset Date1 = new DateTimeOffset(1999, 3, 4, 5, 30, 0, TimeSpan.Zero);
+        private static readonly DateTimeOffset Date2 = new DateTimeOffset(2030, 1, 3, 9, 25, 34, TimeSpan.FromHours(3));
+        private static readonly DateTimeOffset Date3 = new DateTimeOffset(2000, 9, 7, 12, 39, 24, TimeSpan.FromHours(12));
+        private static readonly DateTimeOffset Date4 = new DateTimeOffset(1975, 6, 9, 11, 59, 59, TimeSpan.Zero);
+        private static readonly DateTimeOffset Date5 = new DateTimeOffset(2034, 12, 24, 4, 0, 14, TimeSpan.FromHours(-3));
+        private static readonly DateTimeOffset Date6 = new DateTimeOffset(2020, 10, 11, 19, 17, 10, TimeSpan.Zero);
+
+        public static IEnumerable<TestCaseData<DateTimeOffset>> DateTimeOffsetTestValues()
+        {
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { Date1, Date2, Date3 }, new DateTimeOffset[] { Date4, Date5, Date6 });
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { Date1, Date2, Date3 }, new DateTimeOffset[] { Date1, Date2, Date3 });
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { DateTimeOffset.MaxValue, DateTimeOffset.MinValue }, new DateTimeOffset[] { Date0 });
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { Date0, Date1, DateTimeOffset.MaxValue }, Array.Empty<DateTimeOffset>());
+            yield return new TestCaseData<DateTimeOffset>(Array.Empty<DateTimeOffset>(), new DateTimeOffset[] { Date0 });
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { Date1, Date2 }, new DateTimeOffset[] { DateTimeOffset.MaxValue, DateTimeOffset.UtcNow, Date1, Date2, Date3, Date2 });
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { Date1, Date1, Date1, Date1, Date1, Date1, Date1 }, new DateTimeOffset[] { Date1, Date1 });
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { Date1, Date1, Date1, Date1, Date1, Date1, Date1 }, new DateTimeOffset[] { Date1, Date2 });
+            yield return new TestCaseData<DateTimeOffset>(new DateTimeOffset[] { Date1, Date1, Date1, Date1, Date2, Date2 }, new DateTimeOffset[] { Date1, Date1 });
+        }
+
+        public static IEnumerable<TestCaseData<DateTimeOffset?>> NullableDateTimeOffsetTestValues()
+        {
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date1, Date2, Date3 }, new DateTimeOffset?[] { Date4, Date5, Date6 });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date1, Date2, Date3, null }, new DateTimeOffset?[] { Date1, Date2, Date3, null });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { DateTimeOffset.MaxValue, DateTimeOffset.MinValue }, new DateTimeOffset?[] { Date0 });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date0, Date1, DateTimeOffset.MaxValue }, Array.Empty<DateTimeOffset?>());
+            yield return new TestCaseData<DateTimeOffset?>(Array.Empty<DateTimeOffset?>(), new DateTimeOffset?[] { Date0 });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date1, Date2 }, new DateTimeOffset?[] { DateTimeOffset.MaxValue, DateTimeOffset.UtcNow, Date1, Date2, Date3, Date2 });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date1, Date1, Date1, Date1, Date1, Date1, Date1 }, new DateTimeOffset?[] { Date1, Date1 });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date1, Date1, Date1, Date1, Date1, Date1, Date1 }, new DateTimeOffset?[] { Date1, Date2 });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date1, Date1, Date1, Date1, Date2, Date2 }, new DateTimeOffset?[] { Date1, Date1 });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { Date1, Date2, Date1, Date2, null, null, null }, new DateTimeOffset?[] { Date1, Date1, null });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { null }, new DateTimeOffset?[] { null, null });
+            yield return new TestCaseData<DateTimeOffset?>(new DateTimeOffset?[] { null, null }, new DateTimeOffset?[] { null, Date6 });
+        }
+
+        [TestCaseSource(nameof(DateTimeOffsetTestValues))]
+        public void RealmSet_WhenUnmanaged_DateTimeOffset(TestCaseData<DateTimeOffset> testData)
+        {
+            RunUnmanagedTests(o => o.DateTimeOffsetSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDateTimeOffsetTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableDateTimeOffset(TestCaseData<DateTimeOffset?> testData)
+        {
+            RunUnmanagedTests(o => o.NullableDateTimeOffsetSet, testData);
+        }
+
+        #endregion
+
+        #region String
+
+        public static IEnumerable<TestCaseData<string>> StringTestValues()
+        {
+            yield return new TestCaseData<string>(new string[] { "a", "b", "c" }, new string[] { "d", "e", "f" });
+            yield return new TestCaseData<string>(new string[] { "a", "b", "c" }, new string[] { "a", "b", "c" });
+            yield return new TestCaseData<string>(new string[] { "bla bla bla", string.Empty }, new string[] { " " });
+            yield return new TestCaseData<string>(new string[] { " ", "a", "bla bla bla" }, Array.Empty<string>());
+            yield return new TestCaseData<string>(Array.Empty<string>(), new string[] { " " });
+            yield return new TestCaseData<string>(new string[] { "a", "b" }, new string[] { "bla bla bla", "a", "b", "c", "b" });
+            yield return new TestCaseData<string>(new string[] { "a", "a", "a", "a", "a", "a", "a" }, new string[] { "a", "a" });
+            yield return new TestCaseData<string>(new string[] { "a", "a", "a", "a", "a", "a", "a" }, new string[] { "a", "b" });
+            yield return new TestCaseData<string>(new string[] { "a", "a", "a", "a", "b", "b" }, new string[] { "a", "a" });
+        }
+
+        public static IEnumerable<TestCaseData<string>> NullableStringTestValues()
+        {
+            yield return new TestCaseData<string>(new string[] { "a", "b", "c" }, new string[] { "d", "e", "f" });
+            yield return new TestCaseData<string>(new string[] { "a", "b", "c", null }, new string[] { "a", "b", "c", null });
+            yield return new TestCaseData<string>(new string[] { "bla bla bla" }, new string[] { " " });
+            yield return new TestCaseData<string>(new string[] { " ", "a", "bla bla bla" }, Array.Empty<string>());
+            yield return new TestCaseData<string>(Array.Empty<string>(), new string[] { " " });
+            yield return new TestCaseData<string>(new string[] { "a", "b" }, new string[] { "bla bla bla", "a", "b", "c", "b" });
+            yield return new TestCaseData<string>(new string[] { "a", "a", "a", "a", "a", "a", "a" }, new string[] { "a", "a" });
+            yield return new TestCaseData<string>(new string[] { "a", "a", "a", "a", "a", "a", "a" }, new string[] { "a", "b" });
+            yield return new TestCaseData<string>(new string[] { "a", "a", "a", "a", "b", "b" }, new string[] { "a", "a" });
+            yield return new TestCaseData<string>(new string[] { "a", "b", "a", "b", null, null, null }, new string[] { "a", "a", null });
+            yield return new TestCaseData<string>(new string[] { null }, new string[] { null, null });
+            yield return new TestCaseData<string>(new string[] { null, null }, new string[] { null, "f" });
+        }
+
+        [TestCaseSource(nameof(StringTestValues))]
+        public void RealmSet_WhenUnmanaged_String(TestCaseData<string> testData)
+        {
+            RunUnmanagedTests(o => o.StringSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableStringTestValues))]
+        public void RealmSet_WhenUnmanaged_NullableString(TestCaseData<string> testData)
+        {
+            RunUnmanagedTests(o => o.NullableStringSet, testData);
+        }
+
+        #endregion
+
+
+        private static void RunUnmanagedTests<T>(Func<SetsObject, ISet<T>> accessor, TestCaseData<T> testData)
+        {
+            var testObject = new SetsObject();
+            var set = accessor(testObject);
+
+            testData.AssertCount(set);
+            testData.AssertExceptWith(set);
+            testData.AssertIntersectWith(set);
+            testData.AssertIsProperSubsetOf(set);
+            testData.AssertIsProperSupersetOf(set);
+            testData.AssertIsSubsetOf(set);
+            testData.AssertIsSupersetOf(set);
+            testData.AssertOverlaps(set);
+            testData.AssertSymmetricExceptWith(set);
+            testData.AssertUnionWith(set);
+        }
+
+        private static TestCaseData<RealmInteger<T>> ToInteger<T>(TestCaseData<T> data)
+            where T : struct, IComparable<T>, IFormattable
+        {
+            return new TestCaseData<RealmInteger<T>>(data.InitialValues.ToInteger(), data.OtherCollection.ToInteger());
+        }
+
+        private static TestCaseData<RealmInteger<T>?> ToInteger<T>(TestCaseData<T?> data)
+            where T : struct, IComparable<T>, IFormattable
+        {
+            return new TestCaseData<RealmInteger<T>?>(data.InitialValues.ToInteger(), data.OtherCollection.ToInteger());
         }
 
         public class TestCaseData<T>

--- a/Tests/Realm.Tests/Database/TestObjects.cs
+++ b/Tests/Realm.Tests/Database/TestObjects.cs
@@ -185,7 +185,10 @@ namespace Realms.Tests
 
         public ISet<ObjectId> ObjectIdSet { get; }
 
+        [Required]
         public ISet<string> StringSet { get; }
+
+        public ISet<string> NullableStringSet { get; }
 
         public ISet<byte[]> ByteArraySet { get; }
 

--- a/Tests/Realm.Tests/Database/TestObjects.cs
+++ b/Tests/Realm.Tests/Database/TestObjects.cs
@@ -161,6 +161,77 @@ namespace Realms.Tests
         public IList<RealmInteger<long>?> NullableInt64CounterList { get; }
     }
 
+    public class SetsObject : RealmObject
+    {
+        public ISet<char> CharSet { get; }
+
+        public ISet<byte> ByteSet { get; }
+
+        public ISet<short> Int16Set { get; }
+
+        public ISet<int> Int32Set { get; }
+
+        public ISet<long> Int64Set { get; }
+
+        public ISet<float> SingleSet { get; }
+
+        public ISet<double> DoubleSet { get; }
+
+        public ISet<bool> BooleanSet { get; }
+
+        public ISet<decimal> DecimalSet { get; }
+
+        public ISet<Decimal128> Decimal128Set { get; }
+
+        public ISet<ObjectId> ObjectIdSet { get; }
+
+        public ISet<string> StringSet { get; }
+
+        public ISet<byte[]> ByteArraySet { get; }
+
+        public ISet<DateTimeOffset> DateTimeOffsetSet { get; }
+
+        public ISet<char?> NullableCharSet { get; }
+
+        public ISet<byte?> NullableByteSet { get; }
+
+        public ISet<short?> NullableInt16Set { get; }
+
+        public ISet<int?> NullableInt32Set { get; }
+
+        public ISet<long?> NullableInt64Set { get; }
+
+        public ISet<float?> NullableSingleSet { get; }
+
+        public ISet<double?> NullableDoubleSet { get; }
+
+        public ISet<bool?> NullableBooleanSet { get; }
+
+        public ISet<DateTimeOffset?> NullableDateTimeOffsetSet { get; }
+
+        public ISet<decimal?> NullableDecimalSet { get; }
+
+        public ISet<Decimal128?> NullableDecimal128Set { get; }
+
+        public ISet<ObjectId?> NullableObjectIdSet { get; }
+
+        public ISet<RealmInteger<byte>> ByteCounterSet { get; }
+
+        public ISet<RealmInteger<short>> Int16CounterSet { get; }
+
+        public ISet<RealmInteger<int>> Int32CounterSet { get; }
+
+        public ISet<RealmInteger<long>> Int64CounterSet { get; }
+
+        public ISet<RealmInteger<byte>?> NullableByteCounterSet { get; }
+
+        public ISet<RealmInteger<short>?> NullableInt16CounterSet { get; }
+
+        public ISet<RealmInteger<int>?> NullableInt32CounterSet { get; }
+
+        public ISet<RealmInteger<long>?> NullableInt64CounterSet { get; }
+    }
+
     public class CounterObject : RealmObject
     {
         [PrimaryKey]

--- a/Tests/Realm.Tests/TestHelpers.cs
+++ b/Tests/Realm.Tests/TestHelpers.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;
+using MongoDB.Bson;
 using Nito.AsyncEx;
 using NUnit.Framework;
 using Realms.Helpers;
@@ -139,6 +140,8 @@ namespace Realms.Tests
 
             return false;
         }
+
+        public static ObjectId GenerateRepetitiveObjectId(byte value) => new ObjectId(Enumerable.Range(0, 12).Select(_ => value).ToArray());
 
         public static RealmInteger<T>[] ToInteger<T>(this T[] values)
             where T : struct, IComparable<T>, IFormattable

--- a/Tests/Weaver/AssemblyToProcess/ClassWithStaticProperty.cs
+++ b/Tests/Weaver/AssemblyToProcess/ClassWithStaticProperty.cs
@@ -16,7 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-using System;
 using Realms;
 
 namespace AssemblyToProcess
@@ -27,35 +26,6 @@ namespace AssemblyToProcess
     {
         public string Name { get; set; }
 
-        private static readonly Dog myDog = new Dog();
-
-        public static Dog MyOnlyDog
-        {
-            get
-            {
-                Console.WriteLine("");
-                return myDog;
-
-                // if (myDog != null)
-                // {
-                //     return myDog;
-                // }
-                // var dogs = Realm.GetInstance().All<Dog>();
-                // if (dogs.Count() == 0)
-                // {
-                //     Realm.GetInstance().Write(() =>
-                //     {
-                //         var dog = Realm.GetInstance().CreateObject<Dog>();
-                //         dog.Name = "my precious";
-                //         myDog = dog;
-                //     });
-                // }
-                // else
-                // {
-                //     myDog = dogs.First();
-                // }
-                // return myDog;
-            }
-        }
+        public static Dog MyOnlyDog { get; } = new Dog();
     }
 }

--- a/Tests/Weaver/AssemblyToProcess/ClassWithStaticProperty.cs
+++ b/Tests/Weaver/AssemblyToProcess/ClassWithStaticProperty.cs
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+using System;
 using Realms;
 
 namespace AssemblyToProcess
@@ -26,12 +27,13 @@ namespace AssemblyToProcess
     {
         public string Name { get; set; }
 
-        private static Dog myDog;
+        private static readonly Dog myDog = new Dog();
 
         public static Dog MyOnlyDog
         {
             get
             {
+                Console.WriteLine("");
                 return myDog;
 
                 // if (myDog != null)

--- a/Tests/Weaver/AssemblyToProcess/TestObjects.cs
+++ b/Tests/Weaver/AssemblyToProcess/TestObjects.cs
@@ -165,6 +165,95 @@ namespace AssemblyToProcess
     }
 
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class SetsObject : RealmObject
+    {
+        public ISet<char> CharSet { get; }
+
+        public ISet<byte> ByteSet { get; }
+
+        public ISet<short> Int16Set { get; }
+
+        public ISet<int> Int32Set { get; }
+
+        public ISet<long> Int64Set { get; }
+
+        public ISet<float> SingleSet { get; }
+
+        public ISet<double> DoubleSet { get; }
+
+        public ISet<bool> BooleanSet { get; }
+
+        public ISet<string> StringSet { get; }
+
+        public ISet<DateTimeOffset> DateTimeOffsetSet { get; }
+
+        public ISet<decimal> DecimalSet { get; }
+
+        public ISet<Decimal128> Decimal128Set { get; }
+
+        public ISet<ObjectId> ObjectIdSet { get; }
+
+        public ISet<char?> NullableCharSet { get; }
+
+        public ISet<byte?> NullableByteSet { get; }
+
+        public ISet<short?> NullableInt16Set { get; }
+
+        public ISet<int?> NullableInt32Set { get; }
+
+        public ISet<long?> NullableInt64Set { get; }
+
+        public ISet<float?> NullableSingleSet { get; }
+
+        public ISet<double?> NullableDoubleSet { get; }
+
+        public ISet<bool?> NullableBooleanSet { get; }
+
+        public ISet<DateTimeOffset?> NullableDateTimeOffsetSet { get; }
+
+        public ISet<decimal?> NullableDecimalSet { get; }
+
+        public ISet<Decimal128?> NullableDecimal128Set { get; }
+
+        public ISet<ObjectId?> NullableObjectIdSet { get; }
+
+        public ISet<RealmInteger<byte>> ByteCounterSet { get; }
+
+        public ISet<RealmInteger<short>> Int16CounterSet { get; }
+
+        public ISet<RealmInteger<int>> Int32CounterSet { get; }
+
+        public ISet<RealmInteger<long>> Int64CounterSet { get; }
+
+        public ISet<RealmInteger<byte>?> NullableByteCounterSet { get; }
+
+        public ISet<RealmInteger<short>?> NullableInt16CounterSet { get; }
+
+        public ISet<RealmInteger<int>?> NullableInt32CounterSet { get; }
+
+        public ISet<RealmInteger<long>?> NullableInt64CounterSet { get; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
+    public class MixOfCollectionsObject : RealmObject
+    {
+        [PrimaryKey]
+        public ObjectId Id { get; set; }
+
+        public IList<int> IntegersList { get; }
+
+        public IList<AllTypesObject> ObjectList { get; }
+
+        public IList<EmbeddedAllTypesObject> EmbeddedList { get; }
+
+        public ISet<int> IntegersSet { get; }
+
+        public ISet<AllTypesObject> ObjectSet { get; }
+
+        public ISet<EmbeddedAllTypesObject> EmbeddedSet { get; }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
     public class PrimaryKeyCharObject : RealmObject
     {
         [PrimaryKey]

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmList.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmList.cs
@@ -22,7 +22,7 @@ using System.Collections.Generic;
 
 namespace Realms
 {
-    internal class RealmList<T> : IList<T> where T : RealmObject
+    internal class RealmList<T> : IList<T>
     {
         public IEnumerator<T> GetEnumerator()
         {

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
@@ -108,10 +108,16 @@ namespace Realms
             LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
         }
 
-        protected IList<T> GetListValue<T>(string propertyName) where T : RealmObject
+        protected IList<T> GetListValue<T>(string propertyName)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
             return new RealmList<T>();
+        }
+
+        protected ISet<T> GetSetValue<T>(string propertyName)
+        {
+            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
+            return new RealmSet<T>();
         }
 
         protected void SetListValue<T>(string propertyName, IList<T> value) where T : RealmObject

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
@@ -65,7 +65,7 @@ namespace Realms
             }
         }
 
-        private Realm _realm;
+        private readonly Realm _realm = new Realm();
 
         public Realm Realm
         {

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmSet.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmSet.cs
@@ -1,0 +1,121 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Realms
+{
+    internal class RealmSet<T> : ISet<T>
+    {
+        public int Count => throw new NotImplementedException();
+
+        public bool IsReadOnly => throw new NotImplementedException();
+
+        public bool Add(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ExceptWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void IntersectWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSubsetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSupersetOf(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SymmetricExceptWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UnionWith(IEnumerable<T> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        void ICollection<T>.Add(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmSet.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmSet.cs
@@ -1,6 +1,6 @@
 ﻿////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2020 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -135,9 +135,9 @@ REALM_EXPORT void list_add_primitive(List& list, PrimitiveValue& value, NativeEx
     });
 }
 
-REALM_EXPORT void list_add_string(List& list, uint16_t* value, size_t value_len, bool has_value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_add_string(List& list, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
 {
-    if (has_value) {
+    if (value != nullptr) {
         Utf16StringAccessor str(value, value_len);
         add(list, (StringData)str, ex);
     }
@@ -228,9 +228,9 @@ REALM_EXPORT void list_set_primitive(List& list, size_t list_ndx, PrimitiveValue
     });
 }
 
-REALM_EXPORT void list_set_string(List& list, size_t list_ndx, uint16_t* value, size_t value_len, bool has_value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_set_string(List& list, size_t list_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
 {
-    if (has_value) {
+    if (value != nullptr) {
         Utf16StringAccessor str(value, value_len);
         set(list, list_ndx, (StringData)str, ex);
     }
@@ -326,9 +326,9 @@ REALM_EXPORT void list_insert_primitive(List& list, size_t list_ndx, PrimitiveVa
     });
 }
 
-REALM_EXPORT void list_insert_string(List& list, size_t list_ndx, uint16_t* value, size_t value_len, bool has_value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_insert_string(List& list, size_t list_ndx, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
 {
-    if (has_value) {
+    if (value != nullptr) {
         Utf16StringAccessor str(value, value_len);
         insert(list, list_ndx, (StringData)str, ex);
     }
@@ -437,9 +437,9 @@ REALM_EXPORT size_t list_find_primitive(List& list, PrimitiveValue& value, Nativ
     });
 }
 
-REALM_EXPORT size_t list_find_string(List& list, uint16_t* value, size_t value_len, bool has_value, NativeException::Marshallable& ex)
+REALM_EXPORT size_t list_find_string(List& list, uint16_t* value, size_t value_len, NativeException::Marshallable& ex)
 {
-    if (has_value) {
+    if (value != nullptr) {
         Utf16StringAccessor str(value, value_len);
         return find(list, (StringData)str, ex);
     }


### PR DESCRIPTION
## Description

This is part 1 of https://github.com/realm/realm-dotnet/issues/2099. It stubs the .NET implementation and adds weaver support. It also implements some the Set methods for unmanaged collections, but is not wired up to the native set.

Fixes https://github.com/realm/realm-dotnet/issues/2064.
Fixes https://github.com/realm/realm-dotnet/issues/2089.