### PR TITLE
Simplified WriteAsync code

### DIFF
--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -789,7 +789,6 @@ namespace Realms
         /// <returns>An awaitable <see cref="Task"/> with return type <typeparamref name="T"/>.</returns>
         public async Task<T> WriteAsync<T>(Func<Realm, T> function)
         {
-            // Can't use async/await due to mono inliner bugs
             ThrowIfDisposed();
 
             Argument.NotNull(function, nameof(function));
@@ -861,7 +860,6 @@ namespace Realms
         public async Task<IQueryable<T>> WriteAsync<T>(Func<Realm, IQueryable<T>> function)
             where T : RealmObjectBase
         {
-            // Can't use async/await due to mono inliner bugs
             ThrowIfDisposed();
 
             Argument.NotNull(function, nameof(function));
@@ -934,7 +932,6 @@ namespace Realms
         /// <returns>An awaitable <see cref="Task"/> with return type <see cref="IList{T}"/>.</returns>
         public async Task<IList<T>> WriteAsync<T>(Func<Realm, IList<T>> function)
         {
-            // Can't use async/await due to mono inliner bugs
             ThrowIfDisposed();
 
             Argument.NotNull(function, nameof(function));

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -748,11 +748,11 @@ namespace Realms
         /// Action to execute inside a <see cref="Transaction"/>, creating, updating, or removing objects.
         /// </param>
         /// <returns>An awaitable <see cref="Task"/>.</returns>
-        public async Task WriteAsync(Action<Realm> action)
+        public Task WriteAsync(Action<Realm> action)
         {
             Argument.NotNull(action, nameof(action));
 
-            await WriteAsync(tempRealm =>
+            return WriteAsync(tempRealm =>
             {
                 action(tempRealm);
                 return true;


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description
Simplifies code for `WriteAsync` methods, using `async/await`. This was not done in the past due to a mono bug.

https://github.com/realm/realm-dotnet/blob/6228b00777793780a24e0348c0d6ad6cc85cc43e/Realm/Realm/Realm.cs#L712-L743

Fixes #2088 
