### PR TITLE
Removed passing pointer

### DIFF
--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -33,10 +33,8 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_object", CallingConvention = CallingConvention.Cdecl)]
             public static extern void add_object(ListHandle listHandle, ObjectHandle objectHandle, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_primitive(ListHandle listHandle, IntPtr value, out NativeException ex);
+            public static extern void add_primitive(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern void add_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLength, out NativeException ex);
@@ -55,10 +53,8 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_object", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_object(ListHandle listHandle, IntPtr targetIndex, ObjectHandle objectHandle, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void set_primitive(ListHandle listHandle, IntPtr targetIndex, IntPtr value, out NativeException ex);
+            public static extern void set_primitive(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_string(ListHandle listHandle, IntPtr targetIndex, [MarshalAs(UnmanagedType.LPWStr)] string value,
@@ -78,10 +74,8 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_object", CallingConvention = CallingConvention.Cdecl)]
             public static extern void insert_object(ListHandle listHandle, IntPtr targetIndex, ObjectHandle objectHandle, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void insert_primitive(ListHandle listHandle, IntPtr targetIndex, IntPtr value, out NativeException ex);
+            public static extern void insert_primitive(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern void insert_string(ListHandle listHandle, IntPtr targetIndex, [MarshalAs(UnmanagedType.LPWStr)] string value,
@@ -119,10 +113,8 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_object", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr find_object(ListHandle listHandle, ObjectHandle objectHandle, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr find_primitive(ListHandle listHandle, IntPtr value, out NativeException ex);
+            public static extern IntPtr find_primitive(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr find_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
@@ -222,8 +214,7 @@ namespace Realms
 
         public unsafe void Add(PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.add_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.add_primitive(this, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
@@ -258,8 +249,7 @@ namespace Realms
 
         public unsafe void Set(int targetIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.set_primitive(this, (IntPtr)targetIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.set_primitive(this, (IntPtr)targetIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
@@ -294,8 +284,7 @@ namespace Realms
 
         public unsafe void Insert(int targetIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.insert_primitive(this, (IntPtr)targetIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.insert_primitive(this, (IntPtr)targetIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
@@ -331,8 +320,7 @@ namespace Realms
 
         public unsafe int Find(PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            var result = NativeMethods.find_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            var result = NativeMethods.find_primitive(this, value, out var nativeException);
             nativeException.ThrowIfNecessary();
             return (int)result;
         }

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -45,10 +45,8 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern void get_primitive(ObjectHandle handle, IntPtr propertyIndex, ref PrimitiveValue value, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_set_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void set_primitive(ObjectHandle handle, IntPtr propertyIndex, IntPtr value, out NativeException ex);
+            public static extern void set_primitive(ObjectHandle handle, IntPtr propertyIndex, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_set_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_string(ObjectHandle handle, IntPtr propertyIndex,
@@ -190,8 +188,7 @@ namespace Realms
 
         public unsafe void SetPrimitive(IntPtr propertyIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.set_primitive(this, propertyIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.set_primitive(this, propertyIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Realm/Realm/Handles/QueryHandle.cs
+++ b/Realm/Realm/Handles/QueryHandle.cs
@@ -71,22 +71,22 @@ namespace Realms
             // primitive is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
             // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
+            public static extern void primitive_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_not_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
+            public static extern void primitive_not_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_less", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_less(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
+            public static extern void primitive_less(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_less_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_less_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
+            public static extern void primitive_less_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_greater", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_greater(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
+            public static extern void primitive_greater(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_greater_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_greater_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
+            public static extern void primitive_greater_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_object_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void query_object_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, ObjectHandle objectHandle, out NativeException ex);
@@ -205,37 +205,43 @@ namespace Realms
 
         public unsafe void PrimitiveEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            NativeMethods.primitive_equal(this, realm, propertyIndex, value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            NativeMethods.primitive_not_equal(this, realm, propertyIndex, value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_not_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveLess(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            NativeMethods.primitive_less(this, realm, propertyIndex, value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_less(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveLessEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            NativeMethods.primitive_less_equal(this, realm, propertyIndex, value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_less_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveGreater(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            NativeMethods.primitive_greater(this, realm, propertyIndex, value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_greater(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveGreaterEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            NativeMethods.primitive_greater_equal(this, realm, propertyIndex, value, out var nativeException);
+            PrimitiveValue* valuePtr = &value;
+            NativeMethods.primitive_greater_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Realm/Realm/Handles/QueryHandle.cs
+++ b/Realm/Realm/Handles/QueryHandle.cs
@@ -68,8 +68,6 @@ namespace Realms
             public static extern void string_like(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
                         [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
 
-            // primitive is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void primitive_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 

--- a/Realm/Realm/Handles/QueryHandle.cs
+++ b/Realm/Realm/Handles/QueryHandle.cs
@@ -71,22 +71,22 @@ namespace Realms
             // primitive is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
             // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
+            public static extern void primitive_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_not_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
+            public static extern void primitive_not_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_less", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_less(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
+            public static extern void primitive_less(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_less_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_less_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
+            public static extern void primitive_less_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_greater", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_greater(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
+            public static extern void primitive_greater(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_greater_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void primitive_greater_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr primitive, out NativeException ex);
+            public static extern void primitive_greater_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_object_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void query_object_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, ObjectHandle objectHandle, out NativeException ex);
@@ -205,43 +205,37 @@ namespace Realms
 
         public unsafe void PrimitiveEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.primitive_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.primitive_equal(this, realm, propertyIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.primitive_not_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.primitive_not_equal(this, realm, propertyIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveLess(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.primitive_less(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.primitive_less(this, realm, propertyIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveLessEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.primitive_less_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.primitive_less_equal(this, realm, propertyIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveGreater(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.primitive_greater(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.primitive_greater(this, realm, propertyIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void PrimitiveGreaterEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            NativeMethods.primitive_greater_equal(this, realm, propertyIndex, new IntPtr(valuePtr), out var nativeException);
+            NativeMethods.primitive_greater_equal(this, realm, propertyIndex, value, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -81,11 +81,9 @@ namespace Realms
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool add_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_primitive", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool add_primitive(SetHandle handle, IntPtr value, out NativeException ex);
+            public static extern bool add_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_string", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -108,11 +106,9 @@ namespace Realms
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool contains_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_primitive", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool contains_primitive(SetHandle handle, IntPtr value, out NativeException ex);
+            public static extern bool contains_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_string", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -131,11 +127,9 @@ namespace Realms
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool remove_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_primitive", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool remove_primitive(SetHandle handle, IntPtr value, out NativeException ex);
+            public static extern bool remove_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_string", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -261,8 +255,7 @@ namespace Realms
 
         public unsafe bool Add(PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            var result = NativeMethods.add_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            var result = NativeMethods.add_primitive(this, value, out var nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }
@@ -303,8 +296,7 @@ namespace Realms
 
         public unsafe bool Contains(PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            var result = NativeMethods.contains_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            var result = NativeMethods.contains_primitive(this, value, out var nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }
@@ -340,8 +332,7 @@ namespace Realms
 
         public unsafe bool Remove(PrimitiveValue value)
         {
-            PrimitiveValue* valuePtr = &value;
-            var result = NativeMethods.remove_primitive(this, new IntPtr(valuePtr), out var nativeException);
+            var result = NativeMethods.remove_primitive(this, value, out var nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -133,10 +133,8 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_create_object", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr create_object(SharedRealmHandle sharedRealm, TableHandle table, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_create_object_primitive_unique", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr create_object_unique(SharedRealmHandle sharedRealm, TableHandle table, IntPtr value,
+            public static extern IntPtr create_object_unique(SharedRealmHandle sharedRealm, TableHandle table, PrimitiveValue value,
                                                              [MarshalAs(UnmanagedType.U1)] bool update,
                                                              [MarshalAs(UnmanagedType.U1)] out bool is_new, out NativeException ex);
 
@@ -413,8 +411,7 @@ namespace Realms
                     throw new NotSupportedException($"Unexpected primary key of type: {pkProperty.Type}");
             }
 
-            PrimitiveValue* valuePtr = &primitiveValue;
-            var result = NativeMethods.create_object_unique(this, table, new IntPtr(valuePtr), update, out isNew, out var ex);
+            var result = NativeMethods.create_object_unique(this, table, primitiveValue, update, out isNew, out var ex);
             ex.ThrowIfNecessary();
             return new ObjectHandle(this, result);
         }

--- a/Realm/Realm/Handles/SyncUserHandle.cs
+++ b/Realm/Realm/Handles/SyncUserHandle.cs
@@ -112,28 +112,20 @@ namespace Realms.Sync
                 [MarshalAs(UnmanagedType.LPWStr)] string name, IntPtr name_len,
                 IntPtr tcs_ptr, out NativeException ex);
 
-            // id is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_api_key_fetch", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void fetch_api_key(SyncUserHandle handle, AppHandle app, IntPtr id, IntPtr tcs_ptr, out NativeException ex);
+            public static extern void fetch_api_key(SyncUserHandle handle, AppHandle app, PrimitiveValue id, IntPtr tcs_ptr, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_api_key_fetch_all", CallingConvention = CallingConvention.Cdecl)]
             public static extern void fetch_api_keys(SyncUserHandle handle, AppHandle app, IntPtr tcs_ptr, out NativeException ex);
 
-            // id is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_api_key_delete", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void delete_api_key(SyncUserHandle handle, AppHandle app, IntPtr id, IntPtr tcs_ptr, out NativeException ex);
+            public static extern void delete_api_key(SyncUserHandle handle, AppHandle app, PrimitiveValue id, IntPtr tcs_ptr, out NativeException ex);
 
-            // id is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_api_key_disable", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void disable_api_key(SyncUserHandle handle, AppHandle app, IntPtr id, IntPtr tcs_ptr, out NativeException ex);
+            public static extern void disable_api_key(SyncUserHandle handle, AppHandle app, PrimitiveValue id, IntPtr tcs_ptr, out NativeException ex);
 
-            // id is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_syncuser_api_key_enable", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void enable_api_key(SyncUserHandle handle, AppHandle app, IntPtr id, IntPtr tcs_ptr, out NativeException ex);
+            public static extern void enable_api_key(SyncUserHandle handle, AppHandle app, PrimitiveValue id, IntPtr tcs_ptr, out NativeException ex);
 
             #endregion
 
@@ -308,8 +300,7 @@ namespace Realms.Sync
         {
             var tcsHandle = GCHandle.Alloc(tcs);
             var primitiveId = PrimitiveValue.ObjectId(id);
-            PrimitiveValue* idPtr = &primitiveId;
-            NativeMethods.fetch_api_key(this, app, new IntPtr(idPtr), GCHandle.ToIntPtr(tcsHandle), out var ex);
+            NativeMethods.fetch_api_key(this, app, primitiveId, GCHandle.ToIntPtr(tcsHandle), out var ex);
             ex.ThrowIfNecessary(tcsHandle);
         }
 
@@ -324,8 +315,7 @@ namespace Realms.Sync
         {
             var tcsHandle = GCHandle.Alloc(tcs);
             var primitiveId = PrimitiveValue.ObjectId(id);
-            PrimitiveValue* idPtr = &primitiveId;
-            NativeMethods.delete_api_key(this, app, new IntPtr(idPtr), GCHandle.ToIntPtr(tcsHandle), out var ex);
+            NativeMethods.delete_api_key(this, app, primitiveId, GCHandle.ToIntPtr(tcsHandle), out var ex);
             ex.ThrowIfNecessary(tcsHandle);
         }
 
@@ -333,8 +323,7 @@ namespace Realms.Sync
         {
             var tcsHandle = GCHandle.Alloc(tcs);
             var primitiveId = PrimitiveValue.ObjectId(id);
-            PrimitiveValue* idPtr = &primitiveId;
-            NativeMethods.disable_api_key(this, app, new IntPtr(idPtr), GCHandle.ToIntPtr(tcsHandle), out var ex);
+            NativeMethods.disable_api_key(this, app, primitiveId, GCHandle.ToIntPtr(tcsHandle), out var ex);
             ex.ThrowIfNecessary(tcsHandle);
         }
 
@@ -342,8 +331,7 @@ namespace Realms.Sync
         {
             var tcsHandle = GCHandle.Alloc(tcs);
             var primitiveId = PrimitiveValue.ObjectId(id);
-            PrimitiveValue* idPtr = &primitiveId;
-            NativeMethods.enable_api_key(this, app, new IntPtr(idPtr), GCHandle.ToIntPtr(tcsHandle), out var ex);
+            NativeMethods.enable_api_key(this, app, primitiveId, GCHandle.ToIntPtr(tcsHandle), out var ex);
             ex.ThrowIfNecessary(tcsHandle);
         }
 

--- a/Realm/Realm/Handles/TableHandle.cs
+++ b/Realm/Realm/Handles/TableHandle.cs
@@ -42,10 +42,8 @@ namespace Realms
             public static extern IntPtr get_object_for_string_primarykey(TableHandle handle, SharedRealmHandle realmHandle,
                 [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
 
-            // value is IntPtr rather than PrimitiveValue due to a bug in .NET Core on Linux and Mac
-            // that causes incorrect marshalling of the struct.
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_get_object_for_primitive_primarykey", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_object_for_primitive_primarykey(TableHandle handle, SharedRealmHandle realmHandle, IntPtr value, out NativeException ex);
+            public static extern IntPtr get_object_for_primitive_primarykey(TableHandle handle, SharedRealmHandle realmHandle, PrimitiveValue value, out NativeException ex);
 
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore SA1121 // Use built-in type alias
@@ -90,8 +88,7 @@ namespace Realms
 
         public unsafe bool TryFind(SharedRealmHandle realmHandle, PrimitiveValue id, out ObjectHandle objectHandle)
         {
-            PrimitiveValue* valuePtr = &id;
-            var result = NativeMethods.get_object_for_primitive_primarykey(this, realmHandle, new IntPtr(valuePtr), out var ex);
+            var result = NativeMethods.get_object_for_primitive_primarykey(this, realmHandle, id, out var ex);
             return TryFindCore(realmHandle, result, ex, out objectHandle);
         }
 

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -80,7 +80,7 @@ REALM_EXPORT void list_add_object(List& list, const Object& object_ptr, NativeEx
     });
 }
 
-REALM_EXPORT void list_add_primitive(List& list, PrimitiveValue& value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_add_primitive(List& list, PrimitiveValue value, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
 #pragma GCC diagnostic push
@@ -168,7 +168,7 @@ REALM_EXPORT void list_set_object(List& list, size_t list_ndx, const Object& obj
     set(list, list_ndx, object_ptr.obj(), ex);
 }
 
-REALM_EXPORT void list_set_primitive(List& list, size_t list_ndx, PrimitiveValue& value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_set_primitive(List& list, size_t list_ndx, PrimitiveValue value, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         const size_t count = list.size();
@@ -266,7 +266,7 @@ REALM_EXPORT void list_insert_object(List& list, size_t list_ndx, const Object& 
     insert(list, list_ndx, object_ptr.obj(), ex);
 }
 
-REALM_EXPORT void list_insert_primitive(List& list, size_t list_ndx, PrimitiveValue& value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_insert_primitive(List& list, size_t list_ndx, PrimitiveValue value, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         const size_t count = list.size();
@@ -396,7 +396,7 @@ REALM_EXPORT size_t list_find_object(List& list, const Object& object_ptr, Nativ
     });
 }
 
-REALM_EXPORT size_t list_find_primitive(List& list, PrimitiveValue& value, NativeException::Marshallable& ex)
+REALM_EXPORT size_t list_find_primitive(List& list, PrimitiveValue value, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
 #pragma GCC diagnostic push

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -191,7 +191,7 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT void object_set_primitive(const Object& object, size_t property_ndx, PrimitiveValue& value, NativeException::Marshallable& ex)
+    REALM_EXPORT void object_set_primitive(const Object& object, size_t property_ndx, PrimitiveValue value, NativeException::Marshallable& ex)
     {
         handle_errors(ex, [&]() {
             verify_can_set(object);

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -124,7 +124,7 @@ REALM_EXPORT void query_string_like(Query& query, SharedRealm& realm, size_t pro
     });
 }
 
-REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -170,7 +170,7 @@ REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t
     });
 }
 
-REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -217,7 +217,7 @@ REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, si
     });
 }
 
-REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -263,7 +263,7 @@ REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t 
     });
 }
 
-REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -309,7 +309,7 @@ REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, s
     });
 }
 
-REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -355,7 +355,7 @@ REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size
     });
 }
 
-REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -124,7 +124,7 @@ REALM_EXPORT void query_string_like(Query& query, SharedRealm& realm, size_t pro
     });
 }
 
-REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -170,7 +170,7 @@ REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t
     });
 }
 
-REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -217,7 +217,7 @@ REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, si
     });
 }
 
-REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -263,7 +263,7 @@ REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t 
     });
 }
 
-REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -309,7 +309,7 @@ REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, s
     });
 }
 
-REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {
@@ -355,7 +355,7 @@ REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size
     });
 }
 
-REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue& primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         if (!primitive.has_value) {

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -398,7 +398,7 @@ REALM_EXPORT Object* shared_realm_create_object(SharedRealm& realm, TableRef& ta
     });
 }
 
-REALM_EXPORT Object* shared_realm_create_object_primitive_unique(const SharedRealm& realm, TableRef& table, PrimitiveValue& primitive, bool try_update, bool& is_new, NativeException::Marshallable& ex)
+REALM_EXPORT Object* shared_realm_create_object_primitive_unique(const SharedRealm& realm, TableRef& table, PrimitiveValue primitive, bool try_update, bool& is_new, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
         switch (primitive.type) {

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -348,7 +348,7 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_fetch(SharedSyncUser& user, SharedApp& app, PrimitiveValue& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_fetch(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(to_object_id(id), user, [tcs_ptr](App::UserAPIKey api_key, util::Optional<AppError> err) {
@@ -366,21 +366,21 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_delete(SharedSyncUser& user, SharedApp& app, PrimitiveValue& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_delete(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().delete_api_key(to_object_id(id), user, get_callback_handler(tcs_ptr));
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_disable(SharedSyncUser& user, SharedApp& app, PrimitiveValue& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_disable(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().disable_api_key(to_object_id(id), user, get_callback_handler(tcs_ptr));
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_enable(SharedSyncUser& user, SharedApp& app, PrimitiveValue& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_enable(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().enable_api_key(to_object_id(id), user, get_callback_handler(tcs_ptr));

--- a/wrappers/src/table_cs.cpp
+++ b/wrappers/src/table_cs.cpp
@@ -96,7 +96,7 @@ REALM_EXPORT Object* table_get_object(TableRef& table, SharedRealm& realm, ObjKe
     });
 }
 
-REALM_EXPORT Object* table_get_object_for_primitive_primarykey(TableRef& table, SharedRealm& realm, PrimitiveValue& primitive, NativeException::Marshallable& ex)
+REALM_EXPORT Object* table_get_object_for_primitive_primarykey(TableRef& table, SharedRealm& realm, PrimitiveValue primitive, NativeException::Marshallable& ex)
 {
     if (!primitive.has_value) {
         return get_object_for_primarykey(table, realm, null{}, ex);


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description
Avoid passing `PrimitiveValue` as pointer. It was done like that due to a bug in .NET Core for macOS/Linux.

Fixes #2062 
