### PR TITLE
Migrate to Mixed for property access

### DIFF
--- a/Realm - Windows.sln
+++ b/Realm - Windows.sln
@@ -52,6 +52,7 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ObjectStore", "wrappers\cmake\Windows\Debug-Win32\realm-core\src\realm\object-store\ObjectStore.vcxproj", "{692AD7D4-B10C-3877-B59D-9988A1AA8B0F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerformanceTests", "Tests\PerformanceTests\PerformanceTests.csproj", "{8BDA672B-C40A-41DE-A114-D9E77452ABAB}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RealmFFI", "wrappers\cmake\Windows\Debug-Win32\realm-core\src\realm\object-store\c_api\RealmFFI.vcxproj", "{3DB4A5D8-5C3F-32FE-8506-73564694B274}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -665,6 +666,34 @@ Global
 		{8BDA672B-C40A-41DE-A114-D9E77452ABAB}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 		{8BDA672B-C40A-41DE-A114-D9E77452ABAB}.RelWithDebInfo|x86.ActiveCfg = Release|Any CPU
 		{8BDA672B-C40A-41DE-A114-D9E77452ABAB}.RelWithDebInfo|x86.Build.0 = Release|Any CPU
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|ARM.ActiveCfg = Debug|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|iPhone.ActiveCfg = Debug|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|iPhoneSimulator.ActiveCfg = Debug|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|x64.ActiveCfg = Debug|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|x86.ActiveCfg = Debug|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|x86.Build.0 = Debug|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|Any CPU.ActiveCfg = MinSizeRel|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|ARM.ActiveCfg = MinSizeRel|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|iPhone.ActiveCfg = MinSizeRel|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|iPhoneSimulator.ActiveCfg = MinSizeRel|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|x64.ActiveCfg = MinSizeRel|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|x86.ActiveCfg = MinSizeRel|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|x86.Build.0 = MinSizeRel|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|Any CPU.ActiveCfg = Release|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|ARM.ActiveCfg = Release|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|iPhone.ActiveCfg = Release|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|iPhoneSimulator.ActiveCfg = Release|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|x64.ActiveCfg = Release|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|x86.ActiveCfg = Release|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|x86.Build.0 = Release|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|Any CPU.ActiveCfg = RelWithDebInfo|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|ARM.ActiveCfg = RelWithDebInfo|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|iPhone.ActiveCfg = RelWithDebInfo|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|iPhoneSimulator.ActiveCfg = RelWithDebInfo|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|x64.ActiveCfg = RelWithDebInfo|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|x86.ActiveCfg = RelWithDebInfo|Win32
+		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|x86.Build.0 = RelWithDebInfo|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Realm - Windows.sln
+++ b/Realm - Windows.sln
@@ -52,7 +52,6 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ObjectStore", "wrappers\cmake\Windows\Debug-Win32\realm-core\src\realm\object-store\ObjectStore.vcxproj", "{692AD7D4-B10C-3877-B59D-9988A1AA8B0F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerformanceTests", "Tests\PerformanceTests\PerformanceTests.csproj", "{8BDA672B-C40A-41DE-A114-D9E77452ABAB}"
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RealmFFI", "wrappers\cmake\Windows\Debug-Win32\realm-core\src\realm\object-store\c_api\RealmFFI.vcxproj", "{3DB4A5D8-5C3F-32FE-8506-73564694B274}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -666,34 +665,6 @@ Global
 		{8BDA672B-C40A-41DE-A114-D9E77452ABAB}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 		{8BDA672B-C40A-41DE-A114-D9E77452ABAB}.RelWithDebInfo|x86.ActiveCfg = Release|Any CPU
 		{8BDA672B-C40A-41DE-A114-D9E77452ABAB}.RelWithDebInfo|x86.Build.0 = Release|Any CPU
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|ARM.ActiveCfg = Debug|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|iPhone.ActiveCfg = Debug|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|iPhoneSimulator.ActiveCfg = Debug|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|x64.ActiveCfg = Debug|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|x86.ActiveCfg = Debug|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Debug|x86.Build.0 = Debug|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|Any CPU.ActiveCfg = MinSizeRel|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|ARM.ActiveCfg = MinSizeRel|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|iPhone.ActiveCfg = MinSizeRel|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|iPhoneSimulator.ActiveCfg = MinSizeRel|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|x64.ActiveCfg = MinSizeRel|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|x86.ActiveCfg = MinSizeRel|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.MinSizeRel|x86.Build.0 = MinSizeRel|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|Any CPU.ActiveCfg = Release|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|ARM.ActiveCfg = Release|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|iPhone.ActiveCfg = Release|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|iPhoneSimulator.ActiveCfg = Release|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|x64.ActiveCfg = Release|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|x86.ActiveCfg = Release|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.Release|x86.Build.0 = Release|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|Any CPU.ActiveCfg = RelWithDebInfo|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|ARM.ActiveCfg = RelWithDebInfo|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|iPhone.ActiveCfg = RelWithDebInfo|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|iPhoneSimulator.ActiveCfg = RelWithDebInfo|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|x64.ActiveCfg = RelWithDebInfo|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|x86.ActiveCfg = RelWithDebInfo|Win32
-		{3DB4A5D8-5C3F-32FE-8506-73564694B274}.RelWithDebInfo|x86.Build.0 = RelWithDebInfo|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Realm/Realm.Fody/Realm.Fody.csproj
+++ b/Realm/Realm.Fody/Realm.Fody.csproj
@@ -15,7 +15,7 @@
   <ItemGroup Label="References">
     <PackageReference Include="FodyHelpers" Version="6.*" PrivateAssets="All" />
     <PackageReference Include="System.Management" Version="4.5.0" PrivateAssets="Build;Compile;Runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Realm/Realm.Unity/Editor/Common/ImportedReferences.cs
+++ b/Realm/Realm.Unity/Editor/Common/ImportedReferences.cs
@@ -99,10 +99,6 @@ namespace RealmWeaver
 
         public MethodReference RealmObject_RaisePropertyChanged { get; private set; }
 
-        public MethodReference RealmObject_GetObjectValue { get; private set; }
-
-        public MethodReference RealmObject_SetObjectValue { get; private set; }
-
         public MethodReference RealmObject_GetListValue { get; private set; }
 
         public MethodReference RealmObject_GetSetValue { get; private set; }
@@ -289,22 +285,6 @@ namespace RealmWeaver
                 HasThis = true,
                 Parameters = { new ParameterDefinition(Types.String) }
             };
-
-            {
-                RealmObject_GetObjectValue = new MethodReference("GetObjectValue", Types.Void, RealmObjectBase) { HasThis = true };
-                var T = new GenericParameter(RealmObject_GetObjectValue) { Constraints = { new GenericParameterConstraint(RealmObjectBase) } };
-                RealmObject_GetObjectValue.ReturnType = T;
-                RealmObject_GetObjectValue.GenericParameters.Add(T);
-                RealmObject_GetObjectValue.Parameters.Add(new ParameterDefinition(Types.String));
-            }
-
-            {
-                RealmObject_SetObjectValue = new MethodReference("SetObjectValue", Types.Void, RealmObjectBase) { HasThis = true };
-                var T = new GenericParameter(RealmObject_SetObjectValue) { Constraints = { new GenericParameterConstraint(RealmObjectBase) } };
-                RealmObject_SetObjectValue.GenericParameters.Add(T);
-                RealmObject_SetObjectValue.Parameters.Add(new ParameterDefinition(Types.String));
-                RealmObject_SetObjectValue.Parameters.Add(new ParameterDefinition(T));
-            }
 
             {
                 RealmObject_GetListValue = new MethodReference("GetListValue", new GenericInstanceType(IListOfT), RealmObjectBase) { HasThis = true };

--- a/Realm/Realm.Unity/Editor/Common/RealmWeaver.Schema.cs
+++ b/Realm/Realm.Unity/Editor/Common/RealmWeaver.Schema.cs
@@ -182,7 +182,7 @@ namespace RealmWeaver
 
             // Attempt to filter out Unity assemblies - we're adding the Version(0.0.0.0)
             // as a best effort attempt to avoid filtering out legitimate user assemblies.
-            if (assembly.Name == "UnityEditor" || assembly.Name.StartsWith("UnityEngine") || assembly.Name.StartsWith("Unity."))
+            if (assembly.Name == "UnityEditor" || assembly.Name.StartsWith("UnityEngine", StringComparison.OrdinalIgnoreCase) || assembly.Name.StartsWith("Unity.", StringComparison.OrdinalIgnoreCase))
             {
                 return assembly.Version == default(Version);
             }

--- a/Realm/Realm.Unity/Editor/Common/RealmWeaver.cs
+++ b/Realm/Realm.Unity/Editor/Common/RealmWeaver.cs
@@ -61,34 +61,24 @@ namespace RealmWeaver
         internal const string NullableDateTimeOffsetTypeName = "System.Nullable`1<System.DateTimeOffset>";
         internal const string NullableObjectIdTypeName = "System.Nullable`1<MongoDB.Bson.ObjectId>";
 
-        private static readonly Dictionary<string, string> _typeTable = new Dictionary<string, string>
+        private static readonly HashSet<string> _primitiveValueTypes = new HashSet<string>
         {
-            { StringTypeName, "String" },
-            { ByteArrayTypeName, "ByteArray" },
-        };
-
-        private static readonly Dictionary<string, string> _primitiveValueTypes = new Dictionary<string, string>
-        {
-            { CharTypeName, "Int" },
-            { SingleTypeName, "Float" },
-            { DoubleTypeName, "Double" },
-            { BooleanTypeName, "Bool" },
-            { DecimalTypeName, "Decimal" },
-            { Decimal128TypeName, "Decimal" },
-            { ObjectIdTypeName, "ObjectId" },
-            { DateTimeOffsetTypeName, "Date" },
-            { NullableCharTypeName, "NullableInt" },
-            { NullableSingleTypeName, "NullableFloat" },
-            { NullableDoubleTypeName, "NullableDouble" },
-            { NullableBooleanTypeName, "NullableBool" },
-            { NullableDateTimeOffsetTypeName, "NullableDate" },
-            { NullableDecimalTypeName, "NullableDecimal" },
-            { NullableDecimal128TypeName, "NullableDecimal" },
-            { NullableObjectIdTypeName, "NullableObjectId" },
-        };
-
-        private static readonly IEnumerable<string> _realmIntegerBackedTypes = new[]
-        {
+            CharTypeName,
+            SingleTypeName,
+            DoubleTypeName,
+            BooleanTypeName,
+            DecimalTypeName,
+            Decimal128TypeName,
+            ObjectIdTypeName,
+            DateTimeOffsetTypeName,
+            NullableCharTypeName,
+            NullableSingleTypeName,
+            NullableDoubleTypeName,
+            NullableBooleanTypeName,
+            NullableDateTimeOffsetTypeName,
+            NullableDecimalTypeName,
+            NullableDecimal128TypeName,
+            NullableObjectIdTypeName,
             ByteTypeName,
             Int16TypeName,
             Int32TypeName,
@@ -104,7 +94,9 @@ namespace RealmWeaver
             $"System.Nullable`1<Realms.RealmInteger`1<{ByteTypeName}>>",
             $"System.Nullable`1<Realms.RealmInteger`1<{Int16TypeName}>>",
             $"System.Nullable`1<Realms.RealmInteger`1<{Int32TypeName}>>",
-            $"System.Nullable`1<Realms.RealmInteger`1<{Int64TypeName}>>"
+            $"System.Nullable`1<Realms.RealmInteger`1<{Int64TypeName}>>",
+            ByteArrayTypeName,
+            StringTypeName
         };
 
         private static readonly IEnumerable<string> _primaryKeyTypes = new[]
@@ -374,20 +366,7 @@ Analytics payload
                 return WeavePropertyResult.Error($"{type.Name}.{prop.Name} has [Backlink] applied, but is not IQueryable.");
             }
 
-            if (_typeTable.ContainsKey(prop.PropertyType.FullName))
-            {
-                // If the property is automatic but doesn't have a setter, we should still ignore it.
-                if (prop.SetMethod == null)
-                {
-                    return WeavePropertyResult.Skipped();
-                }
-
-                var realmAccessors = GetAccessors(prop.PropertyType, isPrimaryKey, methodTable);
-
-                ReplaceGetter(prop, columnName, realmAccessors.Getter);
-                ReplaceSetter(prop, backingField, columnName, realmAccessors.Setter);
-            }
-            else if (_primitiveValueTypes.TryGetValue(prop.PropertyType.FullName, out var propertyType))
+            if (_primitiveValueTypes.Contains(prop.PropertyType.FullName))
             {
                 if (prop.SetMethod == null)
                 {
@@ -399,98 +378,19 @@ Analytics payload
 
                 if (!methodTable.TryGetValue(typeId, out var accessors))
                 {
-                    var getter = new GenericInstanceMethod(_references.RealmObject_GetPrimitiveValue) { GenericArguments = { prop.PropertyType } };
-                    var setter = new GenericInstanceMethod(isPrimaryKey ? _references.RealmObject_SetPrimitiveValueUnique : _references.RealmObject_SetPrimitiveValue)
-                    {
-                        GenericArguments = { prop.PropertyType }
-                    };
+                    var getter = _references.RealmObject_GetValue;
+                    var setter = isPrimaryKey ? _references.RealmObject_SetValueUnique : _references.RealmObject_SetValue;
                     methodTable[typeId] = accessors = new Accessors { Getter = getter, Setter = setter };
                 }
 
-                var propertyTypeRef = _references.GetPropertyTypeField(propertyType);
-                ReplaceGetter(prop, columnName, accessors.Getter, propertyTypeRef);
-                ReplaceSetter(prop, backingField, columnName, accessors.Setter, propertyTypeRef);
-            }
-            else if (_realmIntegerBackedTypes.Contains(prop.PropertyType.FullName))
-            {
-                // If the property is automatic but doesn't have a setter, we should still ignore it.
-                if (prop.SetMethod == null)
-                {
-                    return WeavePropertyResult.Skipped();
-                }
-
-                if (!prop.PropertyType.IsRealmInteger(out var isNullable, out var integerType))
-                {
-                    isNullable = prop.PropertyType.IsNullable();
-                    if (isNullable)
-                    {
-                        var genericType = (GenericInstanceType)prop.PropertyType;
-                        integerType = genericType.GenericArguments.Single();
-                    }
-                    else
-                    {
-                        integerType = prop.PropertyType;
-                    }
-                }
-
-                var prefix = isNullable ? "Nullable" : string.Empty;
-                var suffix = isPrimaryKey ? "Unique" : string.Empty;
-
-                var typeId = $"{prefix}{integerType.FullName}{suffix}";
-                if (!methodTable.TryGetValue(typeId, out var accessors))
-                {
-                    var genericGetter = new MethodReference($"Get{prefix}RealmIntegerValue", _moduleDefinition.TypeSystem.Void, _references.RealmObjectBase)
-                    {
-                        HasThis = true,
-                        Parameters = { new ParameterDefinition(_moduleDefinition.TypeSystem.String) }
-                    };
-
-                    var getterGenericParameter = _references.GetRealmIntegerGenericParameter(genericGetter);
-                    genericGetter.GenericParameters.Add(getterGenericParameter);
-
-                    var returnType = _references.RealmIntegerOfT.MakeGenericInstanceType(getterGenericParameter);
-                    if (isNullable)
-                    {
-                        returnType = _references.System_NullableOfT.MakeGenericInstanceType(returnType);
-                    }
-
-                    genericGetter.ReturnType = returnType;
-
-                    var genericSetter = new MethodReference($"Set{prefix}RealmIntegerValue{suffix}", _moduleDefinition.TypeSystem.Void, _references.RealmObjectBase)
-                    {
-                        HasThis = true,
-                        Parameters =
-                    {
-                        new ParameterDefinition(_moduleDefinition.TypeSystem.String),
-                    }
-                    };
-
-                    var setterGenericParameter = _references.GetRealmIntegerGenericParameter(genericSetter);
-                    genericSetter.GenericParameters.Add(setterGenericParameter);
-
-                    var parameterType = _references.RealmIntegerOfT.MakeGenericInstanceType(setterGenericParameter);
-                    if (isNullable)
-                    {
-                        parameterType = _references.System_NullableOfT.MakeGenericInstanceType(parameterType);
-                    }
-
-                    genericSetter.Parameters.Add(new ParameterDefinition(parameterType));
-
-                    var getter = new GenericInstanceMethod(genericGetter) { GenericArguments = { integerType } };
-                    var setter = new GenericInstanceMethod(genericSetter) { GenericArguments = { integerType } };
-                    methodTable[typeId] = accessors = new Accessors { Getter = getter, Setter = setter };
-                }
-
-                ReplaceRealmIntegerGetter(prop, columnName, accessors.Getter, isNullable, integerType);
-                ReplaceRealmIntegerSetter(prop, backingField, columnName, accessors.Setter, isNullable, integerType);
+                ReplaceGetter(prop, columnName, accessors.Getter, implicitConvert: true);
+                ReplaceSetter(prop, backingField, columnName, accessors.Setter, implicitConvert: true);
             }
             else if (prop.IsCollection(out var collectionType))
             {
                 var elementType = ((GenericInstanceType)prop.PropertyType).GenericArguments.Single();
                 if (!elementType.Resolve().IsValidRealmObjectBaseInheritor(_references) &&
-                    !_realmIntegerBackedTypes.Contains(elementType.FullName) &&
-                    !_typeTable.ContainsKey(elementType.FullName) &&
-                    !_primitiveValueTypes.ContainsKey(elementType.FullName))
+                    !_primitiveValueTypes.Contains(elementType.FullName))
                 {
                     return WeavePropertyResult.Error($"{type.Name}.{prop.Name} is an {collectionType} but its generic type is {elementType.Name} which is not supported by Realm.");
                 }
@@ -601,40 +501,7 @@ Analytics payload
             return WeavePropertyResult.Success(prop, backingField, isPrimaryKey, isIndexed);
         }
 
-        private Accessors GetAccessors(TypeReference backingType, bool isPrimaryKey, IDictionary<string, Accessors> methodTable)
-        {
-            var typeId = backingType.FullName + (isPrimaryKey ? " unique" : string.Empty);
-
-            if (!_typeTable.TryGetValue(backingType.FullName, out var typeName))
-            {
-                throw new NotSupportedException($"Unable to find {backingType.FullName} in _typeTable. Please report that to help@realm.io");
-            }
-
-            if (!methodTable.TryGetValue(typeId, out var realmAccessors))
-            {
-                var getter = new MethodReference($"Get{typeName}Value", backingType, _references.RealmObjectBase)
-                {
-                    HasThis = true,
-                    Parameters = { new ParameterDefinition(_moduleDefinition.TypeSystem.String) },
-                };
-
-                var setter = new MethodReference($"Set{typeName}Value" + (isPrimaryKey ? "Unique" : string.Empty), _moduleDefinition.TypeSystem.Void, _references.RealmObjectBase)
-                {
-                    HasThis = true,
-                    Parameters =
-                {
-                    new ParameterDefinition(_moduleDefinition.TypeSystem.String),
-                    new ParameterDefinition(backingType)
-                }
-                };
-
-                methodTable[typeId] = realmAccessors = new Accessors { Getter = getter, Setter = setter };
-            }
-
-            return realmAccessors;
-        }
-
-        private void ReplaceGetter(PropertyDefinition prop, string columnName, MethodReference getValueReference, FieldReference propertyTypeRef = null)
+        private void ReplaceGetter(PropertyDefinition prop, string columnName, MethodReference getValueReference, bool implicitConvert = false)
         {
             //// A synthesized property getter looks like this:
             ////   0: ldarg.0
@@ -663,78 +530,18 @@ Analytics payload
             il.InsertBefore(start, il.Create(OpCodes.Brfalse_S, start));
             il.InsertBefore(start, il.Create(OpCodes.Ldarg_0)); // this for call
             il.InsertBefore(start, il.Create(OpCodes.Ldstr, columnName)); // [stack = this | name ]
-            if (propertyTypeRef != null)
-            {
-                il.InsertBefore(start, il.Create(OpCodes.Ldc_I4, (ushort)propertyTypeRef.Resolve().Constant));
-            }
 
             il.InsertBefore(start, il.Create(OpCodes.Call, getValueReference));
-            il.InsertBefore(start, il.Create(OpCodes.Ret));
-        }
 
-        private void ReplaceRealmIntegerGetter(PropertyDefinition prop, string columnName, MethodReference getValueReference, bool isNullable, TypeReference integerType)
-        {
-            var start = prop.GetMethod.Body.Instructions.First();
-            var il = prop.GetMethod.Body.GetILProcessor();
-
-            il.InsertBefore(start, il.Create(OpCodes.Ldarg_0));
-            il.InsertBefore(start, il.Create(OpCodes.Call, _references.RealmObject_get_IsManaged));
-            il.InsertBefore(start, il.Create(OpCodes.Brfalse_S, start));
-
-            il.InsertBefore(start, il.Create(OpCodes.Ldarg_0));
-            il.InsertBefore(start, il.Create(OpCodes.Ldstr, columnName));
-            il.InsertBefore(start, il.Create(OpCodes.Call, getValueReference));
-
-            if (!prop.PropertyType.IsRealmInteger(out _, out _))
+            if (implicitConvert)
             {
-                var convert = _references.RealmIntegerOfT_ConvertToT.MakeHostInstanceGeneric(integerType);
-                if (isNullable)
+                var convertMethod = new MethodReference("op_Implicit", prop.PropertyType, _references.RealmValue)
                 {
-                    var nullableRealmIntegerType = new GenericInstanceType(_references.System_NullableOfT)
-                    {
-                        GenericArguments =
-                    {
-                        new GenericInstanceType(_references.RealmIntegerOfT)
-                        {
-                            GenericArguments = { integerType }
-                        }
-                    }
-                    };
+                    Parameters = { new ParameterDefinition(_references.RealmValue) },
+                    HasThis = false
+                };
 
-                    var localRealmIntegerVariable = new VariableDefinition(nullableRealmIntegerType);
-                    prop.GetMethod.Body.Variables.Add(localRealmIntegerVariable);
-
-                    var localIntegerVariable = new VariableDefinition(prop.PropertyType);
-                    prop.GetMethod.Body.Variables.Add(localIntegerVariable);
-
-                    il.InsertBefore(start, il.Create(OpCodes.Stloc_0));
-                    il.InsertBefore(start, il.Create(OpCodes.Ldloca_S, localRealmIntegerVariable));
-
-                    var hasValue = new MethodReference("get_HasValue", _moduleDefinition.TypeSystem.Boolean, nullableRealmIntegerType) { HasThis = true };
-                    il.InsertBefore(start, il.Create(OpCodes.Call, hasValue));
-
-                    var hasValueBranch = il.Create(OpCodes.Ldloca_S, localRealmIntegerVariable);
-
-                    il.InsertBefore(start, il.Create(OpCodes.Brtrue_S, hasValueBranch));
-                    il.InsertBefore(start, il.Create(OpCodes.Ldloca_S, localIntegerVariable));
-                    il.InsertBefore(start, il.Create(OpCodes.Initobj, prop.PropertyType));
-                    il.InsertBefore(start, il.Create(OpCodes.Ldloc_1));
-                    il.InsertBefore(start, il.Create(OpCodes.Ret));
-
-                    il.InsertBefore(start, hasValueBranch);
-
-                    var concreteRealmIntegerType = _references.RealmIntegerOfT.MakeGenericInstanceType(integerType);
-                    var getValueOrDefault = _references.System_NullableOfT_GetValueOrDefault.MakeHostInstanceGeneric(concreteRealmIntegerType);
-                    il.InsertBefore(start, il.Create(OpCodes.Call, getValueOrDefault));
-                    il.InsertBefore(start, il.Create(OpCodes.Call, convert));
-
-                    var ctor = _references.System_NullableOfT_Ctor.MakeHostInstanceGeneric(integerType);
-                    il.InsertBefore(start, il.Create(OpCodes.Newobj, ctor));
-                }
-                else
-                {
-                    il.InsertBefore(start, il.Create(OpCodes.Call, convert));
-                }
+                il.InsertBefore(start, il.Create(OpCodes.Call, convertMethod));
             }
 
             il.InsertBefore(start, il.Create(OpCodes.Ret));
@@ -902,7 +709,7 @@ Analytics payload
             // TODO prop.SetMethod.Body.OptimizeMacros();
         }
 
-        private void ReplaceSetter(PropertyDefinition prop, FieldReference backingField, string columnName, MethodReference setValueReference, FieldReference propertyTypeRef = null)
+        private void ReplaceSetter(PropertyDefinition prop, FieldReference backingField, string columnName, MethodReference setValueReference, bool implicitConvert = false)
         {
             //// A synthesized property setter looks like this:
             ////   0: ldarg.0
@@ -964,93 +771,18 @@ Analytics payload
             il.Append(managedSetStart);
             il.Append(il.Create(OpCodes.Ldstr, columnName));
             il.Append(il.Create(OpCodes.Ldarg_1));
-            if (propertyTypeRef != null)
+            if (implicitConvert)
             {
-                il.Append(il.Create(OpCodes.Ldc_I4, (ushort)propertyTypeRef.Resolve().Constant));
+                var convertMethod = new MethodReference("op_Implicit", _references.RealmValue, _references.RealmValue)
+                {
+                    Parameters = { new ParameterDefinition(prop.PropertyType) },
+                    HasThis = false
+                };
+
+                il.Append(il.Create(OpCodes.Call, convertMethod));
             }
 
             il.Append(il.Create(OpCodes.Call, setValueReference));
-            il.Append(il.Create(OpCodes.Ret));
-        }
-
-        private void ReplaceRealmIntegerSetter(PropertyDefinition prop, FieldReference backingField, string columnName, MethodReference setValueReference, bool isNullable, TypeReference integerType)
-        {
-            // Whilst we're only targetting auto-properties here, someone like PropertyChanged.Fody
-            // may have already come in and rewritten our IL. Lets clear everything and start from scratch.
-            var il = prop.SetMethod.Body.GetILProcessor();
-            prop.SetMethod.Body.Instructions.Clear();
-            prop.SetMethod.Body.Variables.Clear();
-
-            // While we can tidy up PropertyChanged.Fody IL if we're ran after it, we can't do a heck of a lot
-            // if they're the last one in.
-            // To combat this, we'll check if the PropertyChanged assembly is available, and if so, attribute
-            // the property such that PropertyChanged.Fody won't touch it.
-            if (_references.PropertyChanged_DoNotNotifyAttribute_Constructor != null)
-            {
-                prop.CustomAttributes.Add(new CustomAttribute(_references.PropertyChanged_DoNotNotifyAttribute_Constructor));
-            }
-
-            var managedSetStart = il.Create(OpCodes.Ldarg_0);
-            il.Append(il.Create(OpCodes.Ldarg_0));
-            il.Append(il.Create(OpCodes.Call, _references.RealmObject_get_IsManaged));
-            il.Append(il.Create(OpCodes.Brtrue_S, managedSetStart));
-
-            il.Append(il.Create(OpCodes.Ldarg_0));
-            il.Append(il.Create(OpCodes.Ldarg_1));
-            il.Append(il.Create(OpCodes.Stfld, backingField));
-            il.Append(il.Create(OpCodes.Ldarg_0));
-            il.Append(il.Create(OpCodes.Ldstr, prop.Name));
-            il.Append(il.Create(OpCodes.Call, _references.RealmObject_RaisePropertyChanged));
-            il.Append(il.Create(OpCodes.Ret));
-
-            il.Append(managedSetStart);
-            il.Append(il.Create(OpCodes.Ldstr, columnName));
-            il.Append(il.Create(OpCodes.Ldarg_1));
-
-            var callSetter = il.Create(OpCodes.Call, setValueReference);
-            il.Append(callSetter);
-
-            if (!prop.PropertyType.IsRealmInteger(out _, out _))
-            {
-                var convert = _references.RealmIntegerOfT_ConvertFromT.MakeHostInstanceGeneric(integerType);
-                if (isNullable)
-                {
-                    var realmIntegerType = _references.RealmIntegerOfT.MakeGenericInstanceType(integerType);
-                    var nullableRealmIntegerType = _references.System_NullableOfT.MakeGenericInstanceType(realmIntegerType);
-
-                    var localIntegerVariable = new VariableDefinition(prop.PropertyType);
-                    prop.SetMethod.Body.Variables.Add(localIntegerVariable);
-
-                    var localRealmIntegerVariable = new VariableDefinition(nullableRealmIntegerType);
-                    prop.SetMethod.Body.Variables.Add(localRealmIntegerVariable);
-
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Stloc_0));
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Ldloca_S, localIntegerVariable));
-
-                    var hasValue = new MethodReference("get_HasValue", _moduleDefinition.TypeSystem.Boolean, prop.PropertyType) { HasThis = true };
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Call, hasValue));
-
-                    var hasValueBranch = il.Create(OpCodes.Ldloca_S, localIntegerVariable);
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Brtrue_S, hasValueBranch));
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Ldloca_S, localRealmIntegerVariable));
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Initobj, nullableRealmIntegerType));
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Ldloc_1));
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Br_S, callSetter));
-
-                    il.InsertBefore(callSetter, hasValueBranch);
-                    var getValueOrDefault = _references.System_NullableOfT_GetValueOrDefault.MakeHostInstanceGeneric(integerType);
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Call, getValueOrDefault));
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Call, convert));
-
-                    var nullableRealmIntegerCtor = _references.System_NullableOfT_Ctor.MakeHostInstanceGeneric(realmIntegerType);
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Newobj, nullableRealmIntegerCtor));
-                }
-                else
-                {
-                    il.InsertBefore(callSetter, il.Create(OpCodes.Call, convert));
-                }
-            }
-
             il.Append(il.Create(OpCodes.Ret));
         }
 

--- a/Realm/Realm.Unity/Editor/Common/RealmWeaver.cs
+++ b/Realm/Realm.Unity/Editor/Common/RealmWeaver.cs
@@ -501,7 +501,7 @@ Analytics payload
             ////   3: ldarg.0
             ////   4: ldstr <columnName>
             ////   5: call Realms.RealmObject.GetValue
-            ////   6: call op_implicit prop.PropertyType
+            ////   6: call op_explicit prop.PropertyType
             ////   7: ret
             ////   8: ldarg.0
             ////   9: ldfld <backingField>
@@ -533,7 +533,7 @@ Analytics payload
                 convertType = _references.RealmObjectBase;
             }
 
-            var convertMethod = new MethodReference("op_Implicit", convertType, _references.RealmValue)
+            var convertMethod = new MethodReference("op_Explicit", convertType, _references.RealmValue)
             {
                 Parameters = { new ParameterDefinition(_references.RealmValue) },
                 HasThis = false

--- a/Realm/Realm.Unity/Editor/Common/RealmWeaver.cs
+++ b/Realm/Realm.Unity/Editor/Common/RealmWeaver.cs
@@ -877,6 +877,7 @@ Analytics payload
                     copyToRealm.Body.Variables.Add(new VariableDefinition(_moduleDefinition.ImportReference(prop.Field.FieldType)));
                 }
 
+                copyToRealm.Body.InitLocals = true;
                 var il = copyToRealm.Body.GetILProcessor();
                 il.Append(il.Create(OpCodes.Ldarg_1));
                 il.Append(il.Create(OpCodes.Castclass, _moduleDefinition.ImportReference(realmObjectType)));
@@ -1154,7 +1155,7 @@ Analytics payload
                     il.Append(il.Create(OpCodes.Ldloc_0));
                     il.Append(il.Create(OpCodes.Call, propertyGetterMethodReference));
                     il.Append(il.Create(OpCodes.Ldloc_S, currentStloc));
-                    il.Append(il.Create(OpCodes.Callvirt, _references.ISetOfT_UnionWith));
+                    il.Append(il.Create(OpCodes.Callvirt, _references.ISetOfT_UnionWith.MakeHostInstanceGeneric(elementType)));
 
                     var setterEnd = il.Create(OpCodes.Nop);
                     il.Append(setterEnd);
@@ -1189,6 +1190,8 @@ Analytics payload
 
                 if (pkProperty != null)
                 {
+                    getPrimaryKeyValue.Body.InitLocals = true;
+
                     il.Emit(OpCodes.Ldarg_1);
                     il.Emit(OpCodes.Castclass, _moduleDefinition.ImportReference(realmObjectType));
                     il.Emit(OpCodes.Stloc_0);

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -88,7 +88,7 @@ namespace Realms
                 optionalPath = Path.Combine(InteropConfig.DefaultStorageFolder, optionalPath);
             }
 
-            if (optionalPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            if (optionalPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 optionalPath = Path.Combine(optionalPath, DefaultRealmName);
             }

--- a/Realm/Realm/Dynamic/MetaRealmObject.cs
+++ b/Realm/Realm/Dynamic/MetaRealmObject.cs
@@ -153,27 +153,11 @@ namespace Realms.Dynamic
             }
             else
             {
-                arguments.Add(Expression.Constant(_metadata.PropertyIndices[property.Name]));
-                switch (property.Type.UnderlyingType())
-                {
-                    case PropertyType.Int:
-                    case PropertyType.Bool:
-                    case PropertyType.Float:
-                    case PropertyType.Double:
-                    case PropertyType.Date:
-                    case PropertyType.Decimal:
-                    case PropertyType.ObjectId:
-                    case PropertyType.String:
-                    case PropertyType.Data:
-                        getter = GetGetMethod(DummyHandle.GetValue);
-                        break;
-                    case PropertyType.Object:
-                        arguments.Insert(0, Expression.Field(self, RealmObjectRealmField));
-                        arguments.Add(Expression.Constant(property.ObjectType));
+                arguments.Add(Expression.Constant(property.Name));
+                arguments.Add(Expression.Constant(_metadata));
+                arguments.Add(Expression.Constant(_realm));
 
-                        getter = IsTargetEmbedded(property) ? GetGetMethod(DummyHandle.GetObject<DynamicEmbeddedObject>) : GetGetMethod(DummyHandle.GetObject<DynamicRealmObject>);
-                        break;
-                }
+                getter = GetGetMethod(DummyHandle.GetValue);
             }
 
             var instance = Expression.Field(self, RealmObjectObjectHandleField);
@@ -193,7 +177,17 @@ namespace Realms.Dynamic
 
             if (expression.Type == typeof(RealmValue))
             {
-                expression = Expression.Call(expression, RealmValueGetMethod.MakeGenericMethod(property.PropertyInfo?.PropertyType ?? property.Type.ToType()));
+                Type targetType;
+                if (property.Type.UnderlyingType() == PropertyType.Object)
+                {
+                    targetType = IsTargetEmbedded(property) ? typeof(DynamicEmbeddedObject) : typeof(DynamicRealmObject);
+                }
+                else
+                {
+                    targetType = property.PropertyInfo?.PropertyType ?? property.Type.ToType();
+                }
+
+                expression = Expression.Call(expression, RealmValueGetMethod.MakeGenericMethod(targetType));
             }
 
             if (binder.ReturnType != expression.Type)
@@ -216,48 +210,23 @@ namespace Realms.Dynamic
                 Expression.Constant(_metadata.PropertyIndices[property.Name])
             };
 
-            MethodInfo setter = null;
-            Type argumentType = null;
-
             var self = GetLimitedSelf();
             var valueExpression = value.Expression;
-            switch (property.Type.ToRealmValueType())
-            {
-                // TODO: split these into individual cases to avoid calling the generic method
-                case RealmValueType.Int:
-                case RealmValueType.Bool:
-                case RealmValueType.Float:
-                case RealmValueType.Double:
-                case RealmValueType.Date:
-                case RealmValueType.Decimal128:
-                case RealmValueType.ObjectId:
-                case RealmValueType.Data:
-                case RealmValueType.String:
-                    argumentType = typeof(RealmValue);
-                    valueExpression = Expression.Call(CreateRealmValueMethod.MakeGenericMethod(valueExpression.Type), new[] { valueExpression, Expression.Constant(property.Type.ToRealmValueType()) });
-                    if (property.IsPrimaryKey)
-                    {
-                        setter = GetSetMethod<RealmValue>(DummyHandle.SetValueUnique);
-                    }
-                    else
-                    {
-                        setter = GetSetMethod<RealmValue>(DummyHandle.SetValue);
-                    }
 
-                    break;
-                case RealmValueType.Object:
-                    argumentType = typeof(RealmObjectBase);
-                    arguments.Insert(0, Expression.Field(self, RealmObjectRealmField));
-                    setter = GetSetMethod<RealmObjectBase>(DummyHandle.SetObject);
-                    break;
-            }
+            valueExpression = Expression.Call(CreateRealmValueMethod.MakeGenericMethod(valueExpression.Type), new[] { valueExpression, Expression.Constant(property.Type.ToRealmValueType()) });
+            var setter = property.IsPrimaryKey ? GetSetMethod<RealmValue>(DummyHandle.SetValueUnique) : GetSetMethod<RealmValue>(DummyHandle.SetValue);
 
-            if (valueExpression.Type != argumentType)
+            if (valueExpression.Type != typeof(RealmValue))
             {
-                valueExpression = Expression.Convert(valueExpression, argumentType);
+                valueExpression = Expression.Convert(valueExpression, typeof(RealmValue));
             }
 
             arguments.Add(valueExpression);
+
+            if (!property.IsPrimaryKey)
+            {
+                arguments.Add(Expression.Constant(_realm));
+            }
 
             var expression = Expression.Block(Expression.Call(Expression.Field(self, RealmObjectObjectHandleField), setter, arguments), Expression.Default(binder.ReturnType));
             return new DynamicMetaObject(expression, GetBindingRestrictions(self));
@@ -309,16 +278,25 @@ namespace Realms.Dynamic
 
         // GetString(propertyIndex)
         // GetBacklinks(propertyIndex)
-        // GetValue(propertyIndex)
         private static MethodInfo GetGetMethod<TResult>(Func<IntPtr, TResult> @delegate) => @delegate.GetMethodInfo();
+
+        // GetValue(propertyIndex)
+        private static MethodInfo GetGetMethod<TResult>(Func<string, RealmObjectBase.Metadata, Realm, TResult> @delegate) => @delegate.GetMethodInfo();
 
         // GetList(realm, propertyIndex, objectType)
         // GetSet(realm, propertyIndex, objectType)
         // GetObject(realm, propertyIndex, objectType)
         private static MethodInfo GetGetMethod<TResult>(Func<Realm, IntPtr, string, TResult> @delegate) => @delegate.GetMethodInfo();
 
-        // SetXXX(propertyIndex)
-        private static MethodInfo GetSetMethod<TValue>(Action<IntPtr, TValue> @delegate) => @delegate.GetMethodInfo();
+        private delegate void SetUniqueDelegate(IntPtr index, in RealmValue value);
+
+        // SetValueUnique(propertyIndex)
+        private static MethodInfo GetSetMethod<TValue>(SetUniqueDelegate @delegate) => @delegate.GetMethodInfo();
+
+        private delegate void SetValueDelegate(IntPtr index, in RealmValue value, Realm realm);
+
+        // SetValue
+        private static MethodInfo GetSetMethod<TValue>(SetValueDelegate @delegate) => @delegate.GetMethodInfo();
 
         // SetObject(this, propertyIndex)
         private static MethodInfo GetSetMethod<TValue>(Action<Realm, IntPtr, TValue> @delegate) => @delegate.GetMethodInfo();

--- a/Realm/Realm/Dynamic/MetaRealmObject.cs
+++ b/Realm/Realm/Dynamic/MetaRealmObject.cs
@@ -47,7 +47,7 @@ namespace Realms.Dynamic
                                                                                               .MakeGenericMethod(typeof(DynamicEmbeddedObject));
 
         private static readonly MethodInfo RealmValueGetMethod = typeof(RealmValue).GetMethod(nameof(RealmValue.As), BindingFlags.Public | BindingFlags.Instance);
-        private static readonly MethodInfo CreateRealmValueMethod = typeof(RealmValue).GetMethod(nameof(RealmValue.Create), BindingFlags.Public | BindingFlags.Static);
+        private static readonly MethodInfo CreateRealmValueMethod = typeof(RealmValue).GetMethod(nameof(RealmValue.Create), BindingFlags.NonPublic | BindingFlags.Static);
 
         private static readonly ObjectHandle DummyHandle = new ObjectHandle(null, IntPtr.Zero);
 

--- a/Realm/Realm/Dynamic/MetaRealmObject.cs
+++ b/Realm/Realm/Dynamic/MetaRealmObject.cs
@@ -164,13 +164,9 @@ namespace Realms.Dynamic
                     case PropertyType.Date:
                     case PropertyType.Decimal:
                     case PropertyType.ObjectId:
-                        getter = GetGetMethod(DummyHandle.GetPrimitive);
-                        break;
                     case PropertyType.String:
-                        getter = GetGetMethod(DummyHandle.GetString);
-                        break;
                     case PropertyType.Data:
-                        getter = GetGetMethod(DummyHandle.GetByteArray);
+                        getter = GetGetMethod(DummyHandle.GetPrimitive);
                         break;
                     case PropertyType.Object:
                         arguments.Insert(0, Expression.Field(self, RealmObjectRealmField));
@@ -198,7 +194,7 @@ namespace Realms.Dynamic
 
             if (expression.Type == typeof(PrimitiveValue))
             {
-                expression = Expression.Call(expression, PrimitiveValueGetMethod.MakeGenericMethod(property.PropertyInfo.PropertyType));
+                expression = Expression.Call(expression, PrimitiveValueGetMethod.MakeGenericMethod(property.PropertyInfo?.PropertyType ?? property.Type.ToType()));
             }
 
             if (binder.ReturnType != expression.Type)

--- a/Realm/Realm/Exceptions/RealmException.cs
+++ b/Realm/Realm/Exceptions/RealmException.cs
@@ -106,6 +106,10 @@ namespace Realms.Exceptions
                 case RealmExceptionCodes.RealmClosed:
                     return new RealmClosedException(message);
 
+                case RealmExceptionCodes.NotNullableProperty:
+                case RealmExceptionCodes.PropertyMismatch:
+                    return new RealmException(message);
+
                 case RealmExceptionCodes.AppClientError:
                 case RealmExceptionCodes.AppCustomError:
                 case RealmExceptionCodes.AppHttpError:

--- a/Realm/Realm/Exceptions/RealmExceptionCodes.cs
+++ b/Realm/Realm/Exceptions/RealmExceptionCodes.cs
@@ -44,6 +44,9 @@ namespace Realms.Exceptions
 
         RealmDotNetExceptionDuringMigration = 30,
 
+        NotNullableProperty = 31,
+        PropertyMismatch = 32,
+
         AppClientError = 50,
         AppCustomError = 51,
         AppHttpError = 52,

--- a/Realm/Realm/FodyWeavers.xml
+++ b/Realm/Realm/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Realm WeaveDataBinding="false" />
+  <Realm />
 </Weavers>

--- a/Realm/Realm/GlobalSuppressions.cs
+++ b/Realm/Realm/GlobalSuppressions.cs
@@ -20,3 +20,4 @@
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.RealmCollectionBase`1._propertyChanged")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.RealmObjectBase._propertyChanged")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.Realm._realmChanged")]
+[assembly: SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "The values of the enum represent types.", Scope = "type", Target = "~T:Realms.RealmValueType")]

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -18,7 +18,6 @@
 
 using System;
 using Realms.Native;
-using Realms.Schema;
 
 namespace Realms
 {
@@ -46,20 +45,15 @@ namespace Realms
 
         protected abstract IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException);
 
-        public PrimitiveValue GetPrimitiveAtIndex(int index, PropertyType type)
+        public PrimitiveValue GetPrimitiveAtIndex(int index)
         {
-            var result = new PrimitiveValue
-            {
-                Type = type
-            };
-
-            GetPrimitiveAtIndexCore((IntPtr)index, ref result, out var nativeException);
+            GetPrimitiveAtIndexCore((IntPtr)index, out var result, out var nativeException);
             nativeException.ThrowIfNecessary();
 
             return result;
         }
 
-        protected abstract void GetPrimitiveAtIndexCore(IntPtr index, ref PrimitiveValue result, out NativeException nativeException);
+        protected abstract void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException);
 
         public abstract string GetStringAtIndex(int index);
 

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -45,12 +45,12 @@ namespace Realms
 
         protected abstract IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException);
 
-        public PrimitiveValue GetPrimitiveAtIndex(int index)
+        public RealmValue GetValueAtIndex(int index)
         {
             GetPrimitiveAtIndexCore((IntPtr)index, out var result, out var nativeException);
             nativeException.ThrowIfNecessary();
 
-            return result;
+            return new RealmValue(result);
         }
 
         protected abstract void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException);

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -29,31 +29,21 @@ namespace Realms
         {
         }
 
-        public bool TryGetObjectAtIndex(int index, out ObjectHandle objectHandle)
+        public RealmValue GetValueAtIndex(int index, RealmObjectBase.Metadata metadata, Realm realm)
         {
-            var result = GetObjectAtIndexCore((IntPtr)index, out var nativeException);
+            GetValueAtIndexCore((IntPtr)index, out var result, out var nativeException);
             nativeException.ThrowIfNecessary();
-            if (result == IntPtr.Zero)
+
+            if (result.Type != RealmValueType.Object)
             {
-                objectHandle = null;
-                return false;
+                return new RealmValue(result);
             }
 
-            objectHandle = new ObjectHandle(Root, result);
-            return true;
+            var objectHandle = result.AsObject(Root);
+            return new RealmValue(realm.MakeObject(metadata, objectHandle));
         }
 
-        protected abstract IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException);
-
-        public RealmValue GetValueAtIndex(int index)
-        {
-            GetPrimitiveAtIndexCore((IntPtr)index, out var result, out var nativeException);
-            nativeException.ThrowIfNecessary();
-
-            return new RealmValue(result);
-        }
-
-        protected abstract void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException);
+        protected abstract void GetValueAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException);
 
         public abstract int Count();
 

--- a/Realm/Realm/Handles/CollectionHandleBase.cs
+++ b/Realm/Realm/Handles/CollectionHandleBase.cs
@@ -55,10 +55,6 @@ namespace Realms
 
         protected abstract void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException);
 
-        public abstract string GetStringAtIndex(int index);
-
-        public abstract byte[] GetByteArrayAtIndex(int index);
-
         public abstract int Count();
 
         public abstract ResultsHandle Snapshot();

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -96,7 +96,7 @@ namespace Realms
             public static extern IntPtr get_object(ListHandle listHandle, IntPtr link_ndx, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void get_primitive(ListHandle listHandle, IntPtr link_ndx, ref PrimitiveValue value, out NativeException ex);
+            public static extern void get_primitive(ListHandle listHandle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_string(ListHandle listHandle, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
@@ -187,8 +187,8 @@ namespace Realms
         protected override IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException) =>
             NativeMethods.get_object(this, index, out nativeException);
 
-        protected override void GetPrimitiveAtIndexCore(IntPtr index, ref PrimitiveValue result, out NativeException nativeException) =>
-            NativeMethods.get_primitive(this, index, ref result, out nativeException);
+        protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
+            NativeMethods.get_primitive(this, index, out result, out nativeException);
 
         public override string GetStringAtIndex(int index)
         {

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -36,13 +36,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern void add_primitive(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLength, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_binary(ListHandle listHandle, IntPtr buffer, IntPtr bufferLength,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_embedded", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr add_embedded(ListHandle listHandle, out NativeException ex);
 
@@ -56,14 +49,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_primitive(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void set_string(ListHandle listHandle, IntPtr targetIndex, [MarshalAs(UnmanagedType.LPWStr)] string value,
-                IntPtr valueLen, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void set_binary(ListHandle listHandle, IntPtr targetIndex, IntPtr buffer, IntPtr bufferLength,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_embedded", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr set_embedded(ListHandle listHandle, IntPtr targetIndex, out NativeException ex);
 
@@ -76,14 +61,6 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern void insert_primitive(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void insert_string(ListHandle listHandle, IntPtr targetIndex, [MarshalAs(UnmanagedType.LPWStr)] string value,
-                IntPtr valueLen, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void insert_binary(ListHandle listHandle, IntPtr targetIndex, IntPtr buffer, IntPtr bufferLength,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_embedded", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr insert_embedded(ListHandle listHandle, IntPtr targetIndex, out NativeException ex);
@@ -107,13 +84,6 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr find_primitive(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr find_string(ListHandle listHandle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr find_binary(ListHandle listHandle, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
 
             #endregion
 
@@ -192,22 +162,12 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void Add(PrimitiveValue value)
+        public unsafe void Add(RealmValue value)
         {
-            NativeMethods.add_primitive(this, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.add_primitive(this, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
-        }
-
-        public void Add(string value)
-        {
-            NativeMethods.add_string(this, value, value.IntPtrLength(), out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public unsafe void Add(byte[] value)
-        {
-            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
-                NativeMethods.add_binary(this, buffer, bufferSize, hasValue, out ex));
         }
 
         public ObjectHandle AddEmbedded()
@@ -227,22 +187,12 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void Set(int targetIndex, PrimitiveValue value)
+        public unsafe void Set(int targetIndex, RealmValue value)
         {
-            NativeMethods.set_primitive(this, (IntPtr)targetIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.set_primitive(this, (IntPtr)targetIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
-        }
-
-        public void Set(int targetIndex, string value)
-        {
-            NativeMethods.set_string(this, (IntPtr)targetIndex, value, value.IntPtrLength(), out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public unsafe void Set(int targetIndex, byte[] value)
-        {
-            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
-                NativeMethods.set_binary(this, (IntPtr)targetIndex, buffer, bufferSize, hasValue, out ex));
         }
 
         public ObjectHandle SetEmbedded(int targetIndex)
@@ -262,22 +212,12 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void Insert(int targetIndex, PrimitiveValue value)
+        public unsafe void Insert(int targetIndex, RealmValue value)
         {
-            NativeMethods.insert_primitive(this, (IntPtr)targetIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.insert_primitive(this, (IntPtr)targetIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
-        }
-
-        public void Insert(int targetIndex, string value)
-        {
-            NativeMethods.insert_string(this, (IntPtr)targetIndex, value, value.IntPtrLength(), out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public unsafe void Insert(int targetIndex, byte[] value)
-        {
-            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
-                NativeMethods.insert_binary(this, (IntPtr)targetIndex, buffer, bufferSize, hasValue, out ex));
         }
 
         public ObjectHandle InsertEmbedded(int targetIndex)
@@ -298,28 +238,12 @@ namespace Realms
             return (int)result;
         }
 
-        public unsafe int Find(PrimitiveValue value)
+        public unsafe int Find(RealmValue value)
         {
-            var result = NativeMethods.find_primitive(this, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            var result = NativeMethods.find_primitive(this, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
-            return (int)result;
-        }
-
-        public int Find(string value)
-        {
-            var result = NativeMethods.find_string(this, value, value.IntPtrLength(), out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return (int)result;
-        }
-
-        public unsafe int Find(byte[] value)
-        {
-            var result = IntPtr.Zero;
-            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
-            {
-                result = NativeMethods.find_binary(this, buffer, bufferSize, hasValue, out ex);
-            });
-
             return (int)result;
         }
 

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -28,64 +28,29 @@ namespace Realms
         {
 #pragma warning disable IDE1006 // Naming Styles
 
-            #region add
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_object(ListHandle listHandle, ObjectHandle objectHandle, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void add_primitive(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void add_value(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_add_embedded", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr add_embedded(ListHandle listHandle, out NativeException ex);
 
-            #endregion
-
-            #region set
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void set_object(ListHandle listHandle, IntPtr targetIndex, ObjectHandle objectHandle, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void set_primitive(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void set_value(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_set_embedded", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr set_embedded(ListHandle listHandle, IntPtr targetIndex, out NativeException ex);
 
-            #endregion
-
-            #region insert
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void insert_object(ListHandle listHandle, IntPtr targetIndex, ObjectHandle objectHandle, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void insert_primitive(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void insert_value(ListHandle listHandle, IntPtr targetIndex, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_insert_embedded", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr insert_embedded(ListHandle listHandle, IntPtr targetIndex, out NativeException ex);
 
-            #endregion
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void get_value(ListHandle listHandle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
-            #region get
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_object(ListHandle listHandle, IntPtr link_ndx, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void get_primitive(ListHandle listHandle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
-
-            #endregion
-
-            #region find
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr find_object(ListHandle listHandle, ObjectHandle objectHandle, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr find_primitive(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
-
-            #endregion
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_find_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr find_value(ListHandle listHandle, PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_erase", CallingConvention = CallingConvention.Cdecl)]
             public static extern void erase(ListHandle listHandle, IntPtr rowIndex, out NativeException ex);
@@ -144,28 +109,13 @@ namespace Realms
             NativeMethods.destroy(handle);
         }
 
-        #region GetAtIndex
+        protected override void GetValueAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
+            NativeMethods.get_value(this, index, out result, out nativeException);
 
-        protected override IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException) =>
-            NativeMethods.get_object(this, index, out nativeException);
-
-        protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
-            NativeMethods.get_primitive(this, index, out result, out nativeException);
-
-        #endregion
-
-        #region Add
-
-        public void Add(ObjectHandle objectHandle)
-        {
-            NativeMethods.add_object(this, objectHandle, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public unsafe void Add(RealmValue value)
+        public unsafe void Add(in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
-            NativeMethods.add_primitive(this, primitive, out var nativeException);
+            NativeMethods.add_value(this, primitive, out var nativeException);
             handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
@@ -177,20 +127,10 @@ namespace Realms
             return new ObjectHandle(Root, result);
         }
 
-        #endregion
-
-        #region Set
-
-        public void Set(int targetIndex, ObjectHandle objectHandle)
-        {
-            NativeMethods.set_object(this, (IntPtr)targetIndex, objectHandle, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public unsafe void Set(int targetIndex, RealmValue value)
+        public unsafe void Set(int targetIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
-            NativeMethods.set_primitive(this, (IntPtr)targetIndex, primitive, out var nativeException);
+            NativeMethods.set_value(this, (IntPtr)targetIndex, primitive, out var nativeException);
             handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
@@ -202,20 +142,10 @@ namespace Realms
             return new ObjectHandle(Root, result);
         }
 
-        #endregion
-
-        #region Insert
-
-        public void Insert(int targetIndex, ObjectHandle objectHandle)
-        {
-            NativeMethods.insert_object(this, (IntPtr)targetIndex, objectHandle, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public unsafe void Insert(int targetIndex, RealmValue value)
+        public unsafe void Insert(int targetIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
-            NativeMethods.insert_primitive(this, (IntPtr)targetIndex, primitive, out var nativeException);
+            NativeMethods.insert_value(this, (IntPtr)targetIndex, primitive, out var nativeException);
             handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
@@ -227,27 +157,14 @@ namespace Realms
             return new ObjectHandle(Root, result);
         }
 
-        #endregion
-
-        #region Find
-
-        public int Find(ObjectHandle objectHandle)
-        {
-            var result = NativeMethods.find_object(this, objectHandle, out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return (int)result;
-        }
-
-        public unsafe int Find(RealmValue value)
+        public unsafe int Find(in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
-            var result = NativeMethods.find_primitive(this, primitive, out var nativeException);
+            var result = NativeMethods.find_value(this, primitive, out var nativeException);
             handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return (int)result;
         }
-
-        #endregion
 
         public void Erase(IntPtr rowIndex)
         {

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -98,14 +98,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern void get_primitive(ListHandle listHandle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_string(ListHandle listHandle, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] out bool isNull, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_binary(ListHandle listHandle, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] out bool isNull, out NativeException ex);
-
             #endregion
 
             #region find
@@ -189,18 +181,6 @@ namespace Realms
 
         protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
             NativeMethods.get_primitive(this, index, out result, out nativeException);
-
-        public override string GetStringAtIndex(int index)
-        {
-            return MarshalHelpers.GetString((IntPtr buffer, IntPtr length, out bool isNull, out NativeException ex) =>
-                NativeMethods.get_string(this, (IntPtr)index, buffer, length, out isNull, out ex));
-        }
-
-        public override byte[] GetByteArrayAtIndex(int index)
-        {
-            return MarshalHelpers.GetByteArray((IntPtr buffer, IntPtr bufferLength, out bool isNull, out NativeException ex) =>
-                NativeMethods.get_binary(this, (IntPtr)index, buffer, bufferLength, out isNull, out ex));
-        }
 
         #endregion
 

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -164,9 +164,9 @@ namespace Realms
 
         public unsafe void Add(RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.add_primitive(this, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -189,9 +189,9 @@ namespace Realms
 
         public unsafe void Set(int targetIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.set_primitive(this, (IntPtr)targetIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -214,9 +214,9 @@ namespace Realms
 
         public unsafe void Insert(int targetIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.insert_primitive(this, (IntPtr)targetIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -240,9 +240,9 @@ namespace Realms
 
         public unsafe int Find(RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             var result = NativeMethods.find_primitive(this, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return (int)result;
         }

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -51,10 +51,6 @@ namespace Realms
             public static extern void set_string(ObjectHandle handle, IntPtr propertyIndex,
                 [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_string(ObjectHandle handle, IntPtr propertyIndex,
-                IntPtr buffer, IntPtr bufsize, [MarshalAs(UnmanagedType.U1)] out bool isNull, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_set_link", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_link(ObjectHandle handle, IntPtr propertyIndex, ObjectHandle targetHandle, out NativeException ex);
 
@@ -82,10 +78,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_set_binary", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr set_binary(ObjectHandle handle, IntPtr propertyIndex,
                 IntPtr buffer, IntPtr bufferLength, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_binary(ObjectHandle handle, IntPtr propertyIndex,
-                IntPtr buffer, IntPtr bufferLength, [MarshalAs(UnmanagedType.U1)] out bool is_null, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_remove", CallingConvention = CallingConvention.Cdecl)]
             public static extern void remove(ObjectHandle handle, RealmHandle realmHandle, out NativeException ex);
@@ -206,15 +198,10 @@ namespace Realms
 
         public void SetStringUnique(IntPtr propertyIndex, string value)
         {
-            if (GetString(propertyIndex) != value)
+            if (GetPrimitive(propertyIndex).AsString() != value)
             {
                 throw new InvalidOperationException("Once set, primary key properties may not be modified.");
             }
-        }
-
-        public string GetString(IntPtr propertyIndex)
-        {
-            return MarshalHelpers.GetString((IntPtr buffer, IntPtr length, out bool isNull, out NativeException ex) => NativeMethods.get_string(this, propertyIndex, buffer, length, out isNull, out ex));
         }
 
         public void SetLink(IntPtr propertyIndex, ObjectHandle targetHandle)
@@ -285,12 +272,6 @@ namespace Realms
                     NativeMethods.set_null(this, propertyIndex, out ex);
                 }
             });
-        }
-
-        public byte[] GetByteArray(IntPtr propertyIndex)
-        {
-            return MarshalHelpers.GetByteArray((IntPtr buffer, IntPtr bufferLength, out bool isNull, out NativeException ex) =>
-                NativeMethods.get_binary(this, propertyIndex, buffer, bufferLength, out isNull, out ex));
         }
 
         public void RemoveFromRealm(SharedRealmHandle realmHandle)

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -166,9 +166,9 @@ namespace Realms
 
         public void SetValue(IntPtr propertyIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.set_primitive(this, propertyIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -234,7 +234,6 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmList instance will own its handle.")]
         public RealmList<T> GetList<T>(Realm realm, IntPtr propertyIndex, string objectType)
         {
             var listHandle = new ListHandle(Root, GetLinkList(propertyIndex));
@@ -242,7 +241,6 @@ namespace Realms
             return new RealmList<T>(realm, listHandle, metadata);
         }
 
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmSet instance will own its handle.")]
         public RealmSet<T> GetSet<T>(Realm realm, IntPtr propertyIndex, string objectType)
         {
             var setHandle = new SetHandle(Root, GetLinkSet(propertyIndex));

--- a/Realm/Realm/Handles/QueryHandle.cs
+++ b/Realm/Realm/Handles/QueryHandle.cs
@@ -38,35 +38,29 @@ namespace Realms
 #pragma warning disable IDE1006 // Naming Styles
 #pragma warning disable SA1121 // Use built-in type alias
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_binary_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void binary_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr buffer, IntPtr bufferLength, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_binary_not_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void binary_not_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, IntPtr buffer, IntPtr bufferLength, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_contains", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_contains(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
+                PrimitiveValue primitive, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_starts_with", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_starts_with(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
+                        PrimitiveValue primitive, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_ends_with", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_ends_with(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
+                        PrimitiveValue primitive, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
+                        PrimitiveValue primitive, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_not_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_not_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
+                        PrimitiveValue primitive, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_like", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_like(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
-                        [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
+                        PrimitiveValue primitive, [MarshalAs(UnmanagedType.U1)] bool caseSensitive, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void primitive_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
@@ -129,111 +123,123 @@ namespace Realms
             NativeMethods.destroy(handle);
         }
 
-        public void BinaryEqual(SharedRealmHandle realm, IntPtr propertyIndex, IntPtr buffer, IntPtr bufferLength)
-        {
-            NativeMethods.binary_equal(this, realm, propertyIndex, buffer, bufferLength, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void BinaryNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, IntPtr buffer, IntPtr bufferLength)
-        {
-            NativeMethods.binary_not_equal(this, realm, propertyIndex, buffer, bufferLength, out var nativeException);
-            nativeException.ThrowIfNecessary();
-        }
-
         /// <summary>
         /// If the user hasn't specified it, should be caseSensitive=true.
         /// </summary>
-        public void StringContains(SharedRealmHandle realm, IntPtr propertyIndex, string value, bool caseSensitive)
+        public void StringContains(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            NativeMethods.string_contains(this, realm, propertyIndex, value, (IntPtr)value.Length, caseSensitive, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.string_contains(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringStartsWith(SharedRealmHandle realm, IntPtr propertyIndex, string value, bool caseSensitive)
+        public void StringStartsWith(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            NativeMethods.string_starts_with(this, realm, propertyIndex, value, (IntPtr)value.Length, caseSensitive, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.string_starts_with(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringEndsWith(SharedRealmHandle realm, IntPtr propertyIndex, string value, bool caseSensitive)
+        public void StringEndsWith(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            NativeMethods.string_ends_with(this, realm, propertyIndex, value, (IntPtr)value.Length, caseSensitive, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.string_ends_with(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringEqual(SharedRealmHandle realm, IntPtr propertyIndex, string value, bool caseSensitive)
+        public void StringEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            NativeMethods.string_equal(this, realm, propertyIndex, value, (IntPtr)value.Length, caseSensitive, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.string_equal(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, string value, bool caseSensitive)
+        public void StringNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            NativeMethods.string_not_equal(this, realm, propertyIndex, value, (IntPtr)value.Length, caseSensitive, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.string_not_equal(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringLike(SharedRealmHandle realm, IntPtr propertyIndex, string value, bool caseSensitive)
+        public void StringLike(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
             NativeException nativeException;
-            if (value == null)
+            if (value.Type == RealmValueType.Null)
             {
                 NativeMethods.null_equal(this, realm, propertyIndex, out nativeException);
             }
             else
             {
-                NativeMethods.string_like(this, realm, propertyIndex, value, (IntPtr)value.Length, caseSensitive, out nativeException);
+                var (primitive, gcHandle) = value.ToNative();
+                NativeMethods.string_like(this, realm, propertyIndex, primitive, caseSensitive, out nativeException);
+                gcHandle?.Free();
             }
 
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void PrimitiveEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
+        public unsafe void ValueEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            NativeMethods.primitive_equal(this, realm, propertyIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.primitive_equal(this, realm, propertyIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void PrimitiveNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
+        public unsafe void ValueNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            NativeMethods.primitive_not_equal(this, realm, propertyIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.primitive_not_equal(this, realm, propertyIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void PrimitiveLess(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
+        public unsafe void ValueLess(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            NativeMethods.primitive_less(this, realm, propertyIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.primitive_less(this, realm, propertyIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void PrimitiveLessEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
+        public unsafe void ValueLessEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            NativeMethods.primitive_less_equal(this, realm, propertyIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.primitive_less_equal(this, realm, propertyIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void PrimitiveGreater(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
+        public unsafe void ValueGreater(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            NativeMethods.primitive_greater(this, realm, propertyIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.primitive_greater(this, realm, propertyIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void PrimitiveGreaterEqual(SharedRealmHandle realm, IntPtr propertyIndex, PrimitiveValue value)
+        public unsafe void ValueGreaterEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            NativeMethods.primitive_greater_equal(this, realm, propertyIndex, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            NativeMethods.primitive_greater_equal(this, realm, propertyIndex, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
         }
 

--- a/Realm/Realm/Handles/QueryHandle.cs
+++ b/Realm/Realm/Handles/QueryHandle.cs
@@ -36,7 +36,6 @@ namespace Realms
         private static class NativeMethods
         {
 #pragma warning disable IDE1006 // Naming Styles
-#pragma warning disable SA1121 // Use built-in type alias
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_string_contains", CallingConvention = CallingConvention.Cdecl)]
             public static extern void string_contains(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx,
@@ -111,7 +110,6 @@ namespace Realms
             public static extern IntPtr create_results(QueryHandle queryPtr, SharedRealmHandle sharedRealm, SortDescriptorHandle sortDescriptor, out NativeException ex);
 
 #pragma warning restore IDE1006 // Naming Styles
-#pragma warning restore SA1121 // Use built-in type alias
         }
 
         public QueryHandle(RealmHandle root, IntPtr handle) : base(root, handle)
@@ -128,9 +126,9 @@ namespace Realms
         /// </summary>
         public void StringContains(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.string_contains(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -139,9 +137,9 @@ namespace Realms
         /// </summary>
         public void StringStartsWith(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.string_starts_with(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -150,9 +148,9 @@ namespace Realms
         /// </summary>
         public void StringEndsWith(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.string_ends_with(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -161,9 +159,9 @@ namespace Realms
         /// </summary>
         public void StringEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.string_equal(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -172,9 +170,9 @@ namespace Realms
         /// </summary>
         public void StringNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.string_not_equal(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
@@ -187,9 +185,9 @@ namespace Realms
             }
             else
             {
-                var (primitive, gcHandle) = value.ToNative();
+                var (primitive, handles) = value.ToNative();
                 NativeMethods.string_like(this, realm, propertyIndex, primitive, caseSensitive, out nativeException);
-                gcHandle?.Free();
+                handles?.Dispose();
             }
 
             nativeException.ThrowIfNecessary();
@@ -197,49 +195,49 @@ namespace Realms
 
         public unsafe void ValueEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_equal(this, realm, propertyIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void ValueNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_not_equal(this, realm, propertyIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void ValueLess(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_less(this, realm, propertyIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void ValueLessEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_less_equal(this, realm, propertyIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void ValueGreater(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_greater(this, realm, propertyIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 
         public unsafe void ValueGreaterEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_greater_equal(this, realm, propertyIndex, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
         }
 

--- a/Realm/Realm/Handles/QueryHandle.cs
+++ b/Realm/Realm/Handles/QueryHandle.cs
@@ -79,9 +79,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_primitive_greater_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void primitive_greater_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, PrimitiveValue primitive, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_object_equal", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void query_object_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, ObjectHandle objectHandle, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "query_null_equal", CallingConvention = CallingConvention.Cdecl)]
             public static extern void null_equal(QueryHandle queryPtr, SharedRealmHandle realm, IntPtr property_ndx, out NativeException ex);
 
@@ -124,7 +121,7 @@ namespace Realms
         /// <summary>
         /// If the user hasn't specified it, should be caseSensitive=true.
         /// </summary>
-        public void StringContains(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
+        public void StringContains(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value, bool caseSensitive)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.string_contains(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
@@ -135,7 +132,7 @@ namespace Realms
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringStartsWith(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
+        public void StringStartsWith(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value, bool caseSensitive)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.string_starts_with(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
@@ -146,7 +143,7 @@ namespace Realms
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringEndsWith(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
+        public void StringEndsWith(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value, bool caseSensitive)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.string_ends_with(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
@@ -157,7 +154,7 @@ namespace Realms
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
+        public void StringEqual(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value, bool caseSensitive)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.string_equal(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
@@ -168,7 +165,7 @@ namespace Realms
         /// <summary>
         /// If the user hasn't specified it, should be <c>caseSensitive = true</c>.
         /// </summary>
-        public void StringNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
+        public void StringNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value, bool caseSensitive)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.string_not_equal(this, realm, propertyIndex, primitive, caseSensitive, out var nativeException);
@@ -176,7 +173,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public void StringLike(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value, bool caseSensitive)
+        public void StringLike(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value, bool caseSensitive)
         {
             NativeException nativeException;
             if (value.Type == RealmValueType.Null)
@@ -193,7 +190,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void ValueEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
+        public unsafe void ValueEqual(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_equal(this, realm, propertyIndex, primitive, out var nativeException);
@@ -201,7 +198,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void ValueNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
+        public unsafe void ValueNotEqual(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_not_equal(this, realm, propertyIndex, primitive, out var nativeException);
@@ -209,7 +206,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void ValueLess(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
+        public unsafe void ValueLess(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_less(this, realm, propertyIndex, primitive, out var nativeException);
@@ -217,7 +214,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void ValueLessEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
+        public unsafe void ValueLessEqual(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_less_equal(this, realm, propertyIndex, primitive, out var nativeException);
@@ -225,7 +222,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void ValueGreater(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
+        public unsafe void ValueGreater(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_greater(this, realm, propertyIndex, primitive, out var nativeException);
@@ -233,17 +230,11 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public unsafe void ValueGreaterEqual(SharedRealmHandle realm, IntPtr propertyIndex, RealmValue value)
+        public unsafe void ValueGreaterEqual(SharedRealmHandle realm, IntPtr propertyIndex, in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
             NativeMethods.primitive_greater_equal(this, realm, propertyIndex, primitive, out var nativeException);
             handles?.Dispose();
-            nativeException.ThrowIfNecessary();
-        }
-
-        public void ObjectEqual(SharedRealmHandle realm, IntPtr propertyIndex, ObjectHandle objectHandle)
-        {
-            NativeMethods.query_object_equal(this, realm, propertyIndex, objectHandle, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -44,14 +44,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern void get_primitive(ResultsHandle results, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_string(ResultsHandle results, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] out bool isNull, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_binary(ResultsHandle results, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] out bool isNull, out NativeException ex);
-
             #endregion
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_count", CallingConvention = CallingConvention.Cdecl)]
@@ -130,18 +122,6 @@ namespace Realms
 
         protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
             NativeMethods.get_primitive(this, index, out result, out nativeException);
-
-        public override string GetStringAtIndex(int index)
-        {
-            return MarshalHelpers.GetString((IntPtr buffer, IntPtr length, out bool isNull, out NativeException ex) =>
-                NativeMethods.get_string(this, (IntPtr)index, buffer, length, out isNull, out ex));
-        }
-
-        public override byte[] GetByteArrayAtIndex(int index)
-        {
-            return MarshalHelpers.GetByteArray((IntPtr buffer, IntPtr bufferLength, out bool isNull, out NativeException ex) =>
-                NativeMethods.get_binary(this, (IntPtr)index, buffer, bufferLength, out isNull, out ex));
-        }
 
         #endregion
 

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -42,7 +42,7 @@ namespace Realms
             public static extern IntPtr get_object(ResultsHandle results, IntPtr index, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void get_primitive(ResultsHandle results, IntPtr link_ndx, ref PrimitiveValue value, out NativeException ex);
+            public static extern void get_primitive(ResultsHandle results, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_string(ResultsHandle results, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
@@ -128,8 +128,8 @@ namespace Realms
         protected override IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException) =>
             NativeMethods.get_object(this, index, out nativeException);
 
-        protected override void GetPrimitiveAtIndexCore(IntPtr index, ref PrimitiveValue result, out NativeException nativeException) =>
-            NativeMethods.get_primitive(this, index, ref result, out nativeException);
+        protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
+            NativeMethods.get_primitive(this, index, out result, out nativeException);
 
         public override string GetStringAtIndex(int index)
         {

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -36,15 +36,8 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_destroy", CallingConvention = CallingConvention.Cdecl)]
             public static extern void destroy(IntPtr resultsHandle);
 
-            #region get
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_object(ResultsHandle results, IntPtr index, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void get_primitive(ResultsHandle results, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
-
-            #endregion
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void get_value(ResultsHandle results, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_count", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr count(ResultsHandle results, out NativeException ex);
@@ -115,15 +108,8 @@ namespace Realms
             NativeMethods.destroy(handle);
         }
 
-        #region GetAtIndex
-
-        protected override IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException) =>
-            NativeMethods.get_object(this, index, out nativeException);
-
-        protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
-            NativeMethods.get_primitive(this, index, out result, out nativeException);
-
-        #endregion
+        protected override void GetValueAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
+            NativeMethods.get_value(this, index, out result, out nativeException);
 
         public override int Count()
         {

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -77,15 +77,6 @@ namespace Realms
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool add_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_string", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool add_string(SetHandle handle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLength, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_binary", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool add_binary(SetHandle handle, IntPtr buffer, IntPtr bufferLength,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_embedded", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern IntPtr add_embedded(SetHandle handle, out NativeException ex);
@@ -102,15 +93,6 @@ namespace Realms
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool contains_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_string", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool contains_string(SetHandle handle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_binary", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool contains_binary(SetHandle handle, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
-
             #endregion
 
             #region remove
@@ -122,15 +104,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_primitive", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool remove_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_string", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool remove_string(SetHandle handle, [MarshalAs(UnmanagedType.LPWStr)] string value, IntPtr valueLen, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_binary", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool remove_binary(SetHandle handle, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] bool has_value, out NativeException ex);
 
             #endregion
 
@@ -233,26 +206,12 @@ namespace Realms
             return result;
         }
 
-        public unsafe bool Add(PrimitiveValue value)
+        public unsafe bool Add(RealmValue value)
         {
-            var result = NativeMethods.add_primitive(this, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            var result = NativeMethods.add_primitive(this, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public bool Add(string value)
-        {
-            var result = NativeMethods.add_string(this, value, value.IntPtrLength(), out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public unsafe bool Add(byte[] value)
-        {
-            var result = false;
-            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
-                result = NativeMethods.add_binary(this, buffer, bufferSize, hasValue, out ex));
-
             return result;
         }
 
@@ -274,28 +233,12 @@ namespace Realms
             return result;
         }
 
-        public unsafe bool Contains(PrimitiveValue value)
+        public unsafe bool Contains(RealmValue value)
         {
-            var result = NativeMethods.contains_primitive(this, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            var result = NativeMethods.contains_primitive(this, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public bool Contains(string value)
-        {
-            var result = NativeMethods.contains_string(this, value, value.IntPtrLength(), out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public unsafe bool Contains(byte[] value)
-        {
-            var result = false;
-            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
-            {
-                result = NativeMethods.contains_binary(this, buffer, bufferSize, hasValue, out ex);
-            });
-
             return result;
         }
 
@@ -310,26 +253,12 @@ namespace Realms
             return result;
         }
 
-        public unsafe bool Remove(PrimitiveValue value)
+        public unsafe bool Remove(RealmValue value)
         {
-            var result = NativeMethods.remove_primitive(this, value, out var nativeException);
+            var (primitive, gcHandle) = value.ToNative();
+            var result = NativeMethods.remove_primitive(this, primitive, out var nativeException);
+            gcHandle?.Free();
             nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public bool Remove(string value)
-        {
-            var result = NativeMethods.remove_string(this, value, value.IntPtrLength(), out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public unsafe bool Remove(byte[] value)
-        {
-            var result = false;
-            MarshalHelpers.SetByteArray(value, (IntPtr buffer, IntPtr bufferSize, bool hasValue, out NativeException ex) =>
-                result = NativeMethods.remove_binary(this, buffer, bufferSize, hasValue, out ex));
-
             return result;
         }
 

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -57,55 +57,20 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_freeze", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr freeze(SetHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
 
-            #region get
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void get_value(SetHandle handle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_object", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_object(SetHandle handle, IntPtr link_ndx, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void get_primitive(SetHandle handle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
-
-            #endregion
-
-            #region add
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_object", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_value", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool add_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
+            public static extern bool add_value(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_primitive", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_value", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool add_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
+            public static extern bool contains_value(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_add_embedded", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_value", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern IntPtr add_embedded(SetHandle handle, out NativeException ex);
-
-            #endregion
-
-            #region find
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_object", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool contains_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_contains_primitive", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool contains_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
-
-            #endregion
-
-            #region remove
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_object", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool remove_object(SetHandle handle, ObjectHandle objectHandle, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_remove_primitive", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool remove_primitive(SetHandle handle, PrimitiveValue value, out NativeException ex);
-
-            #endregion
+            public static extern bool remove_value(SetHandle handle, PrimitiveValue value, out NativeException ex);
 
 #pragma warning restore IDE1006 // Naming Styles
         }
@@ -187,81 +152,34 @@ namespace Realms
             return new SetHandle(frozenRealmHandle, result);
         }
 
-        #region GetAtIndex
+        protected override void GetValueAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
+            NativeMethods.get_value(this, index, out result, out nativeException);
 
-        protected override IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException) =>
-            NativeMethods.get_object(this, index, out nativeException);
-
-        protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
-            NativeMethods.get_primitive(this, index, out result, out nativeException);
-
-        #endregion
-
-        #region Add
-
-        public bool Add(ObjectHandle objectHandle)
-        {
-            var result = NativeMethods.add_object(this, objectHandle, out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public unsafe bool Add(RealmValue value)
+        public unsafe bool Add(in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
-            var result = NativeMethods.add_primitive(this, primitive, out var nativeException);
+            var result = NativeMethods.add_value(this, primitive, out var nativeException);
             handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return result;
         }
 
-        public ObjectHandle AddEmbedded()
-        {
-            var result = NativeMethods.add_embedded(this, out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return new ObjectHandle(Root, result);
-        }
-
-        #endregion
-
-        #region Find
-
-        public bool Contains(ObjectHandle objectHandle)
-        {
-            var result = NativeMethods.contains_object(this, objectHandle, out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public unsafe bool Contains(RealmValue value)
+        public unsafe bool Contains(in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
-            var result = NativeMethods.contains_primitive(this, primitive, out var nativeException);
+            var result = NativeMethods.contains_value(this, primitive, out var nativeException);
             handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return result;
         }
 
-        #endregion
-
-        #region Remove
-
-        public bool Remove(ObjectHandle objectHandle)
-        {
-            var result = NativeMethods.remove_object(this, objectHandle, out var nativeException);
-            nativeException.ThrowIfNecessary();
-            return result;
-        }
-
-        public unsafe bool Remove(RealmValue value)
+        public unsafe bool Remove(in RealmValue value)
         {
             var (primitive, handles) = value.ToNative();
-            var result = NativeMethods.remove_primitive(this, primitive, out var nativeException);
+            var result = NativeMethods.remove_value(this, primitive, out var nativeException);
             handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return result;
         }
-
-        #endregion
     }
 }

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -208,9 +208,9 @@ namespace Realms
 
         public unsafe bool Add(RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             var result = NativeMethods.add_primitive(this, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return result;
         }
@@ -235,9 +235,9 @@ namespace Realms
 
         public unsafe bool Contains(RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             var result = NativeMethods.contains_primitive(this, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return result;
         }
@@ -255,9 +255,9 @@ namespace Realms
 
         public unsafe bool Remove(RealmValue value)
         {
-            var (primitive, gcHandle) = value.ToNative();
+            var (primitive, handles) = value.ToNative();
             var result = NativeMethods.remove_primitive(this, primitive, out var nativeException);
-            gcHandle?.Free();
+            handles?.Dispose();
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -63,7 +63,7 @@ namespace Realms
             public static extern IntPtr get_object(SetHandle handle, IntPtr link_ndx, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_primitive", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void get_primitive(SetHandle handle, IntPtr link_ndx, ref PrimitiveValue value, out NativeException ex);
+            public static extern void get_primitive(SetHandle handle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_string", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_string(SetHandle handle, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
@@ -227,8 +227,8 @@ namespace Realms
         protected override IntPtr GetObjectAtIndexCore(IntPtr index, out NativeException nativeException) =>
             NativeMethods.get_object(this, index, out nativeException);
 
-        protected override void GetPrimitiveAtIndexCore(IntPtr index, ref PrimitiveValue result, out NativeException nativeException) =>
-            NativeMethods.get_primitive(this, index, ref result, out nativeException);
+        protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
+            NativeMethods.get_primitive(this, index, out result, out nativeException);
 
         public override string GetStringAtIndex(int index)
         {

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -65,14 +65,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_primitive", CallingConvention = CallingConvention.Cdecl)]
             public static extern void get_primitive(SetHandle handle, IntPtr link_ndx, out PrimitiveValue value, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_string", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_string(SetHandle handle, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] out bool isNull, out NativeException ex);
-
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_binary", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_binary(SetHandle handle, IntPtr link_ndx, IntPtr buffer, IntPtr bufsize,
-                [MarshalAs(UnmanagedType.U1)] out bool isNull, out NativeException ex);
-
             #endregion
 
             #region add
@@ -229,18 +221,6 @@ namespace Realms
 
         protected override void GetPrimitiveAtIndexCore(IntPtr index, out PrimitiveValue result, out NativeException nativeException) =>
             NativeMethods.get_primitive(this, index, out result, out nativeException);
-
-        public override string GetStringAtIndex(int index)
-        {
-            return MarshalHelpers.GetString((IntPtr buffer, IntPtr length, out bool isNull, out NativeException ex) =>
-                NativeMethods.get_string(this, (IntPtr)index, buffer, length, out isNull, out ex));
-        }
-
-        public override byte[] GetByteArrayAtIndex(int index)
-        {
-            return MarshalHelpers.GetByteArray((IntPtr buffer, IntPtr bufferLength, out bool isNull, out NativeException ex) =>
-                NativeMethods.get_binary(this, (IntPtr)index, buffer, bufferLength, out isNull, out ex));
-        }
 
         #endregion
 

--- a/Realm/Realm/Handles/TableHandle.cs
+++ b/Realm/Realm/Handles/TableHandle.cs
@@ -86,9 +86,11 @@ namespace Realms
             return TryFindCore(realmHandle, result, ex, out objectHandle);
         }
 
-        public unsafe bool TryFind(SharedRealmHandle realmHandle, PrimitiveValue id, out ObjectHandle objectHandle)
+        public unsafe bool TryFind(SharedRealmHandle realmHandle, RealmValue id, out ObjectHandle objectHandle)
         {
-            var result = NativeMethods.get_object_for_primitive_primarykey(this, realmHandle, id, out var ex);
+            var (primitiveValue, gcHandle) = id.ToNative();
+            var result = NativeMethods.get_object_for_primitive_primarykey(this, realmHandle, primitiveValue, out var ex);
+            gcHandle?.Free();
             return TryFindCore(realmHandle, result, ex, out objectHandle);
         }
 

--- a/Realm/Realm/Handles/TableHandle.cs
+++ b/Realm/Realm/Handles/TableHandle.cs
@@ -74,7 +74,7 @@ namespace Realms
             return new ObjectHandle(realmHandle, result);
         }
 
-        public unsafe bool TryFind(SharedRealmHandle realmHandle, RealmValue id, out ObjectHandle objectHandle)
+        public unsafe bool TryFind(SharedRealmHandle realmHandle, in RealmValue id, out ObjectHandle objectHandle)
         {
             var (primitiveValue, handles) = id.ToNative();
             var result = NativeMethods.get_object_for_primarykey(this, realmHandle, primitiveValue, out var ex);

--- a/Realm/Realm/Handles/TableHandle.cs
+++ b/Realm/Realm/Handles/TableHandle.cs
@@ -27,7 +27,6 @@ namespace Realms
         private static class NativeMethods
         {
 #pragma warning disable IDE1006 // Naming Styles
-#pragma warning disable SA1121 // Use built-in type alias
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "table_destroy", CallingConvention = CallingConvention.Cdecl)]
             public static extern void destroy(IntPtr tableHandle, out NativeException ex);
@@ -42,7 +41,6 @@ namespace Realms
             public static extern IntPtr get_object_for_primarykey(TableHandle handle, SharedRealmHandle realmHandle, PrimitiveValue value, out NativeException ex);
 
 #pragma warning restore IDE1006 // Naming Styles
-#pragma warning restore SA1121 // Use built-in type alias
         }
 
         [Preserve]
@@ -78,9 +76,9 @@ namespace Realms
 
         public unsafe bool TryFind(SharedRealmHandle realmHandle, RealmValue id, out ObjectHandle objectHandle)
         {
-            var (primitiveValue, gcHandle) = id.ToNative();
+            var (primitiveValue, handles) = id.ToNative();
             var result = NativeMethods.get_object_for_primarykey(this, realmHandle, primitiveValue, out var ex);
-            gcHandle?.Free();
+            handles?.Dispose();
             ex.ThrowIfNecessary();
 
             if (result == IntPtr.Zero)

--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -39,7 +39,7 @@ namespace Realms.Helpers
 
         public static TResult Convert<TFrom, TResult>(TFrom value)
         {
-            /**
+            /*
              * This is special cased due to a bug in the Xamarin.iOS interpreter. When value
              * is null, we end up with a NRE with the following stacktrace:
              *

--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -39,6 +39,24 @@ namespace Realms.Helpers
 
         public static TResult Convert<TFrom, TResult>(TFrom value)
         {
+            /**
+             * This is special cased due to a bug in the Xamarin.iOS interpreter. When value
+             * is null, we end up with a NRE with the following stacktrace:
+             *
+             * <System.NullReferenceException: Object reference not set to an instance of an object
+             * at System.Linq.Expressions.Interpreter.LightLambda.Run1[T0,TRet] (T0 arg0) [0x00038] in <ee28ffe65f2e47a98ea97b07327fb8f4>:0
+             * at (wrapper delegate-invoke) System.Func`2[System.String,Realms.RealmValue].invoke_TResult_T(string)
+             * at Realms.Helpers.Operator.Convert[TFrom,TResult] (TFrom value) [0x00005] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+             * at Realms.RealmList`1[T].<.ctor>b__5_1 (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+             * at Realms.RealmList`1[T].Add (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+             *
+             * May or may not be related to https://github.com/mono/mono/issues/15852.
+             */
+            if (value is null && typeof(TResult) == typeof(RealmValue))
+            {
+                return Convert<RealmValue, TResult>(RealmValue.Null());
+            }
+
             return GenericOperator<TFrom, TResult>.Convert(value);
         }
 

--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -39,22 +39,33 @@ namespace Realms.Helpers
 
         public static TResult Convert<TFrom, TResult>(TFrom value)
         {
-            /*
-             * This is special cased due to a bug in the Xamarin.iOS interpreter. When value
-             * is null, we end up with a NRE with the following stacktrace:
-             *
-             * <System.NullReferenceException: Object reference not set to an instance of an object
-             * at System.Linq.Expressions.Interpreter.LightLambda.Run1[T0,TRet] (T0 arg0) [0x00038] in <ee28ffe65f2e47a98ea97b07327fb8f4>:0
-             * at (wrapper delegate-invoke) System.Func`2[System.String,Realms.RealmValue].invoke_TResult_T(string)
-             * at Realms.Helpers.Operator.Convert[TFrom,TResult] (TFrom value) [0x00005] in <675c1cc840764fcb9ab78b319ccfeee3>:0
-             * at Realms.RealmList`1[T].<.ctor>b__5_1 (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
-             * at Realms.RealmList`1[T].Add (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
-             *
-             * May or may not be related to https://github.com/mono/mono/issues/15852.
-             */
-            if (value is null && typeof(TResult) == typeof(RealmValue))
+            if (typeof(TResult) == typeof(RealmValue))
             {
-                return Convert<RealmValue, TResult>(RealmValue.Null());
+                /* This is special cased due to a bug in the Xamarin.iOS interpreter. When value
+                 * is null, we end up with a NRE with the following stacktrace:
+                 *
+                 * <System.NullReferenceException: Object reference not set to an instance of an object
+                 * at System.Linq.Expressions.Interpreter.LightLambda.Run1[T0,TRet] (T0 arg0) [0x00038] in <ee28ffe65f2e47a98ea97b07327fb8f4>:0
+                 * at (wrapper delegate-invoke) System.Func`2[System.String,Realms.RealmValue].invoke_TResult_T(string)
+                 * at Realms.Helpers.Operator.Convert[TFrom,TResult] (TFrom value) [0x00005] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 * at Realms.RealmList`1[T].<.ctor>b__5_1 (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 * at Realms.RealmList`1[T].Add (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 *
+                 * May or may not be related to https://github.com/mono/mono/issues/15852.
+                 */
+                if (value is null)
+                {
+                    return Convert<RealmValue, TResult>(RealmValue.Null());
+                }
+
+                /* This is another special case where `value` is inheritable from RealmObjectBase. There's
+                 * no direct conversion from T to RealmValue, but there's conversion if we go through RealmObjectBase.
+                 */
+
+                if (value is RealmObjectBase robj)
+                {
+                    return Convert<RealmValue, TResult>(robj);
+                }
             }
 
             return GenericOperator<TFrom, TResult>.Convert(value);

--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -20,7 +20,6 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Realms.Helpers;
-using Realms.Schema;
 
 namespace Realms
 {
@@ -76,7 +75,7 @@ namespace Realms
         {
             Argument.NotNull(value, nameof(value));
 
-            if (_argumentType != (PropertyType.Object | PropertyType.Nullable))
+            if (_argumentType != RealmValueType.Object)
             {
                 throw new NotSupportedException("IndexOf on non-object results is not supported.");
             }

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -24,7 +24,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using MongoDB.Bson;
-using Realms.Native;
 using Realms.Schema;
 using LazyMethod = System.Lazy<System.Reflection.MethodInfo>;
 
@@ -632,35 +631,12 @@ namespace Realms
                 case string stringValue:
                     queryHandle.StringEqual(_realm.SharedRealmHandle, propertyIndex, stringValue, caseSensitive: true);
                     break;
-                case bool boolValue:
-                    queryHandle.PrimitiveEqual(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Bool(boolValue));
-                    break;
-                case DateTimeOffset dateValue:
-                    queryHandle.PrimitiveEqual(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Date(dateValue));
-                    break;
-                case byte[] buffer:
-                    if (buffer.Length == 0)
-                    {
-                        // see RealmObjectBase.SetByteArrayValue
-                        queryHandle.BinaryEqual(_realm.SharedRealmHandle, propertyIndex, (IntPtr)0x1, IntPtr.Zero);
-                        return;
-                    }
-
-                    unsafe
-                    {
-                        fixed (byte* bufferPtr = (byte[])value)
-                        {
-                            queryHandle.BinaryEqual(_realm.SharedRealmHandle, propertyIndex, (IntPtr)bufferPtr, (IntPtr)buffer.Length);
-                        }
-                    }
-
-                    break;
                 case RealmObjectBase obj:
                     queryHandle.ObjectEqual(_realm.SharedRealmHandle, propertyIndex, obj.ObjectHandle);
                     break;
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.PrimitiveEqual);
+                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.ValueEqual);
                     break;
             }
         }
@@ -676,36 +652,13 @@ namespace Realms
                 case string stringValue:
                     queryHandle.StringNotEqual(_realm.SharedRealmHandle, propertyIndex, stringValue, caseSensitive: true);
                     break;
-                case bool boolValue:
-                    queryHandle.PrimitiveNotEqual(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Bool(boolValue));
-                    break;
-                case DateTimeOffset date:
-                    queryHandle.PrimitiveNotEqual(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Date(date));
-                    break;
-                case byte[] buffer:
-                    if (buffer.Length == 0)
-                    {
-                        // see RealmObjectBase.SetByteArrayValue
-                        queryHandle.BinaryNotEqual(_realm.SharedRealmHandle, propertyIndex, (IntPtr)0x1, IntPtr.Zero);
-                        return;
-                    }
-
-                    unsafe
-                    {
-                        fixed (byte* bufferPtr = (byte[])value)
-                        {
-                            queryHandle.BinaryNotEqual(_realm.SharedRealmHandle, propertyIndex, (IntPtr)bufferPtr, (IntPtr)buffer.Length);
-                        }
-                    }
-
-                    break;
                 case RealmObjectBase obj:
                     queryHandle.Not();
                     queryHandle.ObjectEqual(_realm.SharedRealmHandle, propertyIndex, obj.ObjectHandle);
                     break;
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.PrimitiveNotEqual);
+                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.ValueNotEqual);
                     break;
             }
         }
@@ -715,15 +668,12 @@ namespace Realms
             var propertyIndex = _metadata.PropertyIndices[columnName];
             switch (value)
             {
-                case DateTimeOffset date:
-                    queryHandle.PrimitiveLess(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Date(date));
-                    break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.PrimitiveLess);
+                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.ValueLess);
                     break;
             }
         }
@@ -733,15 +683,12 @@ namespace Realms
             var propertyIndex = _metadata.PropertyIndices[columnName];
             switch (value)
             {
-                case DateTimeOffset date:
-                    queryHandle.PrimitiveLessEqual(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Date(date));
-                    break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.PrimitiveLessEqual);
+                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.ValueLessEqual);
                     break;
             }
         }
@@ -751,15 +698,12 @@ namespace Realms
             var propertyIndex = _metadata.PropertyIndices[columnName];
             switch (value)
             {
-                case DateTimeOffset date:
-                    queryHandle.PrimitiveGreater(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Date(date));
-                    break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.PrimitiveGreater);
+                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.ValueGreater);
                     break;
             }
         }
@@ -769,20 +713,17 @@ namespace Realms
             var propertyIndex = _metadata.PropertyIndices[columnName];
             switch (value)
             {
-                case DateTimeOffset date:
-                    queryHandle.PrimitiveGreaterEqual(_realm.SharedRealmHandle, propertyIndex, PrimitiveValue.Date(date));
-                    break;
                 case string _:
                 case bool _:
                     throw new Exception($"Unsupported type {value.GetType().Name}");
                 default:
                     // The other types aren't handled by the switch because of potential compiler applied conversions
-                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.PrimitiveGreaterEqual);
+                    AddQueryForConvertibleTypes(_realm.SharedRealmHandle, propertyIndex, value, columnType, queryHandle.ValueGreaterEqual);
                     break;
             }
         }
 
-        private static void AddQueryForConvertibleTypes(SharedRealmHandle realm, IntPtr propertyIndex, object value, Type columnType, Action<SharedRealmHandle, IntPtr, PrimitiveValue> action)
+        private static void AddQueryForConvertibleTypes(SharedRealmHandle realm, IntPtr propertyIndex, object value, Type columnType, Action<SharedRealmHandle, IntPtr, RealmValue> action)
         {
             if (columnType.IsConstructedGenericType && columnType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
@@ -799,15 +740,15 @@ namespace Realms
                 columnType == typeof(RealmInteger<int>) ||
                 columnType == typeof(RealmInteger<long>))
             {
-                action(realm, propertyIndex, PrimitiveValue.Int((long)Convert.ChangeType(value, typeof(long))));
+                action(realm, propertyIndex, (long)Convert.ChangeType(value, typeof(long)));
             }
             else if (columnType == typeof(float))
             {
-                action(realm, propertyIndex, PrimitiveValue.Float((float)Convert.ChangeType(value, typeof(float))));
+                action(realm, propertyIndex, (float)Convert.ChangeType(value, typeof(float)));
             }
             else if (columnType == typeof(double))
             {
-                action(realm, propertyIndex, PrimitiveValue.Double((double)Convert.ChangeType(value, typeof(double))));
+                action(realm, propertyIndex, (double)Convert.ChangeType(value, typeof(double)));
             }
             else if (columnType == typeof(Decimal128))
             {
@@ -817,15 +758,27 @@ namespace Realms
                     decimalValue = (Decimal128)Convert.ChangeType(value, typeof(Decimal128));
                 }
 
-                action(realm, propertyIndex, PrimitiveValue.Decimal(decimalValue));
+                action(realm, propertyIndex, decimalValue);
             }
             else if (columnType == typeof(decimal))
             {
-                action(realm, propertyIndex, PrimitiveValue.Decimal((decimal)Convert.ChangeType(value, typeof(decimal))));
+                action(realm, propertyIndex, (decimal)Convert.ChangeType(value, typeof(decimal)));
             }
             else if (columnType == typeof(ObjectId))
             {
-                action(realm, propertyIndex, PrimitiveValue.ObjectId((ObjectId)Convert.ChangeType(value, typeof(ObjectId))));
+                action(realm, propertyIndex, (ObjectId)Convert.ChangeType(value, typeof(ObjectId)));
+            }
+            else if (columnType == typeof(byte[]))
+            {
+                action(realm, propertyIndex, (byte[])value);
+            }
+            else if (columnType == typeof(bool))
+            {
+                action(realm, propertyIndex, (bool)value);
+            }
+            else if (columnType == typeof(DateTimeOffset))
+            {
+                action(realm, propertyIndex, (DateTimeOffset)value);
             }
             else
             {

--- a/Realm/Realm/Native/PrimitiveValue.cs
+++ b/Realm/Realm/Native/PrimitiveValue.cs
@@ -58,6 +58,9 @@ namespace Realms.Native
         [FieldOffset(0)]
         private BinaryValue data_value;
 
+        [FieldOffset(0)]
+        private LinkValue link_value;
+
         [FieldOffset(16)]
         [MarshalAs(UnmanagedType.U1)]
         public RealmValueType Type;
@@ -166,6 +169,18 @@ namespace Realms.Native
             };
         }
 
+        public static PrimitiveValue Object(ObjectHandle handle)
+        {
+            return new PrimitiveValue
+            {
+                Type = handle == null ? RealmValueType.Null : RealmValueType.Object,
+                link_value = new LinkValue
+                {
+                    object_ptr = handle?.DangerousGetHandle() ?? IntPtr.Zero
+                }
+            };
+        }
+
         public bool AsBool() => bool_value;
 
         public long AsInt() => int_value;
@@ -207,6 +222,8 @@ namespace Realms.Native
             return bytes;
         }
 
+        public ObjectHandle AsObject(RealmHandle root) => new ObjectHandle(root, link_value.object_ptr);
+
         [StructLayout(LayoutKind.Sequential)]
         private unsafe struct StringValue
         {
@@ -219,6 +236,12 @@ namespace Realms.Native
         {
             public byte* data;
             public IntPtr size;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LinkValue
+        {
+            public IntPtr object_ptr;
         }
     }
 }

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -1091,20 +1091,8 @@ namespace Realms
         /// <exception cref="RealmClassLacksPrimaryKeyException">
         /// If the <see cref="RealmObject"/> class T lacks <see cref="PrimaryKeyAttribute"/>.
         /// </exception>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
         public T Find<T>(long? primaryKey)
-            where T : RealmObject
-        {
-            ThrowIfDisposed();
-
-            var metadata = Metadata[typeof(T).GetTypeInfo().GetMappedOrOriginalName()];
-            if (metadata.Table.TryFind(SharedRealmHandle, primaryKey, out var objectHandle))
-            {
-                return (T)MakeObject(metadata, objectHandle);
-            }
-
-            return null;
-        }
+            where T : RealmObject => FindCore<T>(primaryKey);
 
         /// <summary>
         /// Fast lookup of an object from a class which has a PrimaryKey property.
@@ -1115,20 +1103,8 @@ namespace Realms
         /// <exception cref="RealmClassLacksPrimaryKeyException">
         /// If the <see cref="RealmObject"/> class T lacks <see cref="PrimaryKeyAttribute"/>.
         /// </exception>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
         public T Find<T>(string primaryKey)
-            where T : RealmObject
-        {
-            ThrowIfDisposed();
-
-            var metadata = Metadata[typeof(T).GetTypeInfo().GetMappedOrOriginalName()];
-            if (metadata.Table.TryFind(SharedRealmHandle, primaryKey, out var objectHandle))
-            {
-                return (T)MakeObject(metadata, objectHandle);
-            }
-
-            return null;
-        }
+            where T : RealmObject => FindCore<T>(primaryKey);
 
         /// <summary>
         /// Fast lookup of an object from a class which has a PrimaryKey property.
@@ -1139,8 +1115,11 @@ namespace Realms
         /// <exception cref="RealmClassLacksPrimaryKeyException">
         /// If the <see cref="RealmObject"/> class T lacks <see cref="PrimaryKeyAttribute"/>.
         /// </exception>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
         public T Find<T>(ObjectId? primaryKey)
+            where T : RealmObject => FindCore<T>(primaryKey);
+
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
+        private T FindCore<T>(RealmValue primaryKey)
             where T : RealmObject
         {
             ThrowIfDisposed();
@@ -1671,19 +1650,7 @@ namespace Realms
             /// <exception cref="RealmClassLacksPrimaryKeyException">
             /// If the <see cref="RealmObject"/> class T lacks <see cref="PrimaryKeyAttribute"/>.
             /// </exception>
-            [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
-            public RealmObject Find(string className, long? primaryKey)
-            {
-                _realm.ThrowIfDisposed();
-
-                var metadata = _realm.Metadata[className];
-                if (metadata.Table.TryFind(_realm.SharedRealmHandle, primaryKey, out var objectHandle))
-                {
-                    return (RealmObject)_realm.MakeObject(metadata, objectHandle);
-                }
-
-                return null;
-            }
+            public dynamic Find(string className, long? primaryKey) => FindCore(className, primaryKey);
 
             /// <summary>
             /// Fast lookup of an object for dynamic use, from a class which has a PrimaryKey property.
@@ -1694,19 +1661,7 @@ namespace Realms
             /// <exception cref="RealmClassLacksPrimaryKeyException">
             /// If the <see cref="RealmObject"/> class T lacks <see cref="PrimaryKeyAttribute"/>.
             /// </exception>
-            [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
-            public dynamic Find(string className, string primaryKey)
-            {
-                _realm.ThrowIfDisposed();
-
-                var metadata = _realm.Metadata[className];
-                if (metadata.Table.TryFind(_realm.SharedRealmHandle, primaryKey, out var objectHandle))
-                {
-                    return _realm.MakeObject(metadata, objectHandle);
-                }
-
-                return null;
-            }
+            public dynamic Find(string className, string primaryKey) => FindCore(className, primaryKey);
 
             /// <summary>
             /// Fast lookup of an object for dynamic use, from a class which has a PrimaryKey property.
@@ -1719,15 +1674,17 @@ namespace Realms
             /// <exception cref="RealmClassLacksPrimaryKeyException">
             /// If the <see cref="RealmObject"/> class T lacks <see cref="PrimaryKeyAttribute"/>.
             /// </exception>
+            public dynamic Find(string className, ObjectId? primaryKey) => FindCore(className, primaryKey);
+
             [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
-            public RealmObject Find(string className, ObjectId? primaryKey)
+            private dynamic FindCore(string className, RealmValue primaryKey)
             {
                 _realm.ThrowIfDisposed();
 
                 var metadata = _realm.Metadata[className];
                 if (metadata.Table.TryFind(_realm.SharedRealmHandle, primaryKey, out var objectHandle))
                 {
-                    return (RealmObject)_realm.MakeObject(metadata, objectHandle);
+                    return _realm.MakeObject(metadata, objectHandle);
                 }
 
                 return null;

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -1098,7 +1098,7 @@ namespace Realms
             ThrowIfDisposed();
 
             var metadata = Metadata[typeof(T).GetTypeInfo().GetMappedOrOriginalName()];
-            if (metadata.Table.TryFind(SharedRealmHandle, PrimitiveValue.NullableInt(primaryKey), out var objectHandle))
+            if (metadata.Table.TryFind(SharedRealmHandle, primaryKey, out var objectHandle))
             {
                 return (T)MakeObject(metadata, objectHandle);
             }
@@ -1146,7 +1146,7 @@ namespace Realms
             ThrowIfDisposed();
 
             var metadata = Metadata[typeof(T).GetTypeInfo().GetMappedOrOriginalName()];
-            if (metadata.Table.TryFind(SharedRealmHandle, PrimitiveValue.NullableObjectId(primaryKey), out var objectHandle))
+            if (metadata.Table.TryFind(SharedRealmHandle, primaryKey, out var objectHandle))
             {
                 return (T)MakeObject(metadata, objectHandle);
             }
@@ -1677,7 +1677,7 @@ namespace Realms
                 _realm.ThrowIfDisposed();
 
                 var metadata = _realm.Metadata[className];
-                if (metadata.Table.TryFind(_realm.SharedRealmHandle, PrimitiveValue.NullableInt(primaryKey), out var objectHandle))
+                if (metadata.Table.TryFind(_realm.SharedRealmHandle, primaryKey, out var objectHandle))
                 {
                     return (RealmObject)_realm.MakeObject(metadata, objectHandle);
                 }
@@ -1725,7 +1725,7 @@ namespace Realms
                 _realm.ThrowIfDisposed();
 
                 var metadata = _realm.Metadata[className];
-                if (metadata.Table.TryFind(_realm.SharedRealmHandle, PrimitiveValue.NullableObjectId(primaryKey), out var objectHandle))
+                if (metadata.Table.TryFind(_realm.SharedRealmHandle, primaryKey, out var objectHandle))
                 {
                     return (RealmObject)_realm.MakeObject(metadata, objectHandle);
                 }

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -23,8 +23,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <ProjectReference Include="..\Realm.Fody\Realm.Fody.csproj" PrivateAssets="None" />

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.*" PrivateAssets="None" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -24,7 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <ProjectReference Include="..\Realm.Fody\Realm.Fody.csproj" PrivateAssets="None" />
   </ItemGroup>

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -170,12 +170,6 @@ namespace Realms
 
                         return Operator.Convert<RealmObject, T>((RealmObject)result);
 
-                    case RealmValueType.String:
-                        return Operator.Convert<string, T>(Handle.Value.GetStringAtIndex(index));
-
-                    case RealmValueType.Data:
-                        return Operator.Convert<byte[], T>(Handle.Value.GetByteArrayAtIndex(index));
-
                     default:
                         return Handle.Value.GetPrimitiveAtIndex(index).Get<T>();
                 }

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -25,9 +25,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Realms.Exceptions;
 using Realms.Helpers;
-using Realms.Native;
 using Realms.Schema;
 
 namespace Realms
@@ -39,7 +37,7 @@ namespace Realms
           IRealmCollection<T>,
           IThreadConfined
     {
-        protected static readonly PropertyType _argumentType = typeof(T).ToPropertyType(out _);
+        protected static readonly RealmValueType _argumentType = typeof(T).ToPropertyType(out _).ToRealmValueType();
         protected static readonly bool _isEmbedded = typeof(T).IsEmbeddedObject();
 
         private readonly List<NotificationCallbackDelegate<T>> _callbacks = new List<NotificationCallbackDelegate<T>>();
@@ -158,7 +156,7 @@ namespace Realms
 
                 switch (_argumentType)
                 {
-                    case PropertyType.Object | PropertyType.Nullable:
+                    case RealmValueType.Object:
                         if (!Handle.Value.TryGetObjectAtIndex(index, out var objectHandle))
                         {
                             throw new ArgumentOutOfRangeException(nameof(index));
@@ -172,16 +170,14 @@ namespace Realms
 
                         return Operator.Convert<RealmObject, T>((RealmObject)result);
 
-                    case PropertyType.String:
-                    case PropertyType.String | PropertyType.Nullable:
+                    case RealmValueType.String:
                         return Operator.Convert<string, T>(Handle.Value.GetStringAtIndex(index));
 
-                    case PropertyType.Data:
-                    case PropertyType.Data | PropertyType.Nullable:
+                    case RealmValueType.Data:
                         return Operator.Convert<byte[], T>(Handle.Value.GetByteArrayAtIndex(index));
 
                     default:
-                        return Handle.Value.GetPrimitiveAtIndex(index, _argumentType).Get<T>();
+                        return Handle.Value.GetPrimitiveAtIndex(index).Get<T>();
                 }
             }
         }

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -171,7 +171,7 @@ namespace Realms
                         return Operator.Convert<RealmObject, T>((RealmObject)result);
 
                     default:
-                        return Handle.Value.GetPrimitiveAtIndex(index).Get<T>();
+                        return Handle.Value.GetValueAtIndex(index).As<T>();
                 }
             }
         }

--- a/Realm/Realm/RealmCollectionBase.cs
+++ b/Realm/Realm/RealmCollectionBase.cs
@@ -154,25 +154,7 @@ namespace Realms
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
-                switch (_argumentType)
-                {
-                    case RealmValueType.Object:
-                        if (!Handle.Value.TryGetObjectAtIndex(index, out var objectHandle))
-                        {
-                            throw new ArgumentOutOfRangeException(nameof(index));
-                        }
-
-                        var result = Realm.MakeObject(Metadata, objectHandle);
-                        if (_isEmbedded)
-                        {
-                            return Operator.Convert<EmbeddedObject, T>((EmbeddedObject)result);
-                        }
-
-                        return Operator.Convert<RealmObject, T>((RealmObject)result);
-
-                    default:
-                        return Handle.Value.GetValueAtIndex(index).As<T>();
-                }
+                return Handle.Value.GetValueAtIndex(index, Metadata, Realm).As<T>();
             }
         }
 

--- a/Realm/Realm/RealmInteger.cs
+++ b/Realm/Realm/RealmInteger.cs
@@ -95,9 +95,8 @@ namespace Realms
         {
             if (IsManaged)
             {
-                _objectHandle.AddInt64(_propertyIndex, value.ToLong());
-                var result = _objectHandle.GetPrimitive(_propertyIndex).AsIntegral<T>();
-                return new RealmInteger<T>(result, _objectHandle, _propertyIndex);
+                var result = _objectHandle.AddInt64(_propertyIndex, value.ToLong());
+                return new RealmInteger<T>(Operator.Convert<long, T>(result), _objectHandle, _propertyIndex);
             }
 
             throw new NotSupportedException("Increment should only be called on RealmInteger properties of managed objects.");

--- a/Realm/Realm/RealmInteger.cs
+++ b/Realm/Realm/RealmInteger.cs
@@ -96,7 +96,7 @@ namespace Realms
             if (IsManaged)
             {
                 _objectHandle.AddInt64(_propertyIndex, value.ToLong());
-                var result = _objectHandle.GetPrimitive(_propertyIndex, Schema.PropertyType.Int).ToIntegral<T>();
+                var result = _objectHandle.GetPrimitive(_propertyIndex).ToIntegral<T>();
                 return new RealmInteger<T>(result, _objectHandle, _propertyIndex);
             }
 

--- a/Realm/Realm/RealmInteger.cs
+++ b/Realm/Realm/RealmInteger.cs
@@ -96,7 +96,7 @@ namespace Realms
             if (IsManaged)
             {
                 _objectHandle.AddInt64(_propertyIndex, value.ToLong());
-                var result = _objectHandle.GetPrimitive(_propertyIndex).ToIntegral<T>();
+                var result = _objectHandle.GetPrimitive(_propertyIndex).AsIntegral<T>();
                 return new RealmInteger<T>(result, _objectHandle, _propertyIndex);
             }
 

--- a/Realm/Realm/RealmList.cs
+++ b/Realm/Realm/RealmList.cs
@@ -27,7 +27,6 @@ using System.Runtime.CompilerServices;
 using Realms.Dynamic;
 using Realms.Exceptions;
 using Realms.Helpers;
-using Realms.Native;
 
 namespace Realms
 {
@@ -74,23 +73,11 @@ namespace Realms
                     };
 
                     break;
-                case RealmValueType.String:
-                    _add = (item) => _listHandle.Add(Operator.Convert<T, string>(item));
-                    _set = (index, item) => _listHandle.Set(index, Operator.Convert<T, string>(item));
-                    _insert = (index, item) => _listHandle.Insert(index, Operator.Convert<T, string>(item));
-                    _indexOf = (value) => _listHandle.Find(Operator.Convert<T, string>(value));
-                    break;
-                case RealmValueType.Data:
-                    _add = (item) => _listHandle.Add(Operator.Convert<T, byte[]>(item));
-                    _set = (index, item) => _listHandle.Set(index, Operator.Convert<T, byte[]>(item));
-                    _insert = (index, item) => _listHandle.Insert(index, Operator.Convert<T, byte[]>(item));
-                    _indexOf = (value) => _listHandle.Find(Operator.Convert<T, byte[]>(value));
-                    break;
                 default:
-                    _add = (item) => _listHandle.Add(PrimitiveValue.Create(item, _argumentType));
-                    _set = (index, item) => _listHandle.Set(index, PrimitiveValue.Create(item, _argumentType));
-                    _insert = (index, item) => _listHandle.Insert(index, PrimitiveValue.Create(item, _argumentType));
-                    _indexOf = (value) => _listHandle.Find(PrimitiveValue.Create(value, _argumentType));
+                    _add = (item) => _listHandle.Add(Operator.Convert<T, RealmValue>(item));
+                    _set = (index, item) => _listHandle.Set(index, Operator.Convert<T, RealmValue>(item));
+                    _insert = (index, item) => _listHandle.Insert(index, Operator.Convert<T, RealmValue>(item));
+                    _indexOf = (value) => _listHandle.Find(Operator.Convert<T, RealmValue>(value));
                     break;
             }
         }

--- a/Realm/Realm/RealmList.cs
+++ b/Realm/Realm/RealmList.cs
@@ -28,7 +28,6 @@ using Realms.Dynamic;
 using Realms.Exceptions;
 using Realms.Helpers;
 using Realms.Native;
-using Realms.Schema;
 
 namespace Realms
 {
@@ -57,7 +56,7 @@ namespace Realms
 
             switch (_argumentType)
             {
-                case PropertyType.Object | PropertyType.Nullable:
+                case RealmValueType.Object:
                     _add = GetObjectExecutor(_listHandle.Add, _listHandle.AddEmbedded);
                     _set = GetObjectExecutor(_listHandle.Set, _listHandle.SetEmbedded);
                     _insert = GetObjectExecutor(_listHandle.Insert, _listHandle.InsertEmbedded);
@@ -75,15 +74,13 @@ namespace Realms
                     };
 
                     break;
-                case PropertyType.String:
-                case PropertyType.String | PropertyType.Nullable:
+                case RealmValueType.String:
                     _add = (item) => _listHandle.Add(Operator.Convert<T, string>(item));
                     _set = (index, item) => _listHandle.Set(index, Operator.Convert<T, string>(item));
                     _insert = (index, item) => _listHandle.Insert(index, Operator.Convert<T, string>(item));
                     _indexOf = (value) => _listHandle.Find(Operator.Convert<T, string>(value));
                     break;
-                case PropertyType.Data:
-                case PropertyType.Data | PropertyType.Nullable:
+                case RealmValueType.Data:
                     _add = (item) => _listHandle.Add(Operator.Convert<T, byte[]>(item));
                     _set = (index, item) => _listHandle.Set(index, Operator.Convert<T, byte[]>(item));
                     _insert = (index, item) => _listHandle.Insert(index, Operator.Convert<T, byte[]>(item));

--- a/Realm/Realm/RealmObjectBase.cs
+++ b/Realm/Realm/RealmObjectBase.cs
@@ -30,7 +30,6 @@ using System.Xml.Serialization;
 using Realms.DataBinding;
 using Realms.Exceptions;
 using Realms.Helpers;
-using Realms.Native;
 using Realms.Schema;
 using Realms.Weaving;
 
@@ -212,14 +211,14 @@ namespace Realms
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetPrimitive(_metadata.PropertyIndices[propertyName]).AsString();
+            return _objectHandle.GetValue(_metadata.PropertyIndices[propertyName]);
         }
 
-        protected T GetPrimitiveValue<T>(string propertyName, PropertyType propertyType)
+        protected RealmValue GetValue(string propertyName)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetPrimitive(_metadata.PropertyIndices[propertyName]).Get<T>();
+            return _objectHandle.GetValue(_metadata.PropertyIndices[propertyName]);
         }
 
         protected internal IList<T> GetListValue<T>(string propertyName)
@@ -253,13 +252,6 @@ namespace Realms
             return null;
         }
 
-        protected byte[] GetByteArrayValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetPrimitive(_metadata.PropertyIndices[propertyName]).AsBinary();
-        }
-
         protected IQueryable<T> GetBacklinks<T>(string propertyName)
             where T : RealmObjectBase
         {
@@ -278,58 +270,15 @@ namespace Realms
             return new RealmResults<T>(_realm, resultsHandle, relatedMeta);
         }
 
-        protected RealmInteger<T> GetRealmIntegerValue<T>(string propertyName)
-            where T : struct, IFormattable, IComparable<T>
-        {
-            var propertyIndex = _metadata.PropertyIndices[propertyName];
-            var result = _objectHandle.GetPrimitive(propertyIndex).AsIntegral<T>();
-            return new RealmInteger<T>(result, ObjectHandle, propertyIndex);
-        }
-
-        protected RealmInteger<T>? GetNullableRealmIntegerValue<T>(string propertyName)
-            where T : struct, IFormattable, IComparable<T>
-        {
-            var propertyIndex = _metadata.PropertyIndices[propertyName];
-            var result = _objectHandle.GetPrimitive(propertyIndex).AsNullableIntegral<T?>();
-
-            if (result.HasValue)
-            {
-                return new RealmInteger<T>(result.Value, ObjectHandle, propertyIndex);
-            }
-
-            return null;
-        }
-
         #endregion
 
         #region Setters
 
-        protected void SetPrimitiveValue<T>(string propertyName, T value, PropertyType propertyType)
+        protected void SetValueUnique(string propertyName, RealmValue val)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            _objectHandle.SetPrimitive(_metadata.PropertyIndices[propertyName], PrimitiveValue.Create(value, propertyType.ToRealmValueType()));
-        }
-
-        protected void SetPrimitiveValueUnique<T>(string propertyName, T value, PropertyType propertyType)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitiveUnique(_metadata.PropertyIndices[propertyName], PrimitiveValue.Create(value, propertyType.ToRealmValueType()));
-        }
-
-        protected void SetStringValue(string propertyName, string value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetString(_metadata.PropertyIndices[propertyName], value);
-        }
-
-        protected void SetStringValueUnique(string propertyName, string value)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetStringUnique(_metadata.PropertyIndices[propertyName], value);
+            _objectHandle.SetValueUnique(_metadata.PropertyIndices[propertyName], val);
         }
 
         // Originally a generic fallback, now used only for RealmObjectBase To-One relationship properties
@@ -342,43 +291,11 @@ namespace Realms
             _objectHandle.SetObject(Realm, _metadata.PropertyIndices[propertyName], value);
         }
 
-        protected void SetByteArrayValue(string propertyName, byte[] value)
+        protected void SetValue(string propertyName, RealmValue val)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            _objectHandle.SetByteArray(_metadata.PropertyIndices[propertyName], value);
-        }
-
-        protected void SetRealmIntegerValue<T>(string propertyName, RealmInteger<T> value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.PropertyIndices[propertyName], PrimitiveValue.Int(value.ToLong()));
-        }
-
-        protected void SetNullableRealmIntegerValue<T>(string propertyName, RealmInteger<T>? value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitive(_metadata.PropertyIndices[propertyName], PrimitiveValue.NullableInt(value?.ToLong()));
-        }
-
-        protected void SetRealmIntegerValueUnique<T>(string propertyName, RealmInteger<T> value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitiveUnique(_metadata.PropertyIndices[propertyName], PrimitiveValue.Int(value.ToLong()));
-        }
-
-        protected void SetNullableRealmIntegerValueUnique<T>(string propertyName, RealmInteger<T>? value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetPrimitiveUnique(_metadata.PropertyIndices[propertyName], PrimitiveValue.NullableInt(value?.ToLong()));
+            _objectHandle.SetValue(_metadata.PropertyIndices[propertyName], val);
         }
 
         #endregion

--- a/Realm/Realm/RealmObjectBase.cs
+++ b/Realm/Realm/RealmObjectBase.cs
@@ -205,20 +205,27 @@ namespace Realms
 
 #pragma warning disable SA1600 // Elements should be documented
 
-        #region Getters
-
-        protected string GetStringValue(string propertyName)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            return _objectHandle.GetValue(_metadata.PropertyIndices[propertyName]);
-        }
-
         protected RealmValue GetValue(string propertyName)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetValue(_metadata.PropertyIndices[propertyName]);
+            return _objectHandle.GetValue(propertyName, _metadata, _realm);
+        }
+
+        protected void SetValue(string propertyName, RealmValue val)
+        {
+            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
+
+            var propertyIndex = _metadata.PropertyIndices[propertyName];
+
+            _objectHandle.SetValue(propertyIndex, val, _realm);
+        }
+
+        protected void SetValueUnique(string propertyName, RealmValue val)
+        {
+            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
+
+            _objectHandle.SetValueUnique(_metadata.PropertyIndices[propertyName], val);
         }
 
         protected internal IList<T> GetListValue<T>(string propertyName)
@@ -235,21 +242,6 @@ namespace Realms
 
             _metadata.Schema.TryFindProperty(propertyName, out var property);
             return _objectHandle.GetSet<T>(_realm, _metadata.PropertyIndices[propertyName], property.ObjectType);
-        }
-
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
-        protected T GetObjectValue<T>(string propertyName)
-            where T : RealmObjectBase
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            if (_objectHandle.TryGetLink(_metadata.PropertyIndices[propertyName], out var objectHandle))
-            {
-                _metadata.Schema.TryFindProperty(propertyName, out var property);
-                return (T)_realm.MakeObject(_realm.Metadata[property.ObjectType], objectHandle);
-            }
-
-            return null;
         }
 
         protected IQueryable<T> GetBacklinks<T>(string propertyName)
@@ -269,36 +261,6 @@ namespace Realms
 
             return new RealmResults<T>(_realm, resultsHandle, relatedMeta);
         }
-
-        #endregion
-
-        #region Setters
-
-        protected void SetValueUnique(string propertyName, RealmValue val)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetValueUnique(_metadata.PropertyIndices[propertyName], val);
-        }
-
-        // Originally a generic fallback, now used only for RealmObjectBase To-One relationship properties
-        // most other properties handled with woven type-specific setters above
-        protected void SetObjectValue<T>(string propertyName, T value)
-            where T : RealmObjectBase
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetObject(Realm, _metadata.PropertyIndices[propertyName], value);
-        }
-
-        protected void SetValue(string propertyName, RealmValue val)
-        {
-            Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
-
-            _objectHandle.SetValue(_metadata.PropertyIndices[propertyName], val);
-        }
-
-        #endregion
 
 #pragma warning restore SA1600 // Elements should be documented
 

--- a/Realm/Realm/RealmObjectBase.cs
+++ b/Realm/Realm/RealmObjectBase.cs
@@ -219,7 +219,7 @@ namespace Realms
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetPrimitive(_metadata.PropertyIndices[propertyName], propertyType).Get<T>();
+            return _objectHandle.GetPrimitive(_metadata.PropertyIndices[propertyName]).Get<T>();
         }
 
         protected internal IList<T> GetListValue<T>(string propertyName)
@@ -282,7 +282,7 @@ namespace Realms
             where T : struct, IFormattable, IComparable<T>
         {
             var propertyIndex = _metadata.PropertyIndices[propertyName];
-            var result = _objectHandle.GetPrimitive(propertyIndex, PropertyType.Int).ToIntegral<T>();
+            var result = _objectHandle.GetPrimitive(propertyIndex).ToIntegral<T>();
             return new RealmInteger<T>(result, ObjectHandle, propertyIndex);
         }
 
@@ -290,7 +290,7 @@ namespace Realms
             where T : struct, IFormattable, IComparable<T>
         {
             var propertyIndex = _metadata.PropertyIndices[propertyName];
-            var result = _objectHandle.GetPrimitive(propertyIndex, PropertyType.NullableInt).ToNullableIntegral<T?>();
+            var result = _objectHandle.GetPrimitive(propertyIndex).ToNullableIntegral<T?>();
 
             if (result.HasValue)
             {
@@ -308,14 +308,14 @@ namespace Realms
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            _objectHandle.SetPrimitive(_metadata.PropertyIndices[propertyName], PrimitiveValue.Create(value, propertyType));
+            _objectHandle.SetPrimitive(_metadata.PropertyIndices[propertyName], PrimitiveValue.Create(value, propertyType.ToRealmValueType()));
         }
 
         protected void SetPrimitiveValueUnique<T>(string propertyName, T value, PropertyType propertyType)
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            _objectHandle.SetPrimitiveUnique(_metadata.PropertyIndices[propertyName], PrimitiveValue.Create(value, propertyType));
+            _objectHandle.SetPrimitiveUnique(_metadata.PropertyIndices[propertyName], PrimitiveValue.Create(value, propertyType.ToRealmValueType()));
         }
 
         protected void SetStringValue(string propertyName, string value)

--- a/Realm/Realm/RealmObjectBase.cs
+++ b/Realm/Realm/RealmObjectBase.cs
@@ -212,7 +212,7 @@ namespace Realms
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetString(_metadata.PropertyIndices[propertyName]);
+            return _objectHandle.GetPrimitive(_metadata.PropertyIndices[propertyName]).AsString();
         }
 
         protected T GetPrimitiveValue<T>(string propertyName, PropertyType propertyType)
@@ -257,7 +257,7 @@ namespace Realms
         {
             Debug.Assert(IsManaged, "Object is not managed, but managed access was attempted");
 
-            return _objectHandle.GetByteArray(_metadata.PropertyIndices[propertyName]);
+            return _objectHandle.GetPrimitive(_metadata.PropertyIndices[propertyName]).AsBinary();
         }
 
         protected IQueryable<T> GetBacklinks<T>(string propertyName)
@@ -282,7 +282,7 @@ namespace Realms
             where T : struct, IFormattable, IComparable<T>
         {
             var propertyIndex = _metadata.PropertyIndices[propertyName];
-            var result = _objectHandle.GetPrimitive(propertyIndex).ToIntegral<T>();
+            var result = _objectHandle.GetPrimitive(propertyIndex).AsIntegral<T>();
             return new RealmInteger<T>(result, ObjectHandle, propertyIndex);
         }
 
@@ -290,7 +290,7 @@ namespace Realms
             where T : struct, IFormattable, IComparable<T>
         {
             var propertyIndex = _metadata.PropertyIndices[propertyName];
-            var result = _objectHandle.GetPrimitive(propertyIndex).ToNullableIntegral<T?>();
+            var result = _objectHandle.GetPrimitive(propertyIndex).AsNullableIntegral<T?>();
 
             if (result.HasValue)
             {

--- a/Realm/Realm/RealmSet.cs
+++ b/Realm/Realm/RealmSet.cs
@@ -24,7 +24,6 @@ using System.Linq.Expressions;
 using Realms.Dynamic;
 using Realms.Exceptions;
 using Realms.Helpers;
-using Realms.Native;
 
 namespace Realms
 {
@@ -50,20 +49,10 @@ namespace Realms
                     _remove = GetObjectExecutor(_setHandle.Remove);
                     _contains = GetObjectExecutor(_setHandle.Contains);
                     break;
-                case RealmValueType.String:
-                    _add = (item) => _setHandle.Add(Operator.Convert<T, string>(item));
-                    _remove = (item) => _setHandle.Remove(Operator.Convert<T, string>(item));
-                    _contains = (item) => _setHandle.Contains(Operator.Convert<T, string>(item));
-                    break;
-                case RealmValueType.Data:
-                    _add = (item) => _setHandle.Add(Operator.Convert<T, byte[]>(item));
-                    _remove = (item) => _setHandle.Remove(Operator.Convert<T, byte[]>(item));
-                    _contains = (item) => _setHandle.Contains(Operator.Convert<T, byte[]>(item));
-                    break;
                 default:
-                    _add = (item) => _setHandle.Add(PrimitiveValue.Create(item, _argumentType));
-                    _remove = (item) => _setHandle.Remove(PrimitiveValue.Create(item, _argumentType));
-                    _contains = (item) => _setHandle.Contains(PrimitiveValue.Create(item, _argumentType));
+                    _add = (item) => _setHandle.Add(Operator.Convert<T, RealmValue>(item));
+                    _remove = (item) => _setHandle.Remove(Operator.Convert<T, RealmValue>(item));
+                    _contains = (item) => _setHandle.Contains(Operator.Convert<T, RealmValue>(item));
                     break;
             }
         }

--- a/Realm/Realm/RealmSet.cs
+++ b/Realm/Realm/RealmSet.cs
@@ -25,7 +25,6 @@ using Realms.Dynamic;
 using Realms.Exceptions;
 using Realms.Helpers;
 using Realms.Native;
-using Realms.Schema;
 
 namespace Realms
 {
@@ -46,19 +45,17 @@ namespace Realms
             _setHandle = adoptedSet;
             switch (_argumentType)
             {
-                case PropertyType.Object | PropertyType.Nullable:
+                case RealmValueType.Object:
                     _add = AddObject;
                     _remove = GetObjectExecutor(_setHandle.Remove);
                     _contains = GetObjectExecutor(_setHandle.Contains);
                     break;
-                case PropertyType.String:
-                case PropertyType.String | PropertyType.Nullable:
+                case RealmValueType.String:
                     _add = (item) => _setHandle.Add(Operator.Convert<T, string>(item));
                     _remove = (item) => _setHandle.Remove(Operator.Convert<T, string>(item));
                     _contains = (item) => _setHandle.Contains(Operator.Convert<T, string>(item));
                     break;
-                case PropertyType.Data:
-                case PropertyType.Data | PropertyType.Nullable:
+                case RealmValueType.Data:
                     _add = (item) => _setHandle.Add(Operator.Convert<T, byte[]>(item));
                     _remove = (item) => _setHandle.Remove(Operator.Convert<T, byte[]>(item));
                     _contains = (item) => _setHandle.Contains(Operator.Convert<T, byte[]>(item));

--- a/Realm/Realm/RealmSet.cs
+++ b/Realm/Realm/RealmSet.cs
@@ -13,6 +13,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 using System;
 using System.Collections.Generic;

--- a/Realm/Realm/RealmSet.cs
+++ b/Realm/Realm/RealmSet.cs
@@ -24,7 +24,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Linq.Expressions;
 using Realms.Dynamic;
-using Realms.Exceptions;
 using Realms.Helpers;
 
 namespace Realms
@@ -36,81 +35,56 @@ namespace Realms
     public class RealmSet<T> : RealmCollectionBase<T>, ISet<T>, IDynamicMetaObjectProvider
     {
         private readonly SetHandle _setHandle;
-        private readonly Func<T, bool> _add;
-        private readonly Func<T, bool> _remove;
-        private readonly Func<T, bool> _contains;
 
         internal RealmSet(Realm realm, SetHandle adoptedSet, RealmObjectBase.Metadata metadata)
             : base(realm, metadata)
         {
             _setHandle = adoptedSet;
-            switch (_argumentType)
-            {
-                case RealmValueType.Object:
-                    _add = AddObject;
-                    _remove = GetObjectExecutor(_setHandle.Remove);
-                    _contains = GetObjectExecutor(_setHandle.Contains);
-                    break;
-                default:
-                    _add = (item) => _setHandle.Add(Operator.Convert<T, RealmValue>(item));
-                    _remove = (item) => _setHandle.Remove(Operator.Convert<T, RealmValue>(item));
-                    _contains = (item) => _setHandle.Contains(Operator.Convert<T, RealmValue>(item));
-                    break;
-            }
         }
 
-        public bool Add(T item) => _add(item);
+        public bool Add(T value)
+        {
+            var realmValue = Operator.Convert<T, RealmValue>(value);
 
-        public bool Remove(T item) => _remove(item);
+            if (_argumentType == RealmValueType.Object)
+            {
+                var robj = realmValue.AsRealmObject<RealmObject>();
+                if (!robj.IsManaged)
+                {
+                    Realm.Add(robj);
+                }
+            }
+
+            return _setHandle.Add(realmValue);
+        }
+
+        public bool Remove(T value)
+        {
+            var realmValue = Operator.Convert<T, RealmValue>(value);
+
+            if (realmValue.Type == RealmValueType.Object && !realmValue.AsRealmObject().IsManaged)
+            {
+                throw new ArgumentException("Value does not belong to a realm", nameof(value));
+            }
+
+            return _setHandle.Remove(realmValue);
+        }
 
         public override int IndexOf(T value)
         {
             throw new NotSupportedException();
         }
 
-        public override bool Contains(T value) => _contains(value);
-
-        private bool AddObject(T item)
+        public override bool Contains(T value)
         {
-            switch (item)
+            var realmValue = Operator.Convert<T, RealmValue>(value);
+
+            if (realmValue.Type == RealmValueType.Object && !realmValue.AsRealmObject().IsManaged)
             {
-                case null:
-                    throw new NotSupportedException("Adding, setting, or inserting <null> in a list of objects is not supported.");
-                case RealmObject realmObj:
-                    if (!realmObj.IsManaged)
-                    {
-                        Realm.Add(realmObj);
-                    }
-
-                    return _setHandle.Add(realmObj.ObjectHandle);
-                case EmbeddedObject embeddedObj:
-                    if (embeddedObj.IsManaged)
-                    {
-                        throw new RealmException("Can't add, set, or insert an embedded object that is already managed.");
-                    }
-
-                    var handle = _setHandle.AddEmbedded();
-                    Realm.ManageEmbedded(embeddedObj, handle);
-                    return true;
-                default:
-                    throw new NotSupportedException($"Adding, setting, or inserting {item.GetType()} in a list of objects is not supported, because it doesn't inherit from RealmObject or EmbeddedObject.");
+                throw new ArgumentException("Value does not belong to a realm", nameof(value));
             }
-        }
 
-        private static Func<T, bool> GetObjectExecutor(Func<ObjectHandle, bool> handler)
-        {
-            return (item) =>
-            {
-                Argument.NotNull(item, nameof(item));
-
-                var obj = Operator.Convert<T, RealmObjectBase>(item);
-                if (!obj.IsManaged)
-                {
-                    throw new ArgumentException("Item does not belong to a realm", nameof(item));
-                }
-
-                return handler(obj.ObjectHandle);
-            };
+            return _setHandle.Contains(realmValue);
         }
 
         void ICollection<T>.Add(T item) => Add(item);

--- a/Realm/Realm/RealmValue.cs
+++ b/Realm/Realm/RealmValue.cs
@@ -25,6 +25,7 @@ using Realms.Native;
 
 namespace Realms
 {
+    [Preserve(AllMembers = true)]
     public struct RealmValue
     {
         private PrimitiveValue _primitiveValue;

--- a/Realm/Realm/RealmValue.cs
+++ b/Realm/Realm/RealmValue.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using MongoDB.Bson;

--- a/Realm/Realm/RealmValue.cs
+++ b/Realm/Realm/RealmValue.cs
@@ -676,75 +676,75 @@ namespace Realms
             }
         }
 
-        public static implicit operator char(RealmValue val) => val.AsChar();
+        public static explicit operator char(RealmValue val) => val.AsChar();
 
-        public static implicit operator byte(RealmValue val) => val.AsByte();
+        public static explicit operator byte(RealmValue val) => val.AsByte();
 
-        public static implicit operator short(RealmValue val) => val.AsInt16();
+        public static explicit operator short(RealmValue val) => val.AsInt16();
 
-        public static implicit operator int(RealmValue val) => val.AsInt32();
+        public static explicit operator int(RealmValue val) => val.AsInt32();
 
-        public static implicit operator long(RealmValue val) => val.AsInt64();
+        public static explicit operator long(RealmValue val) => val.AsInt64();
 
-        public static implicit operator float(RealmValue val) => val.AsFloat();
+        public static explicit operator float(RealmValue val) => val.AsFloat();
 
-        public static implicit operator double(RealmValue val) => val.AsDouble();
+        public static explicit operator double(RealmValue val) => val.AsDouble();
 
-        public static implicit operator bool(RealmValue val) => val.AsBool();
+        public static explicit operator bool(RealmValue val) => val.AsBool();
 
-        public static implicit operator DateTimeOffset(RealmValue val) => val.AsDate();
+        public static explicit operator DateTimeOffset(RealmValue val) => val.AsDate();
 
-        public static implicit operator decimal(RealmValue val) => val.AsDecimal();
+        public static explicit operator decimal(RealmValue val) => val.AsDecimal();
 
-        public static implicit operator Decimal128(RealmValue val) => val.AsDecimal128();
+        public static explicit operator Decimal128(RealmValue val) => val.AsDecimal128();
 
-        public static implicit operator ObjectId(RealmValue val) => val.AsObjectId();
+        public static explicit operator ObjectId(RealmValue val) => val.AsObjectId();
 
-        public static implicit operator char?(RealmValue val) => val.AsNullableChar();
+        public static explicit operator char?(RealmValue val) => val.AsNullableChar();
 
-        public static implicit operator byte?(RealmValue val) => val.AsNullableByte();
+        public static explicit operator byte?(RealmValue val) => val.AsNullableByte();
 
-        public static implicit operator short?(RealmValue val) => val.AsNullableInt16();
+        public static explicit operator short?(RealmValue val) => val.AsNullableInt16();
 
-        public static implicit operator int?(RealmValue val) => val.AsNullableInt32();
+        public static explicit operator int?(RealmValue val) => val.AsNullableInt32();
 
-        public static implicit operator long?(RealmValue val) => val.AsNullableInt64();
+        public static explicit operator long?(RealmValue val) => val.AsNullableInt64();
 
-        public static implicit operator float?(RealmValue val) => val.AsNullableFloat();
+        public static explicit operator float?(RealmValue val) => val.AsNullableFloat();
 
-        public static implicit operator double?(RealmValue val) => val.AsNullableDouble();
+        public static explicit operator double?(RealmValue val) => val.AsNullableDouble();
 
-        public static implicit operator bool?(RealmValue val) => val.AsNullableBool();
+        public static explicit operator bool?(RealmValue val) => val.AsNullableBool();
 
-        public static implicit operator DateTimeOffset?(RealmValue val) => val.AsNullableDate();
+        public static explicit operator DateTimeOffset?(RealmValue val) => val.AsNullableDate();
 
-        public static implicit operator decimal?(RealmValue val) => val.AsNullableDecimal();
+        public static explicit operator decimal?(RealmValue val) => val.AsNullableDecimal();
 
-        public static implicit operator Decimal128?(RealmValue val) => val.AsNullableDecimal128();
+        public static explicit operator Decimal128?(RealmValue val) => val.AsNullableDecimal128();
 
-        public static implicit operator ObjectId?(RealmValue val) => val.AsNullableObjectId();
+        public static explicit operator ObjectId?(RealmValue val) => val.AsNullableObjectId();
 
-        public static implicit operator RealmInteger<byte>(RealmValue val) => val.AsByteRealmInteger();
+        public static explicit operator RealmInteger<byte>(RealmValue val) => val.AsByteRealmInteger();
 
-        public static implicit operator RealmInteger<short>(RealmValue val) => val.AsInt16RealmInteger();
+        public static explicit operator RealmInteger<short>(RealmValue val) => val.AsInt16RealmInteger();
 
-        public static implicit operator RealmInteger<int>(RealmValue val) => val.AsInt32RealmInteger();
+        public static explicit operator RealmInteger<int>(RealmValue val) => val.AsInt32RealmInteger();
 
-        public static implicit operator RealmInteger<long>(RealmValue val) => val.AsInt64RealmInteger();
+        public static explicit operator RealmInteger<long>(RealmValue val) => val.AsInt64RealmInteger();
 
-        public static implicit operator RealmInteger<byte>?(RealmValue val) => val.AsNullableByteRealmInteger();
+        public static explicit operator RealmInteger<byte>?(RealmValue val) => val.AsNullableByteRealmInteger();
 
-        public static implicit operator RealmInteger<short>?(RealmValue val) => val.AsNullableInt16RealmInteger();
+        public static explicit operator RealmInteger<short>?(RealmValue val) => val.AsNullableInt16RealmInteger();
 
-        public static implicit operator RealmInteger<int>?(RealmValue val) => val.AsNullableInt32RealmInteger();
+        public static explicit operator RealmInteger<int>?(RealmValue val) => val.AsNullableInt32RealmInteger();
 
-        public static implicit operator RealmInteger<long>?(RealmValue val) => val.AsNullableInt64RealmInteger();
+        public static explicit operator RealmInteger<long>?(RealmValue val) => val.AsNullableInt64RealmInteger();
 
-        public static implicit operator byte[](RealmValue val) => val.AsData();
+        public static explicit operator byte[](RealmValue val) => val.AsData();
 
-        public static implicit operator string(RealmValue val) => val.AsString();
+        public static explicit operator string(RealmValue val) => val.AsString();
 
-        public static implicit operator RealmObjectBase(RealmValue val) => val.AsRealmObject();
+        public static explicit operator RealmObjectBase(RealmValue val) => val.AsRealmObject();
 
         public static implicit operator RealmValue(char val) => Int(val);
 

--- a/Realm/Realm/RealmValue.cs
+++ b/Realm/Realm/RealmValue.cs
@@ -1,7 +1,462 @@
-﻿namespace Realms
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using MongoDB.Bson;
+using Realms.Helpers;
+using Realms.Native;
+
+namespace Realms
 {
-    public class RealmValue
+    public struct RealmValue
     {
+        private PrimitiveValue _primitiveValue;
+        private string _stringValue;
+        private byte[] _dataValue;
+
+        private ObjectHandle _objectHandle;
+        private IntPtr _propertyIndex;
+
         public RealmValueType Type { get; }
+
+        internal RealmValue(PrimitiveValue primitive, ObjectHandle handle = default, IntPtr propertyIndex = default)
+        {
+            Type = primitive.Type;
+            _objectHandle = handle;
+            _propertyIndex = propertyIndex;
+
+            switch (Type)
+            {
+                case RealmValueType.Data:
+                    _primitiveValue = default;
+                    _dataValue = primitive.AsBinary();
+                    _stringValue = default;
+                    break;
+                case RealmValueType.String:
+                    _primitiveValue = default;
+                    _dataValue = default;
+                    _stringValue = primitive.AsString();
+                    break;
+                default:
+                    _primitiveValue = primitive;
+                    _dataValue = default;
+                    _stringValue = default;
+                    break;
+            }
+        }
+
+        internal RealmValue(byte[] data)
+        {
+            Type = data == null ? RealmValueType.Null : RealmValueType.Data;
+            _dataValue = data;
+            _primitiveValue = default;
+            _stringValue = default;
+            _objectHandle = default;
+            _propertyIndex = default;
+        }
+
+        internal RealmValue(string value)
+        {
+            Type = value == null ? RealmValueType.Null : RealmValueType.String;
+            _stringValue = value;
+            _dataValue = default;
+            _primitiveValue = default;
+            _objectHandle = default;
+            _propertyIndex = default;
+        }
+
+        public static RealmValue Null() => new RealmValue(PrimitiveValue.Null());
+
+        public static RealmValue Bool(bool value) => new RealmValue(PrimitiveValue.Bool(value));
+
+        public static RealmValue NullableBool(bool? value) => new RealmValue(PrimitiveValue.NullableBool(value));
+
+        public static RealmValue Int(long value) => new RealmValue(PrimitiveValue.Int(value));
+
+        public static RealmValue NullableInt(long? value) => new RealmValue(PrimitiveValue.NullableInt(value));
+
+        public static RealmValue Float(float value) => new RealmValue(PrimitiveValue.Float(value));
+
+        public static RealmValue NullableFloat(float? value) => new RealmValue(PrimitiveValue.NullableFloat(value));
+
+        public static RealmValue Double(double value) => new RealmValue(PrimitiveValue.Double(value));
+
+        public static RealmValue NullableDouble(double? value) => new RealmValue(PrimitiveValue.NullableDouble(value));
+
+        public static RealmValue Date(DateTimeOffset value) => new RealmValue(PrimitiveValue.Date(value));
+
+        public static RealmValue NullableDate(DateTimeOffset? value) => new RealmValue(PrimitiveValue.NullableDate(value));
+
+        public static RealmValue Decimal(Decimal128 value) => new RealmValue(PrimitiveValue.Decimal(value));
+
+        public static RealmValue NullableDecimal(Decimal128? value) => new RealmValue(PrimitiveValue.NullableDecimal(value));
+
+        public static RealmValue ObjectId(ObjectId value) => new RealmValue(PrimitiveValue.ObjectId(value));
+
+        public static RealmValue NullableObjectId(ObjectId? value) => new RealmValue(PrimitiveValue.NullableObjectId(value));
+
+        public static RealmValue Data(byte[] value) => new RealmValue(value);
+
+        public static RealmValue String(string value) => new RealmValue(value);
+
+        public static RealmValue Create<T>(T value, RealmValueType type)
+        {
+            if (value is null)
+            {
+                return new RealmValue(PrimitiveValue.Null());
+            }
+
+            return type switch
+            {
+                RealmValueType.String => String(Operator.Convert<T, string>(value)),
+                RealmValueType.Data => Data(Operator.Convert<T, byte[]>(value)),
+                RealmValueType.Bool => Bool(Operator.Convert<T, bool>(value)),
+                RealmValueType.Int => Int(Operator.Convert<T, long>(value)),
+                RealmValueType.Float => Float(Operator.Convert<T, float>(value)),
+                RealmValueType.Double => Double(Operator.Convert<T, double>(value)),
+                RealmValueType.Date => Date(Operator.Convert<T, DateTimeOffset>(value)),
+                RealmValueType.Decimal128 => Decimal(Operator.Convert<T, Decimal128>(value)),
+                RealmValueType.ObjectId => ObjectId(Operator.Convert<T, ObjectId>(value)),
+                _ => throw new NotSupportedException($"RealmValueType {type} is not supported."),
+            };
+        }
+
+        internal (PrimitiveValue Value, GCHandle? GCHandle) ToNative()
+        {
+            switch (Type)
+            {
+                case RealmValueType.String:
+                    if (_stringValue == null)
+                    {
+                        return (PrimitiveValue.Null(), null);
+                    }
+
+                    // TODO-niki: use memory pool to avoid allocating/deallocating all the time
+                    var bytes = Encoding.UTF8.GetBytes(_stringValue);
+                    var stringHandle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+                    return (PrimitiveValue.String(stringHandle.AddrOfPinnedObject(), bytes.Length), stringHandle);
+                case RealmValueType.Data:
+                    if (_dataValue == null)
+                    {
+                        return (PrimitiveValue.Null(), null);
+                    }
+
+                    var handle = GCHandle.Alloc(_dataValue, GCHandleType.Pinned);
+                    return (PrimitiveValue.Data(handle.AddrOfPinnedObject(), _dataValue?.Length ?? 0), handle);
+                default:
+                    return (_primitiveValue, null);
+            }
+        }
+
+        public char AsChar()
+        {
+            EnsureType("char", RealmValueType.Int);
+            return (char)_primitiveValue.AsInt();
+        }
+
+        public byte AsByte()
+        {
+            EnsureType("byte", RealmValueType.Int);
+            return (byte)_primitiveValue.AsInt();
+        }
+
+        public short AsInt16()
+        {
+            EnsureType("short", RealmValueType.Int);
+            return (short)_primitiveValue.AsInt();
+        }
+
+        public int AsInt32()
+        {
+            EnsureType("int", RealmValueType.Int);
+            return (int)_primitiveValue.AsInt();
+        }
+
+        public long AsInt64()
+        {
+            EnsureType("long", RealmValueType.Int);
+            return _primitiveValue.AsInt();
+        }
+
+        public float AsFloat()
+        {
+            EnsureType("float", RealmValueType.Float);
+            return _primitiveValue.AsFloat();
+        }
+
+        public double AsDouble()
+        {
+            EnsureType("double", RealmValueType.Double);
+            return _primitiveValue.AsDouble();
+        }
+
+        public bool AsBool()
+        {
+            EnsureType("bool", RealmValueType.Bool);
+            return _primitiveValue.AsBool();
+        }
+
+        public DateTimeOffset AsDate()
+        {
+            EnsureType("date", RealmValueType.Date);
+            return _primitiveValue.AsDate();
+        }
+
+        public decimal AsDecimal()
+        {
+            EnsureType("decimal", RealmValueType.Decimal128);
+            return (decimal)_primitiveValue.AsDecimal();
+        }
+
+        public Decimal128 AsDecimal128()
+        {
+            EnsureType("Decimal128", RealmValueType.Decimal128);
+            return _primitiveValue.AsDecimal();
+        }
+
+        public ObjectId AsObjectId()
+        {
+            EnsureType("ObjectId", RealmValueType.ObjectId);
+            return _primitiveValue.AsObjectId();
+        }
+
+        public RealmInteger<byte> AsByteInteger() => new RealmInteger<byte>(AsByte(), _objectHandle, _propertyIndex);
+
+        public T As<T>()
+        {
+            if (Type == RealmValueType.Int)
+            {
+                return Operator.Convert<long, T>(AsInt64());
+            }
+
+            if (Type == RealmValueType.Decimal128)
+            {
+                return Operator.Convert<Decimal128, T>(AsDecimal128());
+            }
+
+            return (T)AsObject();
+        }
+
+        public RealmInteger<short> AsInt16Integer() => new RealmInteger<short>(AsInt16(), _objectHandle, _propertyIndex);
+
+        public RealmInteger<int> AsInt32Integer() => new RealmInteger<int>(AsInt32(), _objectHandle, _propertyIndex);
+
+        public RealmInteger<long> AsInt64Integer() => new RealmInteger<long>(AsInt64(), _objectHandle, _propertyIndex);
+
+        public char? AsNullableChar() => Type == RealmValueType.Null ? null : (char?)AsChar();
+
+        public byte? AsNullableByte() => Type == RealmValueType.Null ? null : (byte?)AsByte();
+
+        public short? AsNullableInt16() => Type == RealmValueType.Null ? null : (short?)AsInt16();
+
+        public int? AsNullableInt32() => Type == RealmValueType.Null ? null : (int?)AsInt32();
+
+        public long? AsNullableInt64() => Type == RealmValueType.Null ? null : (long?)AsInt64();
+
+        public RealmInteger<byte>? AsNullableByteInteger() => Type == RealmValueType.Null ? null : (RealmInteger<byte>?)AsByteInteger();
+
+        public RealmInteger<short>? AsNullableInt16Integer() => Type == RealmValueType.Null ? null : (RealmInteger<short>?)AsInt16Integer();
+
+        public RealmInteger<int>? AsNullableInt32Integer() => Type == RealmValueType.Null ? null : (RealmInteger<int>?)AsInt32Integer();
+
+        public RealmInteger<long>? AsNullableInt64Integer() => Type == RealmValueType.Null ? null : (RealmInteger<long>?)AsInt64Integer();
+
+        public float? AsNullableFloat() => Type == RealmValueType.Null ? null : (float?)AsFloat();
+
+        public double? AsNullableDouble() => Type == RealmValueType.Null ? null : (double?)AsDouble();
+
+        public bool? AsNullableBool() => Type == RealmValueType.Null ? null : (bool?)AsBool();
+
+        public DateTimeOffset? AsNullableDate() => Type == RealmValueType.Null ? null : (DateTimeOffset?)AsDate();
+
+        public decimal? AsNullableDecimal() => Type == RealmValueType.Null ? null : (decimal?)AsDecimal();
+
+        public Decimal128? AsNullableDecimal128() => Type == RealmValueType.Null ? null : (Decimal128?)AsDecimal128();
+
+        public ObjectId? AsNullableObjectId() => Type == RealmValueType.Null ? null : (ObjectId?)AsObjectId();
+
+        public byte[] AsData()
+        {
+            if (Type == RealmValueType.Null)
+            {
+                return null;
+            }
+
+            EnsureType("byte[]", RealmValueType.Data);
+            return _dataValue;
+        }
+
+        public string AsString()
+        {
+            if (Type == RealmValueType.Null)
+            {
+                return null;
+            }
+
+            EnsureType("string", RealmValueType.String);
+            return _stringValue;
+        }
+
+        public object AsObject()
+        {
+            return Type switch
+            {
+                RealmValueType.Null => null,
+                RealmValueType.Int => AsInt64(),
+                RealmValueType.Bool => AsBool(),
+                RealmValueType.String => AsString(),
+                RealmValueType.Data => AsData(),
+                RealmValueType.Date => AsDate(),
+                RealmValueType.Float => AsFloat(),
+                RealmValueType.Double => AsDouble(),
+                RealmValueType.Decimal128 => AsDecimal128(),
+                RealmValueType.ObjectId => AsObjectId(),
+                RealmValueType.Object => throw new NotImplementedException(),
+                _ => throw new NotSupportedException($"RealmValue of type {Type} is not supported."),
+            };
+        }
+
+        public static implicit operator char(RealmValue val) => val.AsChar();
+
+        public static implicit operator byte(RealmValue val) => val.AsByte();
+
+        public static implicit operator short(RealmValue val) => val.AsInt16();
+
+        public static implicit operator int(RealmValue val) => val.AsInt32();
+
+        public static implicit operator long(RealmValue val) => val.AsInt64();
+
+        public static implicit operator float(RealmValue val) => val.AsFloat();
+
+        public static implicit operator double(RealmValue val) => val.AsDouble();
+
+        public static implicit operator bool(RealmValue val) => val.AsBool();
+
+        public static implicit operator DateTimeOffset(RealmValue val) => val.AsDate();
+
+        public static implicit operator decimal(RealmValue val) => val.AsDecimal();
+
+        public static implicit operator Decimal128(RealmValue val) => val.AsDecimal128();
+
+        public static implicit operator ObjectId(RealmValue val) => val.AsObjectId();
+
+        public static implicit operator char?(RealmValue val) => val.AsNullableChar();
+
+        public static implicit operator byte?(RealmValue val) => val.AsNullableByte();
+
+        public static implicit operator short?(RealmValue val) => val.AsNullableInt16();
+
+        public static implicit operator int?(RealmValue val) => val.AsNullableInt32();
+
+        public static implicit operator long?(RealmValue val) => val.AsNullableInt64();
+
+        public static implicit operator float?(RealmValue val) => val.AsNullableFloat();
+
+        public static implicit operator double?(RealmValue val) => val.AsNullableDouble();
+
+        public static implicit operator bool?(RealmValue val) => val.AsNullableBool();
+
+        public static implicit operator DateTimeOffset?(RealmValue val) => val.AsNullableDate();
+
+        public static implicit operator decimal?(RealmValue val) => val.AsNullableDecimal();
+
+        public static implicit operator Decimal128?(RealmValue val) => val.AsNullableDecimal128();
+
+        public static implicit operator ObjectId?(RealmValue val) => val.AsNullableObjectId();
+
+        public static implicit operator RealmInteger<byte>(RealmValue val) => val.AsByteInteger();
+
+        public static implicit operator RealmInteger<short>(RealmValue val) => val.AsInt16Integer();
+
+        public static implicit operator RealmInteger<int>(RealmValue val) => val.AsInt32Integer();
+
+        public static implicit operator RealmInteger<long>(RealmValue val) => val.AsInt64Integer();
+
+        public static implicit operator RealmInteger<byte>?(RealmValue val) => val.AsNullableByteInteger();
+
+        public static implicit operator RealmInteger<short>?(RealmValue val) => val.AsNullableInt16Integer();
+
+        public static implicit operator RealmInteger<int>?(RealmValue val) => val.AsNullableInt32Integer();
+
+        public static implicit operator RealmInteger<long>?(RealmValue val) => val.AsNullableInt64Integer();
+
+        public static implicit operator byte[](RealmValue val) => val.AsData();
+
+        public static implicit operator string(RealmValue val) => val.AsString();
+
+        public static implicit operator RealmValue(char val) => Int(val);
+
+        public static implicit operator RealmValue(byte val) => Int(val);
+
+        public static implicit operator RealmValue(short val) => Int(val);
+
+        public static implicit operator RealmValue(int val) => Int(val);
+
+        public static implicit operator RealmValue(long val) => Int(val);
+
+        public static implicit operator RealmValue(float val) => Float(val);
+
+        public static implicit operator RealmValue(double val) => Double(val);
+
+        public static implicit operator RealmValue(bool val) => Bool(val);
+
+        public static implicit operator RealmValue(DateTimeOffset val) => Date(val);
+
+        public static implicit operator RealmValue(decimal val) => Decimal(val);
+
+        public static implicit operator RealmValue(Decimal128 val) => Decimal(val);
+
+        public static implicit operator RealmValue(ObjectId val) => ObjectId(val);
+
+        public static implicit operator RealmValue(char? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(byte? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(short? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(int? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(long? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(float? val) => val == null ? Null() : Float(val.Value);
+
+        public static implicit operator RealmValue(double? val) => val == null ? Null() : Double(val.Value);
+
+        public static implicit operator RealmValue(bool? val) => val == null ? Null() : Bool(val.Value);
+
+        public static implicit operator RealmValue(DateTimeOffset? val) => val == null ? Null() : Date(val.Value);
+
+        public static implicit operator RealmValue(decimal? val) => val == null ? Null() : Decimal(val.Value);
+
+        public static implicit operator RealmValue(Decimal128? val) => val == null ? Null() : Decimal(val.Value);
+
+        public static implicit operator RealmValue(ObjectId? val) => val == null ? Null() : ObjectId(val.Value);
+
+        public static implicit operator RealmValue(RealmInteger<byte> val) => Int(val);
+
+        public static implicit operator RealmValue(RealmInteger<short> val) => Int(val);
+
+        public static implicit operator RealmValue(RealmInteger<int> val) => Int(val);
+
+        public static implicit operator RealmValue(RealmInteger<long> val) => Int(val);
+
+        public static implicit operator RealmValue(RealmInteger<byte>? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(RealmInteger<short>? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(RealmInteger<int>? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(RealmInteger<long>? val) => val == null ? Null() : Int(val.Value);
+
+        public static implicit operator RealmValue(byte[] val) => Data(val);
+
+        public static implicit operator RealmValue(string val) => String(val);
+
+        private void EnsureType(string target, RealmValueType type)
+        {
+            if (Type != type)
+            {
+                throw new InvalidOperationException($"Can't cast to {target} since the underlying value is {Type}");
+            }
+        }
     }
 }

--- a/Realm/Realm/RealmValue.cs
+++ b/Realm/Realm/RealmValue.cs
@@ -1,0 +1,7 @@
+﻿namespace Realms
+{
+    public class RealmValue
+    {
+        public RealmValueType Type { get; }
+    }
+}

--- a/Realm/Realm/RealmValueType.cs
+++ b/Realm/Realm/RealmValueType.cs
@@ -1,5 +1,20 @@
-﻿using System;
-using Realms.Schema;
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 namespace Realms
 {
@@ -16,37 +31,5 @@ namespace Realms
         Decimal128,
         ObjectId,
         Object,
-    }
-
-    internal static class TempExtensions
-    {
-        public static RealmValueType ToRealmValueType(this PropertyType type)
-        {
-            switch (type.UnderlyingType())
-            {
-                case PropertyType.Int:
-                    return RealmValueType.Int;
-                case PropertyType.Bool:
-                    return RealmValueType.Bool;
-                case PropertyType.String:
-                    return RealmValueType.String;
-                case PropertyType.Data:
-                    return RealmValueType.Data;
-                case PropertyType.Date:
-                    return RealmValueType.Date;
-                case PropertyType.Float:
-                    return RealmValueType.Float;
-                case PropertyType.Double:
-                    return RealmValueType.Double;
-                case PropertyType.Object:
-                    return RealmValueType.Object;
-                case PropertyType.ObjectId:
-                    return RealmValueType.ObjectId;
-                case PropertyType.Decimal:
-                    return RealmValueType.Decimal128;
-                default:
-                    throw new NotSupportedException($"The type {type} can't be mapped to RealmValueType.");
-            }
-        }
     }
 }

--- a/Realm/Realm/RealmValueType.cs
+++ b/Realm/Realm/RealmValueType.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Realms.Schema;
+
+namespace Realms
+{
+    public enum RealmValueType : byte
+    {
+        Null,
+        Int,
+        Bool,
+        String,
+        Data,
+        Date,
+        Float,
+        Double,
+        Decimal128,
+        ObjectId,
+        Object,
+    }
+
+    internal static class TempExtensions
+    {
+        public static RealmValueType ToRealmValueType(this PropertyType type)
+        {
+            switch (type.UnderlyingType())
+            {
+                case PropertyType.Int:
+                    return RealmValueType.Int;
+                case PropertyType.Bool:
+                    return RealmValueType.Bool;
+                case PropertyType.String:
+                    return RealmValueType.String;
+                case PropertyType.Data:
+                    return RealmValueType.Data;
+                case PropertyType.Date:
+                    return RealmValueType.Date;
+                case PropertyType.Float:
+                    return RealmValueType.Float;
+                case PropertyType.Double:
+                    return RealmValueType.Double;
+                case PropertyType.Object:
+                    return RealmValueType.Object;
+                case PropertyType.ObjectId:
+                    return RealmValueType.ObjectId;
+                case PropertyType.Decimal:
+                    return RealmValueType.Decimal128;
+                default:
+                    throw new NotSupportedException($"The type {type} can't be mapped to RealmValueType.");
+            }
+        }
+    }
+}

--- a/Realm/Realm/RealmValueType.cs
+++ b/Realm/Realm/RealmValueType.cs
@@ -35,8 +35,8 @@ namespace Realms
         /// </summary>
         /// <remarks>
         /// For performance reasons, all integers, as well as <see cref="char"/>, in Realm are stored as 64-bit values.
-        /// You can still cast it to the narrower types using <see cref="RealmValue.AsByte"/>, <see cref="RealmValue.AsShort"/>,
-        /// <see cref="RealmValue.AsInt"/>, or <see cref="RealmValue.AsChar"/>.
+        /// You can still cast it to the narrower types using <see cref="RealmValue.AsByte"/>, <see cref="RealmValue.AsInt16"/>,
+        /// <see cref="RealmValue.AsInt32"/>, or <see cref="RealmValue.AsChar"/>.
         /// </remarks>
         Int,
 

--- a/Realm/Realm/RealmValueType.cs
+++ b/Realm/Realm/RealmValueType.cs
@@ -16,20 +16,77 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+using System;
+
 namespace Realms
 {
+    /// <summary>
+    /// Represents the type of a value stored in a <see cref="RealmValue"/> property.
+    /// </summary>
     public enum RealmValueType : byte
     {
+        /// <summary>
+        /// The value is <c>null</c>.
+        /// </summary>
         Null,
+
+        /// <summary>
+        /// The value is a <see cref="long"/>.
+        /// </summary>
+        /// <remarks>
+        /// For performance reasons, all integers, as well as <see cref="char"/>, in Realm are stored as 64-bit values.
+        /// You can still cast it to the narrower types using <see cref="RealmValue.AsByte"/>, <see cref="RealmValue.AsShort"/>,
+        /// <see cref="RealmValue.AsInt"/>, or <see cref="RealmValue.AsChar"/>.
+        /// </remarks>
         Int,
+
+        /// <summary>
+        /// The value represents a <see cref="bool"/>.
+        /// </summary>
         Bool,
+
+        /// <summary>
+        /// The value represents a non-null <see cref="string"/>.
+        /// </summary>
         String,
+
+        /// <summary>
+        /// The value represents a non-null byte array.
+        /// </summary>
         Data,
+
+        /// <summary>
+        /// The value represents a <see cref="DateTimeOffset"/>.
+        /// </summary>
         Date,
+
+        /// <summary>
+        /// The value represents a <see cref="float"/>.
+        /// </summary>
         Float,
+
+        /// <summary>
+        /// The value represents a <see cref="double"/>.
+        /// </summary>
         Double,
+
+        /// <summary>
+        /// The value represents a <see cref="MongoDB.Bson.Decimal128"/>.
+        /// </summary>
+        /// <remarks>
+        /// For performance reasons, all decimals in Realm are stored as 128-bit values.
+        /// You can still cast it to the 96-bit <see cref="decimal"/> using <see cref="RealmValue.AsDecimal"/>.
+        /// </remarks>
         Decimal128,
+
+        /// <summary>
+        /// The value represents a <see cref="MongoDB.Bson.ObjectId"/>.
+        /// </summary>
         ObjectId,
+
+        /// <summary>
+        /// The value represents a link to another object.
+        /// </summary>
         Object,
     }
 }

--- a/Realm/Realm/Schema/PropertyType.cs
+++ b/Realm/Realm/Schema/PropertyType.cs
@@ -121,6 +121,16 @@ namespace Realms.Schema
         NullableBool = Bool | Nullable,
 
         /// <summary>
+        /// A shorthand for PropertyType.String | PropertyType.Nullable.
+        /// </summary>
+        NullableString = String | Nullable,
+
+        /// <summary>
+        /// A shorthand for PropertyType.Data | PropertyType.Nullable.
+        /// </summary>
+        NullableData = Data | Nullable,
+
+        /// <summary>
         /// A shorthand for PropertyType.Float | PropertyType.Nullable.
         /// </summary>
         NullableFloat = Float | Nullable,

--- a/Realm/Realm/Schema/PropertyTypeEx.cs
+++ b/Realm/Realm/Schema/PropertyTypeEx.cs
@@ -139,6 +139,24 @@ namespace Realms.Schema
             };
         }
 
+        public static RealmValueType ToRealmValueType(this PropertyType type)
+        {
+            return type.UnderlyingType() switch
+            {
+                PropertyType.Int => RealmValueType.Int,
+                PropertyType.Bool => RealmValueType.Bool,
+                PropertyType.String => RealmValueType.String,
+                PropertyType.Data => RealmValueType.Data,
+                PropertyType.Date => RealmValueType.Date,
+                PropertyType.Float => RealmValueType.Float,
+                PropertyType.Double => RealmValueType.Double,
+                PropertyType.Object => RealmValueType.Object,
+                PropertyType.ObjectId => RealmValueType.ObjectId,
+                PropertyType.Decimal => RealmValueType.Decimal128,
+                _ => throw new NotSupportedException($"The type {type} can't be mapped to RealmValueType."),
+            };
+        }
+
         public static bool IsComputed(this PropertyType propertyType) => propertyType == (PropertyType.LinkingObjects | PropertyType.Array);
 
         public static bool IsNullable(this PropertyType propertyType) => propertyType.HasFlag(PropertyType.Nullable);

--- a/Realm/Realm/Schema/PropertyTypeEx.cs
+++ b/Realm/Realm/Schema/PropertyTypeEx.cs
@@ -112,6 +112,33 @@ namespace Realms.Schema
             }
         }
 
+        public static Type ToType(this PropertyType type)
+        {
+            return type switch
+            {
+                PropertyType.Int => typeof(long),
+                PropertyType.Bool => typeof(bool),
+                PropertyType.String => typeof(string),
+                PropertyType.Data => typeof(byte[]),
+                PropertyType.Date => typeof(DateTimeOffset),
+                PropertyType.Float => typeof(float),
+                PropertyType.Double => typeof(double),
+                PropertyType.Object => typeof(RealmObjectBase),
+                PropertyType.ObjectId => typeof(ObjectId),
+                PropertyType.Decimal => typeof(Decimal128),
+                PropertyType.NullableInt => typeof(long?),
+                PropertyType.NullableBool => typeof(bool?),
+                PropertyType.NullableString => typeof(string),
+                PropertyType.NullableData => typeof(byte[]),
+                PropertyType.NullableDate => typeof(DateTimeOffset?),
+                PropertyType.NullableFloat => typeof(float?),
+                PropertyType.NullableDouble => typeof(double?),
+                PropertyType.NullableObjectId => typeof(ObjectId?),
+                PropertyType.NullableDecimal => typeof(Decimal128?),
+                _ => throw new NotSupportedException($"Unexpected property type: {type}"),
+            };
+        }
+
         public static bool IsComputed(this PropertyType propertyType) => propertyType == (PropertyType.LinkingObjects | PropertyType.Array);
 
         public static bool IsNullable(this PropertyType propertyType) => propertyType.HasFlag(PropertyType.Nullable);

--- a/Realm/Realm/Sync/UserIdentity.cs
+++ b/Realm/Realm/Sync/UserIdentity.cs
@@ -48,10 +48,13 @@ namespace Realms.Sync
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            var hashCode = -1285871140;
-            hashCode = (hashCode * -1521134295) + (Id?.GetHashCode() ?? 0);
-            hashCode = (hashCode * -1521134295) + Provider.GetHashCode();
-            return hashCode;
+            unchecked
+            {
+                var hashCode = -1285871140;
+                hashCode = (hashCode * -1521134295) + (Id?.GetHashCode() ?? 0);
+                hashCode = (hashCode * -1521134295) + Provider.GetHashCode();
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/Tests/PerformanceTests/ObjectTests.cs
+++ b/Tests/PerformanceTests/ObjectTests.cs
@@ -1,0 +1,245 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Realms;
+
+namespace PerformanceTests
+{
+    public class ObjectTests : BenchmarkBase
+    {
+        private const int ObjectCount = 100;
+
+        private ObjectClass _robject;
+        private DummyClass[] _newPropertyValues;
+        private Transaction _transaction;
+        private DummyClass _temp;
+
+        protected override void SeedData()
+        {
+            base.SeedData();
+
+            _realm.Write(() =>
+            {
+                for (var i = 0; i < ObjectCount; i++)
+                {
+                    _realm.Add(new ObjectClass
+                    {
+                        Value0 = new DummyClass(),
+                        Value1 = new DummyClass(),
+                        Value2 = new DummyClass(),
+                        Value3 = new DummyClass(),
+                        Value4 = new DummyClass(),
+                        Value5 = new DummyClass(),
+                        Value6 = new DummyClass(),
+                        Value7 = new DummyClass(),
+                        Value8 = new DummyClass(),
+                        Value9 = new DummyClass(),
+                        Value10 = new DummyClass(),
+                        Value11 = new DummyClass(),
+                        Value12 = new DummyClass(),
+                        Value13 = new DummyClass(),
+                        Value14 = new DummyClass(),
+                        Value15 = new DummyClass(),
+                        Value16 = new DummyClass(),
+                        Value17 = new DummyClass(),
+                        Value18 = new DummyClass(),
+                        Value19 = new DummyClass(),
+                        Value20 = new DummyClass(),
+                        Value21 = new DummyClass(),
+                        Value22 = new DummyClass(),
+                        Value23 = new DummyClass(),
+                        Value24 = new DummyClass(),
+                        Value25 = new DummyClass(),
+                        Value26 = new DummyClass(),
+                        Value27 = new DummyClass(),
+                        Value28 = new DummyClass(),
+                        Value29 = new DummyClass(),
+                        Value30 = new DummyClass(),
+                        Value31 = new DummyClass(),
+                    });
+                }
+            });
+
+            _robject = _realm.All<ObjectClass>().ElementAt(_faker.Random.Int(0, ObjectCount - 1));
+
+            _newPropertyValues = new DummyClass[32];
+            for (var i = 0; i < _newPropertyValues.Length; i++)
+            {
+                var prop = typeof(ObjectClass).GetProperty($"Value{i}", BindingFlags.Public | BindingFlags.Instance);
+                _newPropertyValues[i] = (DummyClass)prop.GetValue(_robject);
+            }
+
+            _transaction = _realm.BeginWrite();
+        }
+
+        protected override void CleanupCore()
+        {
+            _transaction.Rollback();
+        }
+
+        [Benchmark(OperationsPerInvoke = 32)]
+        public object GetPropertyValue()
+        {
+            _temp = _robject.Value0;
+            _temp = _robject.Value1;
+            _temp = _robject.Value2;
+            _temp = _robject.Value3;
+            _temp = _robject.Value4;
+            _temp = _robject.Value5;
+            _temp = _robject.Value6;
+            _temp = _robject.Value7;
+            _temp = _robject.Value8;
+            _temp = _robject.Value9;
+            _temp = _robject.Value10;
+            _temp = _robject.Value11;
+            _temp = _robject.Value12;
+            _temp = _robject.Value13;
+            _temp = _robject.Value14;
+            _temp = _robject.Value15;
+            _temp = _robject.Value16;
+            _temp = _robject.Value17;
+            _temp = _robject.Value18;
+            _temp = _robject.Value19;
+            _temp = _robject.Value20;
+            _temp = _robject.Value21;
+            _temp = _robject.Value22;
+            _temp = _robject.Value23;
+            _temp = _robject.Value24;
+            _temp = _robject.Value25;
+            _temp = _robject.Value26;
+            _temp = _robject.Value27;
+            _temp = _robject.Value28;
+            _temp = _robject.Value29;
+            _temp = _robject.Value30;
+            _temp = _robject.Value31;
+            return _temp;
+        }
+
+        [Benchmark(OperationsPerInvoke = 32)]
+        public void SetPropertyValue()
+        {
+            _robject.Value0 = _newPropertyValues[0];
+            _robject.Value1 = _newPropertyValues[1];
+            _robject.Value2 = _newPropertyValues[2];
+            _robject.Value3 = _newPropertyValues[3];
+            _robject.Value4 = _newPropertyValues[4];
+            _robject.Value5 = _newPropertyValues[5];
+            _robject.Value6 = _newPropertyValues[6];
+            _robject.Value7 = _newPropertyValues[7];
+            _robject.Value8 = _newPropertyValues[8];
+            _robject.Value9 = _newPropertyValues[9];
+            _robject.Value10 = _newPropertyValues[10];
+            _robject.Value11 = _newPropertyValues[11];
+            _robject.Value12 = _newPropertyValues[12];
+            _robject.Value13 = _newPropertyValues[13];
+            _robject.Value14 = _newPropertyValues[14];
+            _robject.Value15 = _newPropertyValues[15];
+            _robject.Value16 = _newPropertyValues[16];
+            _robject.Value17 = _newPropertyValues[17];
+            _robject.Value18 = _newPropertyValues[18];
+            _robject.Value19 = _newPropertyValues[19];
+            _robject.Value20 = _newPropertyValues[20];
+            _robject.Value21 = _newPropertyValues[21];
+            _robject.Value22 = _newPropertyValues[22];
+            _robject.Value23 = _newPropertyValues[23];
+            _robject.Value24 = _newPropertyValues[24];
+            _robject.Value25 = _newPropertyValues[25];
+            _robject.Value26 = _newPropertyValues[26];
+            _robject.Value27 = _newPropertyValues[27];
+            _robject.Value28 = _newPropertyValues[28];
+            _robject.Value29 = _newPropertyValues[29];
+            _robject.Value30 = _newPropertyValues[30];
+            _robject.Value31 = _newPropertyValues[31];
+        }
+
+        private class ObjectClass : RealmObject
+        {
+            public DummyClass Value0 { get; set; }
+
+            public DummyClass Value1 { get; set; }
+
+            public DummyClass Value2 { get; set; }
+
+            public DummyClass Value3 { get; set; }
+
+            public DummyClass Value4 { get; set; }
+
+            public DummyClass Value5 { get; set; }
+
+            public DummyClass Value6 { get; set; }
+
+            public DummyClass Value7 { get; set; }
+
+            public DummyClass Value8 { get; set; }
+
+            public DummyClass Value9 { get; set; }
+
+            public DummyClass Value10 { get; set; }
+
+            public DummyClass Value11 { get; set; }
+
+            public DummyClass Value12 { get; set; }
+
+            public DummyClass Value13 { get; set; }
+
+            public DummyClass Value14 { get; set; }
+
+            public DummyClass Value15 { get; set; }
+
+            public DummyClass Value16 { get; set; }
+
+            public DummyClass Value17 { get; set; }
+
+            public DummyClass Value18 { get; set; }
+
+            public DummyClass Value19 { get; set; }
+
+            public DummyClass Value20 { get; set; }
+
+            public DummyClass Value21 { get; set; }
+
+            public DummyClass Value22 { get; set; }
+
+            public DummyClass Value23 { get; set; }
+
+            public DummyClass Value24 { get; set; }
+
+            public DummyClass Value25 { get; set; }
+
+            public DummyClass Value26 { get; set; }
+
+            public DummyClass Value27 { get; set; }
+
+            public DummyClass Value28 { get; set; }
+
+            public DummyClass Value29 { get; set; }
+
+            public DummyClass Value30 { get; set; }
+
+            public DummyClass Value31 { get; set; }
+        }
+
+        private class DummyClass : RealmObject
+        {
+            public int Int { get; set; }
+        }
+    }
+}

--- a/Tests/PerformanceTests/Program.cs
+++ b/Tests/PerformanceTests/Program.cs
@@ -48,7 +48,7 @@ namespace PerformanceTests
                 .WithSummaryStyle(defaultConfig.SummaryStyle)
                 .WithArtifactsPath(defaultConfig.ArtifactsPath)
                 .AddDiagnoser(MemoryDiagnoser.Default)
-                .AddJob(Job.LongRun.WithToolchain(InProcessEmitToolchain.Instance))
+                .AddJob(Job.Default.WithToolchain(InProcessEmitToolchain.Instance))
                 .WithOrderer(new DefaultOrderer(SummaryOrderPolicy.Method, MethodOrderPolicy.Alphabetical))
                 .AddExporter(new JenkinsHtmlExporter(), MarkdownExporter.GitHub, JsonExporter.Full);
 

--- a/Tests/PerformanceTests/Program.cs
+++ b/Tests/PerformanceTests/Program.cs
@@ -48,7 +48,7 @@ namespace PerformanceTests
                 .WithSummaryStyle(defaultConfig.SummaryStyle)
                 .WithArtifactsPath(defaultConfig.ArtifactsPath)
                 .AddDiagnoser(MemoryDiagnoser.Default)
-                .AddJob(Job.ShortRun.WithToolchain(InProcessEmitToolchain.Instance))
+                .AddJob(Job.LongRun.WithToolchain(InProcessEmitToolchain.Instance))
                 .WithOrderer(new DefaultOrderer(SummaryOrderPolicy.Method, MethodOrderPolicy.Alphabetical))
                 .AddExporter(new JenkinsHtmlExporter(), MarkdownExporter.GitHub, JsonExporter.Full);
 

--- a/Tests/Realm.Tests/Database/CollectionTests.cs
+++ b/Tests/Realm.Tests/Database/CollectionTests.cs
@@ -246,7 +246,7 @@ namespace Realms.Tests.Database
             Assert.That(items, Is.EqualTo(Enumerable.Range(0, 10)));
         }
 
-        [Test]
+        [Test, Ignore("Regression in Core, unignore when https://github.com/realm/realm-core/pull/4122 is merged.")]
         public void ObjectList_WhenEnumeratingAndRemovingFromRealm_ShouldBeStable()
         {
             var container = new ContainerObject();

--- a/Tests/Realm.Tests/Database/EmbeddedObjectsTests.cs
+++ b/Tests/Realm.Tests/Database/EmbeddedObjectsTests.cs
@@ -101,7 +101,7 @@ namespace Realms.Tests.Database
 
             foreach (var prop in properties)
             {
-                Assert.That(prop.GetValue(parent.AllTypesObject), Is.EqualTo(prop.GetValue(copy)));
+                Assert.That(prop.GetValue(parent.AllTypesObject), Is.EqualTo(prop.GetValue(copy)), $"Expected {prop.Name} to have value {prop.GetValue(copy)} but was {prop.GetValue(parent.AllTypesObject)}");
             }
         }
 

--- a/Tests/Realm.Tests/Database/ListOfPrimitivesTests.cs
+++ b/Tests/Realm.Tests/Database/ListOfPrimitivesTests.cs
@@ -565,7 +565,7 @@ namespace Realms.Tests.Database
             _realm.Write(() => _realm.Add(obj));
 
             var ex = Assert.Throws<RealmException>(() => _realm.Write(() => obj.Strings.Add(null)));
-            Assert.That(ex.Message, Does.Contain("Attempted to insert null into non-nullable column"));
+            Assert.That(ex.Message, Does.Contain("Attempted to add null to a list of required values"));
         }
 
         [TestCase]
@@ -588,7 +588,7 @@ namespace Realms.Tests.Database
             obj.Strings.Add(null);
             obj.Strings.Add("strings.NonEmpty");
             var ex = Assert.Throws<RealmException>(() => _realm.Write(() => _realm.Add(obj)));
-            Assert.That(ex.Message, Does.Contain("Attempted to insert null into non-nullable column"));
+            Assert.That(ex.Message, Does.Contain("Attempted to add null to a list of required values"));
         }
 
         private void RunManagedTests<T>(Func<ListsObject, IList<T>> itemsGetter, T[] toAdd)

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
     <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp20;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
     <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
     <RootNamespace>Realms.Tests</RootNamespace>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -26,6 +26,9 @@
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnitLite" Version="3.12.0" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnitLite" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" Condition="!$(TargetFramework.StartsWith('uap'))" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -21,12 +21,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnitLite" Version="3.12.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnitLite" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" Condition="!$(TargetFramework.StartsWith('uap'))" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
-    <TargetFrameworks>net461</TargetFrameworks>
-    <TargetFrameworks>net461;netcoreapp20;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
     <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
     <RootNamespace>Realms.Tests</RootNamespace>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
     <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
     <RootNamespace>Realms.Tests</RootNamespace>

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -51,15 +51,19 @@ namespace Realms.Tests.Sync
 
                 using (var realm = GetRealm(config))
                 {
+                    var session = GetSession(realm);
+                    session.Stop();
                     if (populate)
                     {
                         AddDummyData(realm, singleTransaction: false);
                     }
+
+                    session.CloseHandle();
                 }
 
                 var initialSize = new FileInfo(config.DatabasePath).Length;
 
-                var attempts = 20;
+                var attempts = 200;
 
                 // Give core a chance to close the Realm
                 while (!Realm.Compact(config) && (attempts-- > 0))
@@ -67,10 +71,10 @@ namespace Realms.Tests.Sync
                     await Task.Delay(50);
                 }
 
-                Assert.That(attempts > 0);
+                Assert.That(attempts, Is.GreaterThan(0));
 
                 var finalSize = new FileInfo(config.DatabasePath).Length;
-                Assert.That(initialSize >= finalSize);
+                Assert.That(initialSize, Is.GreaterThanOrEqualTo(finalSize));
 
                 using (var realm = GetRealm(config))
                 {

--- a/Tests/Weaver/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/Tests/Weaver/AssemblyToProcess/AssemblyToProcess.csproj
@@ -4,10 +4,6 @@
     <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.11.1" />
-  </ItemGroup>
-
   <ItemGroup Label="References">
     <ProjectReference Include="..\Realm.FakeForWeaverTests\Realm.FakeForWeaverTests.csproj" />
   </ItemGroup>

--- a/Tests/Weaver/AssemblyToProcess/Person.cs
+++ b/Tests/Weaver/AssemblyToProcess/Person.cs
@@ -107,12 +107,12 @@ namespace AssemblyToProcess
         {
             get
             {
-                return GetStringValue("Address");
+                return GetValue("Address");
             }
 
             set
             {
-                SetStringValue("Address", value);
+                SetValue("Address", value);
             }
         }
 

--- a/Tests/Weaver/AssemblyToProcess/Person.cs
+++ b/Tests/Weaver/AssemblyToProcess/Person.cs
@@ -107,7 +107,7 @@ namespace AssemblyToProcess
         {
             get
             {
-                return GetValue("Address");
+                return (string)GetValue("Address");
             }
 
             set

--- a/Tests/Weaver/AssemblyToProcess/TestObjects.cs
+++ b/Tests/Weaver/AssemblyToProcess/TestObjects.cs
@@ -24,7 +24,6 @@ using Realms;
 
 namespace AssemblyToProcess
 {
-    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass")]
     public class AllTypesObject : RealmObject
     {
         public char CharProperty { get; set; }

--- a/Tests/Weaver/AssemblyToProcess/TestSyncActive.cs
+++ b/Tests/Weaver/AssemblyToProcess/TestSyncActive.cs
@@ -4,6 +4,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 namespace AssemblyToProcess
 {

--- a/Tests/Weaver/Realm.FakeForWeaverTests/Realm.FakeForWeaverTests.csproj
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/Realm.FakeForWeaverTests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\..\..\Realm\Realm\Attributes\PreserveAttribute.cs" Link="Attributes\PreserveAttribute.cs" />
     <Compile Include="..\..\..\Realm\Realm\Attributes\PrimaryKeyAttribute.cs" Link="Attributes\PrimaryKeyAttribute.cs" />
     <Compile Include="..\..\..\Realm\Realm\Attributes\RequiredAttribute.cs" Link="Attributes\RequiredAttribute.cs" />
+    <Compile Include="..\..\..\Realm\Realm\RealmValueType.cs" Link="RealmValueType.cs" />
     <Compile Include="..\..\..\Realm\Realm\Schema\PropertyType.cs" Link="PropertyType.cs" />
     <Compile Include="..\..\..\Realm\Realm\Weaving\IRealmObjectHelper.cs" Link="IRealmObjectHelper.cs" />
     <Compile Include="..\..\..\Realm\Realm\Attributes\ExplicitAttribute.cs">
@@ -30,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Label="References">
+    <PackageReference Include="MongoDB.Bson" Version="2.11.4" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
   </ItemGroup>
 

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
@@ -86,7 +86,7 @@ namespace Realms
             LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
         }
 
-        protected T GetPrimitiveValue<T>(string propertyName, PropertyType propertyType)
+        protected T GetPrimitiveValue<T>(string propertyName)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
             return default(T);
@@ -156,30 +156,6 @@ namespace Realms
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        protected void SetRealmIntegerValue<T>(string propertyName, RealmInteger<T> value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected void SetNullableRealmIntegerValue<T>(string propertyName, RealmInteger<T>? value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected void SetRealmIntegerValueUnique<T>(string propertyName, RealmInteger<T> value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected void SetNullableRealmIntegerValueUnique<T>(string propertyName, RealmInteger<T>? value)
-            where T : struct, IComparable<T>, IFormattable
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
         }
 
         protected RealmInteger<T> GetRealmIntegerValue<T>(string propertyName)

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmObject.cs
@@ -16,12 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Realms.Schema;
 
 namespace Realms
 {
@@ -76,36 +74,20 @@ namespace Realms
             }
         }
 
-        protected void SetPrimitiveValue<T>(string propertyName, T value, PropertyType propertyType)
+        protected void SetValue(string propertyName, RealmValue value)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
         }
 
-        protected void SetPrimitiveValueUnique<T>(string propertyName, T value, PropertyType propertyType)
+        protected void SetValueUnique(string propertyName, RealmValue value)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
         }
 
-        protected T GetPrimitiveValue<T>(string propertyName)
+        protected RealmValue GetValue(string propertyName)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return default(T);
-        }
-
-        protected string GetStringValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return string.Empty;
-        }
-
-        protected void SetStringValue(string propertyName, string value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
-        protected void SetStringValueUnique(string propertyName, string value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
+            return new RealmValue();
         }
 
         protected IList<T> GetListValue<T>(string propertyName)
@@ -136,17 +118,6 @@ namespace Realms
             LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
         }
 
-        protected byte[] GetByteArrayValue(string propertyName)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return new byte[0];
-        }
-
-        protected void SetByteArrayValue(string propertyName, byte[] value)
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\", {nameof(value)} = {value}");
-        }
-
         protected IQueryable<T> GetBacklinks<T>(string propertyName)
         {
             LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
@@ -156,20 +127,6 @@ namespace Realms
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        protected RealmInteger<T> GetRealmIntegerValue<T>(string propertyName)
-            where T : struct, IFormattable, IComparable<T>
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return default(RealmInteger<T>);
-        }
-
-        protected RealmInteger<T>? GetNullableRealmIntegerValue<T>(string propertyName)
-            where T : struct, IFormattable, IComparable<T>
-        {
-            LogCall($"{nameof(propertyName)} = \"{propertyName}\"");
-            return null;
         }
     }
 }

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
@@ -3,7 +3,7 @@ using MongoDB.Bson;
 
 namespace Realms
 {
-    public struct RealmValue
+    public readonly struct RealmValue
     {
         public RealmValueType Type { get; }
 

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
@@ -75,6 +75,8 @@ namespace Realms
 
         public static implicit operator string(RealmValue val) => default;
 
+        public static implicit operator RealmObjectBase(RealmValue val) => default;
+
         public static implicit operator RealmValue(char val) => default;
 
         public static implicit operator RealmValue(byte val) => default;
@@ -142,5 +144,7 @@ namespace Realms
         public static implicit operator RealmValue(byte[] val) => default;
 
         public static implicit operator RealmValue(string val) => default;
+
+        public static implicit operator RealmValue(RealmObjectBase val) => default;
     }
 }

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
@@ -7,75 +7,75 @@ namespace Realms
     {
         public RealmValueType Type { get; }
 
-        public static implicit operator char(RealmValue val) => default;
+        public static explicit operator char(RealmValue val) => default;
 
-        public static implicit operator byte(RealmValue val) => default;
+        public static explicit operator byte(RealmValue val) => default;
 
-        public static implicit operator short(RealmValue val) => default;
+        public static explicit operator short(RealmValue val) => default;
 
-        public static implicit operator int(RealmValue val) => default;
+        public static explicit operator int(RealmValue val) => default;
 
-        public static implicit operator long(RealmValue val) => default;
+        public static explicit operator long(RealmValue val) => default;
 
-        public static implicit operator float(RealmValue val) => default;
+        public static explicit operator float(RealmValue val) => default;
 
-        public static implicit operator double(RealmValue val) => default;
+        public static explicit operator double(RealmValue val) => default;
 
-        public static implicit operator bool(RealmValue val) => default;
+        public static explicit operator bool(RealmValue val) => default;
 
-        public static implicit operator DateTimeOffset(RealmValue val) => default;
+        public static explicit operator DateTimeOffset(RealmValue val) => default;
 
-        public static implicit operator decimal(RealmValue val) => default;
+        public static explicit operator decimal(RealmValue val) => default;
 
-        public static implicit operator Decimal128(RealmValue val) => default;
+        public static explicit operator Decimal128(RealmValue val) => default;
 
-        public static implicit operator ObjectId(RealmValue val) => default;
+        public static explicit operator ObjectId(RealmValue val) => default;
 
-        public static implicit operator char?(RealmValue val) => default;
+        public static explicit operator char?(RealmValue val) => default;
 
-        public static implicit operator byte?(RealmValue val) => default;
+        public static explicit operator byte?(RealmValue val) => default;
 
-        public static implicit operator short?(RealmValue val) => default;
+        public static explicit operator short?(RealmValue val) => default;
 
-        public static implicit operator int?(RealmValue val) => default;
+        public static explicit operator int?(RealmValue val) => default;
 
-        public static implicit operator long?(RealmValue val) => default;
+        public static explicit operator long?(RealmValue val) => default;
 
-        public static implicit operator float?(RealmValue val) => default;
+        public static explicit operator float?(RealmValue val) => default;
 
-        public static implicit operator double?(RealmValue val) => default;
+        public static explicit operator double?(RealmValue val) => default;
 
-        public static implicit operator bool?(RealmValue val) => default;
+        public static explicit operator bool?(RealmValue val) => default;
 
-        public static implicit operator DateTimeOffset?(RealmValue val) => default;
+        public static explicit operator DateTimeOffset?(RealmValue val) => default;
 
-        public static implicit operator decimal?(RealmValue val) => default;
+        public static explicit operator decimal?(RealmValue val) => default;
 
-        public static implicit operator Decimal128?(RealmValue val) => default;
+        public static explicit operator Decimal128?(RealmValue val) => default;
 
-        public static implicit operator ObjectId?(RealmValue val) => default;
+        public static explicit operator ObjectId?(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<byte>(RealmValue val) => default;
+        public static explicit operator RealmInteger<byte>(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<short>(RealmValue val) => default;
+        public static explicit operator RealmInteger<short>(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<int>(RealmValue val) => default;
+        public static explicit operator RealmInteger<int>(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<long>(RealmValue val) => default;
+        public static explicit operator RealmInteger<long>(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<byte>?(RealmValue val) => default;
+        public static explicit operator RealmInteger<byte>?(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<short>?(RealmValue val) => default;
+        public static explicit operator RealmInteger<short>?(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<int>?(RealmValue val) => default;
+        public static explicit operator RealmInteger<int>?(RealmValue val) => default;
 
-        public static implicit operator RealmInteger<long>?(RealmValue val) => default;
+        public static explicit operator RealmInteger<long>?(RealmValue val) => default;
 
-        public static implicit operator byte[](RealmValue val) => default;
+        public static explicit operator byte[](RealmValue val) => default;
 
-        public static implicit operator string(RealmValue val) => default;
+        public static explicit operator string(RealmValue val) => default;
 
-        public static implicit operator RealmObjectBase(RealmValue val) => default;
+        public static explicit operator RealmObjectBase(RealmValue val) => default;
 
         public static implicit operator RealmValue(char val) => default;
 

--- a/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/RealmValue.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using MongoDB.Bson;
+
+namespace Realms
+{
+    public struct RealmValue
+    {
+        public RealmValueType Type { get; }
+
+        public static implicit operator char(RealmValue val) => default;
+
+        public static implicit operator byte(RealmValue val) => default;
+
+        public static implicit operator short(RealmValue val) => default;
+
+        public static implicit operator int(RealmValue val) => default;
+
+        public static implicit operator long(RealmValue val) => default;
+
+        public static implicit operator float(RealmValue val) => default;
+
+        public static implicit operator double(RealmValue val) => default;
+
+        public static implicit operator bool(RealmValue val) => default;
+
+        public static implicit operator DateTimeOffset(RealmValue val) => default;
+
+        public static implicit operator decimal(RealmValue val) => default;
+
+        public static implicit operator Decimal128(RealmValue val) => default;
+
+        public static implicit operator ObjectId(RealmValue val) => default;
+
+        public static implicit operator char?(RealmValue val) => default;
+
+        public static implicit operator byte?(RealmValue val) => default;
+
+        public static implicit operator short?(RealmValue val) => default;
+
+        public static implicit operator int?(RealmValue val) => default;
+
+        public static implicit operator long?(RealmValue val) => default;
+
+        public static implicit operator float?(RealmValue val) => default;
+
+        public static implicit operator double?(RealmValue val) => default;
+
+        public static implicit operator bool?(RealmValue val) => default;
+
+        public static implicit operator DateTimeOffset?(RealmValue val) => default;
+
+        public static implicit operator decimal?(RealmValue val) => default;
+
+        public static implicit operator Decimal128?(RealmValue val) => default;
+
+        public static implicit operator ObjectId?(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<byte>(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<short>(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<int>(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<long>(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<byte>?(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<short>?(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<int>?(RealmValue val) => default;
+
+        public static implicit operator RealmInteger<long>?(RealmValue val) => default;
+
+        public static implicit operator byte[](RealmValue val) => default;
+
+        public static implicit operator string(RealmValue val) => default;
+
+        public static implicit operator RealmValue(char val) => default;
+
+        public static implicit operator RealmValue(byte val) => default;
+
+        public static implicit operator RealmValue(short val) => default;
+
+        public static implicit operator RealmValue(int val) => default;
+
+        public static implicit operator RealmValue(long val) => default;
+
+        public static implicit operator RealmValue(float val) => default;
+
+        public static implicit operator RealmValue(double val) => default;
+
+        public static implicit operator RealmValue(bool val) => default;
+
+        public static implicit operator RealmValue(DateTimeOffset val) => default;
+
+        public static implicit operator RealmValue(decimal val) => default;
+
+        public static implicit operator RealmValue(Decimal128 val) => default;
+
+        public static implicit operator RealmValue(ObjectId val) => default;
+
+        public static implicit operator RealmValue(char? val) => default;
+
+        public static implicit operator RealmValue(byte? val) => default;
+
+        public static implicit operator RealmValue(short? val) => default;
+
+        public static implicit operator RealmValue(int? val) => default;
+
+        public static implicit operator RealmValue(long? val) => default;
+
+        public static implicit operator RealmValue(float? val) => default;
+
+        public static implicit operator RealmValue(double? val) => default;
+
+        public static implicit operator RealmValue(bool? val) => default;
+
+        public static implicit operator RealmValue(DateTimeOffset? val) => default;
+
+        public static implicit operator RealmValue(decimal? val) => default;
+
+        public static implicit operator RealmValue(Decimal128? val) => default;
+
+        public static implicit operator RealmValue(ObjectId? val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<byte> val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<short> val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<int> val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<long> val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<byte>? val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<short>? val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<int>? val) => default;
+
+        public static implicit operator RealmValue(RealmInteger<long>? val) => default;
+
+        public static implicit operator RealmValue(byte[] val) => default;
+
+        public static implicit operator RealmValue(string val) => default;
+    }
+}

--- a/Tests/Weaver/Realm.FakeForWeaverTests/SyncConfiguration.cs
+++ b/Tests/Weaver/Realm.FakeForWeaverTests/SyncConfiguration.cs
@@ -1,6 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 namespace Realms.Sync
 {

--- a/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
+++ b/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnitLite" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="PropertyChanged.Fody" Version="3.1.3">
+    <PackageReference Include="PropertyChanged.Fody" Version="3.3.1">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </PackageReference>
     <PackageReference Include="FodyHelpers" Version="6.*" />

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTestBase.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTestBase.cs
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Fody;
 
@@ -25,7 +24,6 @@ namespace RealmWeaver
 {
     extern alias realm;
 
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1304:NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter")]
     public abstract class WeaverTestBase
     {
         protected readonly List<string> _warnings = new List<string>();

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTestBase.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTestBase.cs
@@ -36,7 +36,7 @@ namespace RealmWeaver
         {
             var weaver = new realm::ModuleWeaver();
 
-            var result = weaver.ExecuteTestRun(assemblyPath, ignoreCodes: new[] { "80131869" }, runPeVerify: false);
+            var result = weaver.ExecuteTestRun(assemblyPath, ignoreCodes: new[] { "80131869" });
             _warnings.AddRange(result.Warnings.Select(m => m.Text));
             _errors.AddRange(result.Errors.Select(m => m.Text));
             _messages.AddRange(result.Messages.Where(m => m.MessageImportance?.Equals(MessageImportance.Normal) == true).Select(m => m.Text));

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -46,16 +46,14 @@ namespace RealmWeaver
 
         private static dynamic GetAutoPropertyBackingFieldValue(object o, string propertyName)
         {
-            var propertyField = ((Type)o.GetType())
-                .GetField($"<{propertyName}>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+            var propertyField = o.GetType().GetField($"<{propertyName}>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
             var fieldValue = propertyField.GetValue(o);
             return fieldValue;
         }
 
         private static void SetAutoPropertyBackingFieldValue(object o, string propertyName, object propertyValue)
         {
-            var propertyField = ((Type)o.GetType())
-                .GetField($"<{propertyName}>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+            var propertyField = o.GetType().GetField($"<{propertyName}>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
             propertyField.SetValue(o, propertyValue);
         }
 
@@ -88,55 +86,7 @@ namespace RealmWeaver
             return weaver.ExecuteTestRun(assemblyPath, ignoreCodes: new[] { "80131869" });
         }
 
-        private static string GetCoreMethodName(string type)
-        {
-            type = type.Replace("Counter", string.Empty);
-            if (_realmIntegerBackedTypes.Contains(type))
-            {
-                return (type.StartsWith("Nullable") ? "Nullable" : string.Empty) + "RealmInteger";
-            }
-
-            if (_primitiveValueTypes.Contains(type))
-            {
-                return "Primitive";
-            }
-
-            return type;
-        }
-
         #endregion helpers
-
-        private static readonly IEnumerable<string> _realmIntegerBackedTypes = new[]
-        {
-            "Byte",
-            "Int16",
-            "Int32",
-            "Int64",
-            "NullableByte",
-            "NullableInt16",
-            "NullableInt32",
-            "NullableInt64"
-        };
-
-        private static readonly IEnumerable<string> _primitiveValueTypes = new[]
-        {
-            "Char",
-            "Single",
-            "Double",
-            "Boolean",
-            "DateTimeOffset",
-            "Decimal",
-            "Decimal128",
-            "ObjectId",
-            "NullableChar",
-            "NullableSingle",
-            "NullableDouble",
-            "NullableBoolean",
-            "NullableDateTimeOffset",
-            "NullableDecimal",
-            "NullableDecimal128",
-            "NullableObjectId",
-        };
 
         public enum PropertyChangedWeaver
         {
@@ -297,7 +247,7 @@ namespace RealmWeaver
             Assert.That(o.LogList, Is.EqualTo(new List<string>
             {
                 "IsManaged",
-                $"RealmObject.Get{GetCoreMethodName(typeName)}Value(propertyName = \"{propertyName}\")"
+                $"RealmObject.GetValue(propertyName = \"{propertyName}\")"
             }));
         }
 
@@ -316,7 +266,7 @@ namespace RealmWeaver
             Assert.That(o.LogList, Is.EqualTo(new List<string>
             {
                 "IsManaged",
-                $"RealmObject.Set{GetCoreMethodName(typeName)}Value(propertyName = \"{propertyName}\", value = {propertyValue})"
+                $"RealmObject.SetValue(propertyName = \"{propertyName}\", value = Realms.RealmValue)"
             }));
             Assert.That(GetAutoPropertyBackingFieldValue(o, propertyName), Is.EqualTo(defaultPropertyValue));
         }
@@ -345,7 +295,7 @@ namespace RealmWeaver
             Assert.That(o.LogList, Is.EqualTo(new List<string>
             {
                 "IsManaged",
-                $"RealmObject.Set{GetCoreMethodName(typeName)}Value(propertyName = \"{propertyName}\", value = {propertyValue})"
+                $"RealmObject.SetValue(propertyName = \"{propertyName}\", value = Realms.RealmValue)"
             }));
             Assert.That(GetAutoPropertyBackingFieldValue(o, propertyName), Is.EqualTo(defaultPropertyValue));
             Assert.That(eventRaised, Is.False);
@@ -392,7 +342,7 @@ namespace RealmWeaver
             Assert.That(o.LogList, Is.EqualTo(new List<string>
             {
                 "IsManaged",
-                $"RealmObject.Set{GetCoreMethodName(typeName)}ValueUnique(propertyName = \"{propertyName}\", value = {propertyValue})"
+                $"RealmObject.SetValueUnique(propertyName = \"{propertyName}\", value = Realms.RealmValue)"
             }));
             Assert.That(GetAutoPropertyBackingFieldValue(o, propertyName), Is.EqualTo(defaultPropertyValue));
         }
@@ -473,7 +423,7 @@ namespace RealmWeaver
             Assert.That(o.LogList, Is.EqualTo(new List<string>
             {
                 "IsManaged",
-                "RealmObject.SetStringValue(propertyName = \"Email\", value = a@b.com)"
+                "RealmObject.SetValue(propertyName = \"Email\", value = Realms.RealmValue)"
             }));
         }
 
@@ -610,7 +560,7 @@ namespace RealmWeaver
             {
                 "IsManaged",
                 "IsManaged",
-                $"RealmObject.Set{GetCoreMethodName(propertyName)}Value(propertyName = \"{propertyName}\", value = {propertyValue})"
+                $"RealmObject.SetValue(propertyName = \"{propertyName}\", value = Realms.RealmValue)"
             }));
         }
 
@@ -650,7 +600,7 @@ namespace RealmWeaver
                                            return new[]
                                            {
                                                "IsManaged",
-                                               $"RealmObject.Set{GetCoreMethodName(p.Name)}Value(propertyName = \"{p.Name}\", value = )"
+                                               $"RealmObject.SetValue(propertyName = \"{p.Name}\", value = Realms.RealmValue)"
                                            };
                                        })
                                        .ToList();
@@ -672,7 +622,7 @@ namespace RealmWeaver
 
             var propertyType = objectType.GetProperty(type + "Property").PropertyType;
             var defaultValue = propertyType.IsValueType ? Activator.CreateInstance(propertyType).ToString() : string.Empty;
-            Assert.That(instance.LogList, Does.Not.Contain($"RealmObject.Set{GetCoreMethodName(type)}ValueUnique(propertyName = \"{type}Property\", value = {defaultValue})"));
+            Assert.That(instance.LogList, Does.Not.Contain($"RealmObject.SetValueUnique(propertyName = \"{type}Property\", value = Realms.RealmValue)"));
         }
 
         [TestCase("RequiredObject", true)]
@@ -694,7 +644,7 @@ namespace RealmWeaver
                                            return new[]
                                            {
                                                "IsManaged",
-                                               $"RealmObject.Set{p.Name}Value(propertyName = \"{p.Name}\", value = )"
+                                               $"RealmObject.SetValue(propertyName = \"{p.Name}\", value = Realms.RealmValue)"
                                            };
                                        })
                                        .ToList();

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -362,7 +362,7 @@ namespace RealmWeaver
             Assert.That(o.LogList, Is.EqualTo(new List<string>
             {
                 "IsManaged",
-                "RealmObject.SetObjectValue(propertyName = \"PrimaryNumber\", value = AssemblyToProcess.PhoneNumber)"
+                "RealmObject.SetValue(propertyName = \"PrimaryNumber\", value = Realms.RealmValue)"
             }));
             Assert.That(GetAutoPropertyBackingFieldValue(o, "PrimaryNumber"), Is.Null);
         }
@@ -381,7 +381,7 @@ namespace RealmWeaver
             Assert.That(o.LogList, Is.EqualTo(new List<string>
             {
                 "IsManaged",
-                "RealmObject.GetObjectValue(propertyName = \"PrimaryNumber\")"
+                "RealmObject.GetValue(propertyName = \"PrimaryNumber\")"
             }));
         }
 

--- a/Tools/SetupUnityPackage/SetupUnityPackage/MetaFiles/Dependencies/System.Buffers.dll.meta
+++ b/Tools/SetupUnityPackage/SetupUnityPackage/MetaFiles/Dependencies/System.Buffers.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 29e374bcbed7d443baa40888b70e941e
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tools/SetupUnityPackage/SetupUnityPackage/Program.cs
+++ b/Tools/SetupUnityPackage/SetupUnityPackage/Program.cs
@@ -65,6 +65,10 @@ namespace SetupUnityPackage
             {
                 { "lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll", "Dependencies/System.Runtime.CompilerServices.Unsafe.dll" },
             },
+            ["System.Buffers"] = new Dictionary<string, string>
+            {
+                { "lib/netstandard2.0/System.Buffers.dll", "Dependencies/System.Buffers.dll" },
+            },
         };
 
         public static async Task Main(string[] args)
@@ -93,14 +97,18 @@ namespace SetupUnityPackage
 
                 foreach (var package in realmDependencies)
                 {
+                    var packageVersion = package.VersionRange.MinVersion.ToNormalizedString();
                     if (_packageMaps.TryGetValue(package.Id, out var fileMap))
                     {
-                        var packageVersion = package.VersionRange.MinVersion.ToNormalizedString();
                         Console.WriteLine($"Including {package.Id}@{packageVersion}");
                         var path = await DownloadPackage(package.Id, packageVersion);
                         await CopyBinaries(path, fileMap);
 
                         Console.WriteLine($"Included {fileMap.Count} files from {package.Id}@{packageVersion}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Skipping {package.Id}@{packageVersion} because it's not included in packageMaps");
                     }
                 }
 

--- a/Tools/SetupUnityPackage/SetupUnityPackage/SetupUnityPackage.csproj
+++ b/Tools/SetupUnityPackage/SetupUnityPackage/SetupUnityPackage.csproj
@@ -23,6 +23,9 @@
     <None Update="MetaFiles\Dependencies\Remotion.Linq.dll.meta">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="MetaFiles\Dependencies\System.Buffers.dll.meta">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="MetaFiles\Dependencies\System.Runtime.CompilerServices.Unsafe.dll.meta">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/wrappers/build.ps1
+++ b/wrappers/build.ps1
@@ -22,7 +22,7 @@ param(
     [Parameter(Position=0)]
     [string]$Target = 'Windows',
 
-    [Switch]$NoRebuild
+    [Switch]$Incremental
 )
 
 Push-Location $PSScriptRoot
@@ -63,12 +63,12 @@ function triplet([string]$target, [string]$platform) {
 }
 
 foreach ($platform in $Platforms) {
-    if (-Not $NoRebuild) {
+    if (-Not $Incremental) {
         Remove-Item .\cmake\$Target\$Configuration-$platform -Recurse -Force -ErrorAction Ignore
     }
     New-Item .\cmake\$Target\$Configuration-$platform -ItemType "Directory" | Out-Null
     Push-Location .\cmake\$Target\$Configuration-$platform
-    if (-Not $NoRebuild) {
+    if (-Not $Incremental) {
         & $cmake $PSScriptRoot $cmakeArgs -DCMAKE_GENERATOR_PLATFORM="$platform" -DVCPKG_TARGET_TRIPLET="$(triplet -target $Target -platform $platform)"
     }
     

--- a/wrappers/build.ps1
+++ b/wrappers/build.ps1
@@ -20,7 +20,9 @@ param(
 
     [ValidateSet('Windows', 'WindowsStore')]
     [Parameter(Position=0)]
-    [string]$Target = 'Windows'
+    [string]$Target = 'Windows',
+
+    [Switch]$NoRebuild
 )
 
 Push-Location $PSScriptRoot
@@ -61,10 +63,15 @@ function triplet([string]$target, [string]$platform) {
 }
 
 foreach ($platform in $Platforms) {
-    Remove-Item .\cmake\$Target\$Configuration-$platform -Recurse -Force -ErrorAction Ignore
+    if (-Not $NoRebuild) {
+        Remove-Item .\cmake\$Target\$Configuration-$platform -Recurse -Force -ErrorAction Ignore
+    }
     New-Item .\cmake\$Target\$Configuration-$platform -ItemType "Directory" | Out-Null
     Push-Location .\cmake\$Target\$Configuration-$platform
-    & $cmake $PSScriptRoot $cmakeArgs -DCMAKE_GENERATOR_PLATFORM="$platform" -DVCPKG_TARGET_TRIPLET="$(triplet -target $Target -platform $platform)"
+    if (-Not $NoRebuild) {
+        & $cmake $PSScriptRoot $cmakeArgs -DCMAKE_GENERATOR_PLATFORM="$platform" -DVCPKG_TARGET_TRIPLET="$(triplet -target $Target -platform $platform)"
+    }
+    
     & $cmake --build . --target install --config $Configuration
     Pop-Location
 }

--- a/wrappers/src/error_handling.cpp
+++ b/wrappers/src/error_handling.cpp
@@ -34,14 +34,6 @@
 using namespace realm::app;
 
 namespace realm {
-
-    SetDuplicatePrimaryKeyValueException::SetDuplicatePrimaryKeyValueException(std::string object_type, std::string property, std::string value)
-        : std::runtime_error(util::format(
-            "A %1 object already exists with primary key property %2 == '%3'",
-        object_type, property, value))
-    {}
-
-
     /**
     @note mostly copied from util.cpp in Java but has a much richer range of exceptions
     @warning if you update these codes also update the matching RealmExceptionCodes.cs
@@ -118,6 +110,12 @@ namespace realm {
         }
         catch (const ObjectManagedByAnotherRealmException& e) {
             return { RealmErrorType::ObjectManagedByAnotherRealm, e.what() };
+        }
+        catch (const NotNullableException& e) {
+            return { RealmErrorType::NotNullableProperty, e.what() };
+        }
+        catch (const PropertyTypeMismatchException& e) {
+            return { RealmErrorType::PropertyMismatch, e.what() };
         }
         catch (const AppError& e) {
             if (e.is_client_error()) {

--- a/wrappers/src/error_handling.hpp
+++ b/wrappers/src/error_handling.hpp
@@ -67,7 +67,8 @@ public:
 
 class SetDuplicatePrimaryKeyValueException : public std::runtime_error {
 public:
-    SetDuplicatePrimaryKeyValueException(std::string object_type, std::string property, std::string value);
+    SetDuplicatePrimaryKeyValueException(std::string object_type, std::string property, std::string value)
+        : std::runtime_error(util::format("A %1 object already exists with primary key property %2 == '%3'", object_type, property, value)) {}
 };
 
 class InvalidSchemaException : public std::runtime_error {
@@ -79,7 +80,24 @@ class ObjectManagedByAnotherRealmException : public std::runtime_error {
 public:
     ObjectManagedByAnotherRealmException(std::string message) : std::runtime_error(message) {}
 };
-    
+
+class NotNullableException : public std::runtime_error {
+public:
+    NotNullableException(std::string object_type, std::string property)
+        : std::runtime_error(util::format("Attempted to set %1.%2 to null, but it is defined as required.", object_type, property)) {}
+
+    NotNullableException() : std::runtime_error("Attempted to add null to a list of required values") {}
+};
+
+class PropertyTypeMismatchException : public std::runtime_error {
+public:
+    PropertyTypeMismatchException(std::string object_type, std::string property, std::string property_type, std::string actual_type)
+        : std::runtime_error(util::format("Property type mismatch: %1.%2 is of type %3, but the value is of type %4")) {}
+
+    PropertyTypeMismatchException(std::string property_type, std::string actual_type) 
+        : std::runtime_error(util::format("List type mismatch: attempted to add a value of type '%1' to a list that expects '%2'", actual_type, property_type)) {}
+};
+
 REALM_EXPORT NativeException convert_exception();
 
 void throw_managed_exception(const NativeException& exception);

--- a/wrappers/src/error_handling.hpp
+++ b/wrappers/src/error_handling.hpp
@@ -69,6 +69,11 @@ class SetDuplicatePrimaryKeyValueException : public std::runtime_error {
 public:
     SetDuplicatePrimaryKeyValueException(std::string object_type, std::string property, std::string value);
 };
+
+class InvalidSchemaException : public std::runtime_error {
+public:
+    InvalidSchemaException(std::string message) : std::runtime_error(message) {}
+};
     
 class ObjectManagedByAnotherRealmException : public std::runtime_error {
 public:

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -181,7 +181,7 @@ REALM_EXPORT size_t list_find_object(List& list, const Object& object_ptr, Nativ
 REALM_EXPORT size_t list_find_primitive(List& list, realm_value_t value, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
-        // This doesn't use EnsureTypes to allow List<string>.Find(null) to return false
+        // This doesn't use ensure_types to allow List<string>.Find(null) to return false
         if (value.is_null() && !is_nullable(list.get_type())) {
             return (size_t)-1;
         }

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -140,7 +140,7 @@ REALM_EXPORT void list_get_value(List& list, size_t ndx, realm_value_t* value, N
         }
         else {
             auto val = list.get_any(ndx);
-            if (!val.is_null() && val.get_type() == DataType::type_TypedLink) {
+            if (!val.is_null() && val.get_type() == type_TypedLink) {
                 *value = to_capi(new Object(list.get_realm(), val.get<ObjLink>()));
             }
             else {

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -238,16 +238,6 @@ REALM_EXPORT void list_get_primitive(List& list, size_t ndx, realm_value_t* valu
     });
 }
 
-REALM_EXPORT size_t list_get_string(List& list, size_t ndx, uint16_t* value, size_t value_len, bool* is_null, NativeException::Marshallable& ex)
-{
-    return collection_get_string(list, ndx, value, value_len, is_null, ex);
-}
-
-REALM_EXPORT size_t list_get_binary(List& list, size_t ndx, char* return_buffer, size_t buffer_size, bool* is_null, NativeException::Marshallable& ex)
-{
-    return collection_get_binary(list, ndx, return_buffer, buffer_size, is_null, ex);
-}
-
 REALM_EXPORT size_t list_find_object(List& list, const Object& object_ptr, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -80,58 +80,37 @@ REALM_EXPORT void list_add_object(List& list, const Object& object_ptr, NativeEx
     });
 }
 
-REALM_EXPORT void list_add_primitive(List& list, PrimitiveValue value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_add_primitive(List& list, realm_value_t value, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (value.type) {
-            case realm::PropertyType::Bool:
-                list.add(value.value.bool_value);
-                break;
-            case realm::PropertyType::Bool | realm::PropertyType::Nullable:
-                list.add(value.has_value ? util::Optional<bool>(value.value.bool_value) : util::Optional<bool>(none));
-                break;
-            case realm::PropertyType::Int:
-                list.add(value.value.int_value);
-                break;
-            case realm::PropertyType::Int | realm::PropertyType::Nullable:
-                list.add(value.has_value ? util::Optional<int64_t>(value.value.int_value) : util::Optional<int64_t>(none));
-                break;
-            case realm::PropertyType::Float:
-                list.add(value.value.float_value);
-                break;
-            case realm::PropertyType::Float | realm::PropertyType::Nullable:
-                list.add(value.has_value ? util::Optional<float>(value.value.float_value) : util::Optional<float>(none));
-                break;
-            case realm::PropertyType::Double:
-                list.add(value.value.double_value);
-                break;
-            case realm::PropertyType::Double | realm::PropertyType::Nullable:
-                list.add(value.has_value ? util::Optional<double>(value.value.double_value) : util::Optional<double>(none));
-                break;
-            case realm::PropertyType::Date:
-                list.add(from_ticks(value.value.int_value));
-                break;
-            case realm::PropertyType::Date | realm::PropertyType::Nullable:
-                list.add(value.has_value ? from_ticks(value.value.int_value) : Timestamp());
-                break;
-            case realm::PropertyType::Decimal:
-                list.add(realm::Decimal128(value.value.decimal_bits));
-                break;
-            case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-                list.add(value.has_value ? realm::Decimal128(value.value.decimal_bits) : Decimal128(null()));
-                break;
-            case realm::PropertyType::ObjectId:
-                list.add(to_object_id(value));
-                break;
-            case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-                list.add(value.has_value ? util::Optional<ObjectId>(to_object_id(value)) : util::Optional<ObjectId>());
-                break;
-            default:
-                REALM_UNREACHABLE();
+        switch (value.type)
+        {
+        case realm_value_type_e::RLM_TYPE_NULL:
+            throw std::runtime_error("Implement me!!");
+        case realm_value_type_e::RLM_TYPE_BOOL:
+            list.add(value.boolean);
+            break;
+        case realm_value_type_e::RLM_TYPE_INT:
+            list.add(value.integer);
+            break;
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            list.add(value.fnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            list.add(value.dnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            list.add(from_capi(value.timestamp));
+            break;
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            list.add(from_capi(value.decimal128));
+            break;
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            list.add(from_capi(value.object_id));
+            break;
+        default:
+            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 
@@ -168,7 +147,7 @@ REALM_EXPORT void list_set_object(List& list, size_t list_ndx, const Object& obj
     set(list, list_ndx, object_ptr.obj(), ex);
 }
 
-REALM_EXPORT void list_set_primitive(List& list, size_t list_ndx, PrimitiveValue value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_set_primitive(List& list, size_t list_ndx, realm_value_t value, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         const size_t count = list.size();
@@ -176,55 +155,34 @@ REALM_EXPORT void list_set_primitive(List& list, size_t list_ndx, PrimitiveValue
             throw IndexOutOfRangeException("Set into RealmList", list_ndx, count);
         }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (value.type) {
-            case realm::PropertyType::Bool:
-                list.set(list_ndx, value.value.bool_value);
-                break;
-            case realm::PropertyType::Bool | realm::PropertyType::Nullable:
-                list.set(list_ndx, value.has_value ? util::Optional<bool>(value.value.bool_value) : util::Optional<bool>());
-                break;
-            case realm::PropertyType::Int:
-                list.set(list_ndx, value.value.int_value);
-                break;
-            case realm::PropertyType::Int | realm::PropertyType::Nullable:
-                list.set(list_ndx, value.has_value ? util::Optional<int64_t>(value.value.int_value) : util::Optional<int64_t>());
-                break;
-            case realm::PropertyType::Float:
-                list.set(list_ndx, value.value.float_value);
-                break;
-            case realm::PropertyType::Float | realm::PropertyType::Nullable:
-                list.set(list_ndx, value.has_value ? util::Optional<float>(value.value.float_value) : util::Optional<float>());
-                break;
-            case realm::PropertyType::Double:
-                list.set(list_ndx, value.value.double_value);
-                break;
-            case realm::PropertyType::Double | realm::PropertyType::Nullable:
-                list.set(list_ndx, value.has_value ? util::Optional<double>(value.value.double_value) : util::Optional<double>());
-                break;
-            case realm::PropertyType::Date:
-                list.set(list_ndx, from_ticks(value.value.int_value));
-                break;
-            case realm::PropertyType::Date | realm::PropertyType::Nullable:
-                list.set(list_ndx, value.has_value ? from_ticks(value.value.int_value) : Timestamp());
-                break;
-            case realm::PropertyType::Decimal:
-                list.set(list_ndx, realm::Decimal128(value.value.decimal_bits));
-                break;
-            case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-                list.set(list_ndx, value.has_value ? realm::Decimal128(value.value.decimal_bits) : Decimal128(null()));
-                break;
-            case realm::PropertyType::ObjectId:
-                list.set(list_ndx, to_object_id(value));
-                break;
-            case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-                list.set(list_ndx, value.has_value ? util::Optional<ObjectId>(to_object_id(value)) : util::Optional<ObjectId>());
-                break;
-            default:
-                REALM_UNREACHABLE();
+        switch (value.type)
+        {
+        case realm_value_type_e::RLM_TYPE_NULL:
+            throw std::runtime_error("Implement me!!");
+        case realm_value_type_e::RLM_TYPE_BOOL:
+            list.set(list_ndx, value.boolean);
+            break;
+        case realm_value_type_e::RLM_TYPE_INT:
+            list.add(value.integer);
+            break;
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            list.set(list_ndx, value.fnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            list.set(list_ndx, value.dnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            list.set(list_ndx, from_capi(value.timestamp));
+            break;
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            list.set(list_ndx, from_capi(value.decimal128));
+            break;
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            list.set(list_ndx, from_capi(value.object_id));
+            break;
+        default:
+            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 
@@ -266,7 +224,7 @@ REALM_EXPORT void list_insert_object(List& list, size_t list_ndx, const Object& 
     insert(list, list_ndx, object_ptr.obj(), ex);
 }
 
-REALM_EXPORT void list_insert_primitive(List& list, size_t list_ndx, PrimitiveValue value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_insert_primitive(List& list, size_t list_ndx, realm_value_t value, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         const size_t count = list.size();
@@ -274,55 +232,34 @@ REALM_EXPORT void list_insert_primitive(List& list, size_t list_ndx, PrimitiveVa
             throw IndexOutOfRangeException("Insert into RealmList", list_ndx, count);
         }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (value.type) {
-            case realm::PropertyType::Bool:
-                list.insert(list_ndx, value.value.bool_value);
-                break;
-            case realm::PropertyType::Bool | realm::PropertyType::Nullable:
-                list.insert(list_ndx, value.has_value ? util::Optional<bool>(value.value.bool_value) : util::Optional<bool>(none));
-                break;
-            case realm::PropertyType::Int:
-                list.insert(list_ndx, value.value.int_value);
-                break;
-            case realm::PropertyType::Int | realm::PropertyType::Nullable:
-                list.insert(list_ndx, value.has_value ? util::Optional<int64_t>(value.value.int_value) : util::Optional<int64_t>(none));
-                break;
-            case realm::PropertyType::Float:
-                list.insert(list_ndx, value.value.float_value);
-                break;
-            case realm::PropertyType::Float | realm::PropertyType::Nullable:
-                list.insert(list_ndx, value.has_value ? util::Optional<float>(value.value.float_value) : util::Optional<float>(none));
-                break;
-            case realm::PropertyType::Double:
-                list.insert(list_ndx, value.value.double_value);
-                break;
-            case realm::PropertyType::Double | realm::PropertyType::Nullable:
-                list.insert(list_ndx, value.has_value ? util::Optional<double>(value.value.double_value) : util::Optional<double>(none));
-                break;
-            case realm::PropertyType::Date:
-                list.insert(list_ndx, from_ticks(value.value.int_value));
-                break;
-            case realm::PropertyType::Date | realm::PropertyType::Nullable:
-                list.insert(list_ndx, value.has_value ? from_ticks(value.value.int_value) : Timestamp());
-                break;
-            case realm::PropertyType::Decimal:
-                list.insert(list_ndx, realm::Decimal128(value.value.decimal_bits));
-                break;
-            case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-                list.insert(list_ndx, value.has_value ? realm::Decimal128(value.value.decimal_bits) : Decimal128(null()));
-                break;
-            case realm::PropertyType::ObjectId:
-                list.insert(list_ndx, to_object_id(value));
-                break;
-            case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-                list.insert(list_ndx, value.has_value ? util::Optional<ObjectId>(to_object_id(value)) : util::Optional<ObjectId>());
-                break;
-            default:
-                REALM_UNREACHABLE();
+        switch (value.type)
+        {
+        case realm_value_type_e::RLM_TYPE_NULL:
+            throw std::runtime_error("Implement me!!");
+        case realm_value_type_e::RLM_TYPE_BOOL:
+            list.insert(list_ndx, value.boolean);
+            break;
+        case realm_value_type_e::RLM_TYPE_INT:
+            list.insert(list_ndx, value.integer);
+            break;
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            list.insert(list_ndx, value.fnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            list.insert(list_ndx, value.dnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            list.insert(list_ndx, from_capi(value.timestamp));
+            break;
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            list.insert(list_ndx, from_capi(value.decimal128));
+            break;
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            list.insert(list_ndx, from_capi(value.object_id));
+            break;
+        default:
+            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 
@@ -370,9 +307,17 @@ REALM_EXPORT Object* list_get_object(List& list, size_t ndx, NativeException::Ma
     });
 }
 
-REALM_EXPORT void list_get_primitive(List& list, size_t ndx, PrimitiveValue& value, NativeException::Marshallable& ex)
+REALM_EXPORT void list_get_primitive(List& list, size_t ndx, realm_value_t* value, NativeException::Marshallable& ex)
 {
-    collection_get_primitive(list, ndx, value, ex);
+    handle_errors(ex, [&]() {
+        const size_t count = list.size();
+        if (ndx >= count)
+            throw IndexOutOfRangeException("Get from Collection", ndx, count);
+
+        throw std::runtime_error("implement me!!");
+        //auto val = list.get<Mixed>(ndx);
+        //*value = to_capi(val);
+    });
 }
 
 REALM_EXPORT size_t list_get_string(List& list, size_t ndx, uint16_t* value, size_t value_len, bool* is_null, NativeException::Marshallable& ex)
@@ -396,44 +341,30 @@ REALM_EXPORT size_t list_find_object(List& list, const Object& object_ptr, Nativ
     });
 }
 
-REALM_EXPORT size_t list_find_primitive(List& list, PrimitiveValue value, NativeException::Marshallable& ex)
+REALM_EXPORT size_t list_find_primitive(List& list, realm_value_t value, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (value.type) {
-            case realm::PropertyType::Bool:
-                return list.find(value.value.bool_value);
-            case realm::PropertyType::Bool | realm::PropertyType::Nullable:
-                return list.find(value.has_value ? util::Optional<bool>(value.value.bool_value) : util::Optional<bool>(none));
-            case realm::PropertyType::Int:
-                return list.find(value.value.int_value);
-            case realm::PropertyType::Int | realm::PropertyType::Nullable:
-                return list.find(value.has_value ? util::Optional<int64_t>(value.value.int_value) : util::Optional<int64_t>(none));
-            case realm::PropertyType::Float:
-                return list.find(value.value.float_value);
-            case realm::PropertyType::Float | realm::PropertyType::Nullable:
-                return list.find(value.has_value ? util::Optional<float>(value.value.float_value) : util::Optional<float>(none));
-            case realm::PropertyType::Double:
-                return list.find(value.value.double_value);
-            case realm::PropertyType::Double | realm::PropertyType::Nullable:
-                return list.find(value.has_value ? util::Optional<double>(value.value.double_value) : util::Optional<double>(none));
-            case realm::PropertyType::Date:
-                return list.find(from_ticks(value.value.int_value));
-            case realm::PropertyType::Date | realm::PropertyType::Nullable:
-                return list.find(value.has_value ? from_ticks(value.value.int_value) : Timestamp());
-            case realm::PropertyType::Decimal:
-                return list.find(realm::Decimal128(value.value.decimal_bits));
-            case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-                return list.find(value.has_value ? realm::Decimal128(value.value.decimal_bits) : Decimal128(null()));
-            case realm::PropertyType::ObjectId:
-                return list.find(to_object_id(value));
-            case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-                return list.find(value.has_value ? util::Optional<ObjectId>(to_object_id(value)) : util::Optional<ObjectId>());
-            default:
-                REALM_UNREACHABLE();
+        switch (value.type)
+        {
+        case realm_value_type_e::RLM_TYPE_NULL:
+            throw std::runtime_error("Implement me!!");
+        case realm_value_type_e::RLM_TYPE_BOOL:
+            return list.find(value.boolean);
+        case realm_value_type_e::RLM_TYPE_INT:
+            return list.find(value.integer);
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            return list.find(value.fnum);
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            return list.find(value.dnum);
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            return list.find(from_capi(value.timestamp));
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            return list.find(from_capi(value.decimal128));
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            return list.find(from_capi(value.object_id));
+        default:
+            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -347,31 +347,5 @@ private:
 
 size_t stringdata_to_csharpstringbuffer(StringData str, uint16_t * csharpbuffer, size_t bufsize); //note bufsize is _in_16bit_words
 
-template<typename Collection>
-size_t collection_get_string(Collection& collection, size_t ndx, uint16_t* value, size_t value_len, bool* is_null, NativeException::Marshallable& ex)
-{
-    auto result = get<StringData>(collection, ndx, ex);
-
-    if ((*is_null = result.is_null()))
-        return 0;
-
-    return stringdata_to_csharpstringbuffer(result, value, value_len);
-}
-
-template<typename Collection>
-size_t collection_get_binary(Collection& collection, size_t ndx, char* return_buffer, size_t buffer_size, bool* is_null, NativeException::Marshallable& ex)
-{
-    auto result = get<BinaryData>(collection, ndx, ex);
-
-    if ((*is_null = result.is_null()))
-        return 0;
-
-    const size_t data_size = result.size();
-    if (data_size <= buffer_size)
-        std::copy(result.data(), result.data() + data_size, return_buffer);
-
-    return data_size;
-}
-
 } // namespace binding
 } // namespace realm

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -79,7 +79,7 @@ extern "C" {
             }
             else {
                 auto val = object.obj().get_any(prop.column_key);
-                if (!val.is_null() && val.get_type() == DataType::type_TypedLink) {
+                if (!val.is_null() && val.get_type() == type_TypedLink) {
                     *value = to_capi(new Object(object.realm(), val.get<ObjLink>()));
                 }
                 else {

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -116,39 +116,6 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT size_t object_get_string(const Object& object, size_t property_ndx, uint16_t* string_buffer, size_t buffer_size, bool& is_null, NativeException::Marshallable& ex)
-    {
-        StringData field_data = object_get<StringData>(object, property_ndx, ex);
-        if (ex.type != RealmErrorType::NoError) {
-            return -1;
-        }
-
-        if ((is_null = field_data.is_null())) {
-            return 0;
-        }
-
-        return stringdata_to_csharpstringbuffer(field_data, string_buffer, buffer_size);
-    }
-
-    REALM_EXPORT size_t object_get_binary(const Object& object, size_t property_ndx, char* return_buffer, size_t buffer_size, bool& is_null, NativeException::Marshallable& ex)
-    {
-        BinaryData field_data = object_get<BinaryData>(object, property_ndx, ex);
-        if (ex.type != RealmErrorType::NoError) {
-            return -1;
-        }
-
-        if ((is_null = field_data.is_null())) {
-            return 0;
-        }
-
-        const size_t data_size = field_data.size();
-        if (data_size <= buffer_size) {
-            std::copy(field_data.data(), field_data.data() + data_size, return_buffer);
-        }
-
-        return data_size;
-    }
-
     REALM_EXPORT Results* object_get_backlinks(Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {

--- a/wrappers/src/object_cs.hpp
+++ b/wrappers/src/object_cs.hpp
@@ -44,7 +44,11 @@ namespace realm {
         object.realm()->verify_in_write();
     }
 
+    inline const Property get_property(const Object& object, const size_t property_index) {
+        return object.get_object_schema().persisted_properties[property_index];
+    }
+
     inline const ColKey get_column_key(const Object& object, const size_t property_index) {
-         return object.get_object_schema().persisted_properties[property_index].column_key;
+         return get_property(object, property_index).column_key;
     }
 }

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -124,280 +124,191 @@ REALM_EXPORT void query_string_like(Query& query, SharedRealm& realm, size_t pro
     });
 }
 
-REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        if (!primitive.has_value) {
+        auto col_key = get_key_for_prop(query, realm, property_index);
+        switch (primitive.type) {
+        case realm_value_type_e::RLM_TYPE_NULL:
             throw std::runtime_error("Comparing null values should be done via query_null_equal. If you get this error, please report it to help@realm.io.");
+        case realm_value_type_e::RLM_TYPE_BOOL:
+            query.equal(std::move(col_key), primitive.boolean);
+            break;
+        case realm_value_type_e::RLM_TYPE_INT:
+            query.equal(std::move(col_key), primitive.integer);
+            break;
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            query.equal(std::move(col_key), primitive.fnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            query.equal(std::move(col_key), primitive.dnum);
+            break;
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            query.equal(std::move(col_key), from_capi(primitive.timestamp));
+            break;
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            query.equal(std::move(col_key), from_capi(primitive.decimal128));
+            break;
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            query.equal(std::move(col_key), from_capi(primitive.object_id));
+            break;
         }
-
-        auto col_key = get_key_for_prop(query, realm, property_index);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (primitive.type) {
-        case realm::PropertyType::Bool:
-        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
-            query.equal(std::move(col_key), primitive.value.bool_value);
-            break;
-        case realm::PropertyType::Int:
-        case realm::PropertyType::Int | realm::PropertyType::Nullable:
-            query.equal(std::move(col_key), primitive.value.int_value);
-            break;
-        case realm::PropertyType::Float:
-        case realm::PropertyType::Float | realm::PropertyType::Nullable:
-            query.equal(std::move(col_key), primitive.value.float_value);
-            break;
-        case realm::PropertyType::Double:
-        case realm::PropertyType::Double | realm::PropertyType::Nullable:
-            query.equal(std::move(col_key), primitive.value.double_value);
-            break;
-        case realm::PropertyType::Date:
-        case realm::PropertyType::Date | realm::PropertyType::Nullable:
-            query.equal(std::move(col_key), from_ticks(primitive.value.int_value));
-            break;
-        case realm::PropertyType::Decimal:
-        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.equal(std::move(col_key), realm::Decimal128(primitive.value.decimal_bits));
-            break;
-        case realm::PropertyType::ObjectId:
-        case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-            query.equal(std::move(col_key), to_object_id(primitive));
-            break;
-        default:
-            REALM_UNREACHABLE();
-        }
-#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        if (!primitive.has_value) {
-            throw std::runtime_error("Comparing null values should be done via query_null_not_equal. If you get this error, please report it to help@realm.io.");
-        }
-
         auto col_key = get_key_for_prop(query, realm, property_index);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
         switch (primitive.type) {
-        case realm::PropertyType::Bool:
-        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
-            query.not_equal(std::move(col_key), primitive.value.bool_value);
+        case realm_value_type_e::RLM_TYPE_NULL:
+            throw std::runtime_error("Comparing null values should be done via query_null_equal. If you get this error, please report it to help@realm.io.");
+        case realm_value_type_e::RLM_TYPE_BOOL:
+            query.not_equal(std::move(col_key), primitive.boolean);
             break;
-        case realm::PropertyType::Int:
-        case realm::PropertyType::Int | realm::PropertyType::Nullable:
-            query.not_equal(std::move(col_key), primitive.value.int_value);
+        case realm_value_type_e::RLM_TYPE_INT:
+            query.not_equal(std::move(col_key), primitive.integer);
             break;
-        case realm::PropertyType::Float:
-        case realm::PropertyType::Float | realm::PropertyType::Nullable:
-            query.not_equal(std::move(col_key), primitive.value.float_value);
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            query.not_equal(std::move(col_key), primitive.fnum);
             break;
-        case realm::PropertyType::Double:
-        case realm::PropertyType::Double | realm::PropertyType::Nullable:
-            query.not_equal(std::move(col_key), primitive.value.double_value);
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            query.not_equal(std::move(col_key), primitive.dnum);
             break;
-        case realm::PropertyType::Date:
-        case realm::PropertyType::Date | realm::PropertyType::Nullable:
-            query.not_equal(std::move(col_key), from_ticks(primitive.value.int_value));
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            query.not_equal(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm::PropertyType::Decimal:
-        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.not_equal(std::move(col_key), realm::Decimal128(primitive.value.decimal_bits));
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            query.not_equal(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm::PropertyType::ObjectId:
-        case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-            query.not_equal(std::move(col_key), to_object_id(primitive));
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            query.not_equal(std::move(col_key), from_capi(primitive.object_id));
             break;
-        default:
-            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        if (!primitive.has_value) {
+        auto col_key = get_key_for_prop(query, realm, property_index);
+        switch (primitive.type) {
+        case realm_value_type_e::RLM_TYPE_NULL:
             throw std::runtime_error("Using primitive_less with null is not supported. If you get this error, please report it to help@realm.io.");
-        }
-
-        auto col_key = get_key_for_prop(query, realm, property_index);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (primitive.type) {
-        case realm::PropertyType::Bool:
-        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+        case realm_value_type_e::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_less with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm::PropertyType::Int:
-        case realm::PropertyType::Int | realm::PropertyType::Nullable:
-            query.less(std::move(col_key), primitive.value.int_value);
+        case realm_value_type_e::RLM_TYPE_INT:
+            query.less(std::move(col_key), primitive.integer);
             break;
-        case realm::PropertyType::Float:
-        case realm::PropertyType::Float | realm::PropertyType::Nullable:
-            query.less(std::move(col_key), primitive.value.float_value);
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            query.less(std::move(col_key), primitive.fnum);
             break;
-        case realm::PropertyType::Double:
-        case realm::PropertyType::Double | realm::PropertyType::Nullable:
-            query.less(std::move(col_key), primitive.value.double_value);
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            query.less(std::move(col_key), primitive.dnum);
             break;
-        case realm::PropertyType::Date:
-        case realm::PropertyType::Date | realm::PropertyType::Nullable:
-            query.less(std::move(col_key), from_ticks(primitive.value.int_value));
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            query.less(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm::PropertyType::Decimal:
-        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.less(std::move(col_key), realm::Decimal128(primitive.value.decimal_bits));
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            query.less(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm::PropertyType::ObjectId:
-        case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-            query.less(std::move(col_key), to_object_id(primitive));
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            query.less(std::move(col_key), from_capi(primitive.object_id));
             break;
-        default:
-            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        if (!primitive.has_value) {
+        auto col_key = get_key_for_prop(query, realm, property_index);
+        switch (primitive.type) {
+        case realm_value_type_e::RLM_TYPE_NULL:
             throw std::runtime_error("Using primitive_less_equal with null is not supported. If you get this error, please report it to help@realm.io.");
-        }
-
-        auto col_key = get_key_for_prop(query, realm, property_index);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (primitive.type) {
-        case realm::PropertyType::Bool:
-        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+        case realm_value_type_e::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_less_equal with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm::PropertyType::Int:
-        case realm::PropertyType::Int | realm::PropertyType::Nullable:
-            query.less_equal(std::move(col_key), primitive.value.int_value);
+        case realm_value_type_e::RLM_TYPE_INT:
+            query.less_equal(std::move(col_key), primitive.integer);
             break;
-        case realm::PropertyType::Float:
-        case realm::PropertyType::Float | realm::PropertyType::Nullable:
-            query.less_equal(std::move(col_key), primitive.value.float_value);
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            query.less_equal(std::move(col_key), primitive.fnum);
             break;
-        case realm::PropertyType::Double:
-        case realm::PropertyType::Double | realm::PropertyType::Nullable:
-            query.less_equal(std::move(col_key), primitive.value.double_value);
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            query.less_equal(std::move(col_key), primitive.dnum);
             break;
-        case realm::PropertyType::Date:
-        case realm::PropertyType::Date | realm::PropertyType::Nullable:
-            query.less_equal(std::move(col_key), from_ticks(primitive.value.int_value));
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            query.less_equal(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm::PropertyType::Decimal:
-        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.less_equal(std::move(col_key), realm::Decimal128(primitive.value.decimal_bits));
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            query.less_equal(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm::PropertyType::ObjectId:
-        case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-            query.less_equal(std::move(col_key), to_object_id(primitive));
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            query.less_equal(std::move(col_key), from_capi(primitive.object_id));
             break;
-        default:
-            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        if (!primitive.has_value) {
+        auto col_key = get_key_for_prop(query, realm, property_index);
+        switch (primitive.type) {
+        case realm_value_type_e::RLM_TYPE_NULL:
             throw std::runtime_error("Using primitive_greater with null is not supported. If you get this error, please report it to help@realm.io.");
-        }
-
-        auto col_key = get_key_for_prop(query, realm, property_index);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-        switch (primitive.type) {
-        case realm::PropertyType::Bool:
-        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+        case realm_value_type_e::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_greater with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm::PropertyType::Int:
-        case realm::PropertyType::Int | realm::PropertyType::Nullable:
-            query.greater(std::move(col_key), primitive.value.int_value);
+        case realm_value_type_e::RLM_TYPE_INT:
+            query.greater(std::move(col_key), primitive.integer);
             break;
-        case realm::PropertyType::Float:
-        case realm::PropertyType::Float | realm::PropertyType::Nullable:
-            query.greater(std::move(col_key), primitive.value.float_value);
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            query.greater(std::move(col_key), primitive.fnum);
             break;
-        case realm::PropertyType::Double:
-        case realm::PropertyType::Double | realm::PropertyType::Nullable:
-            query.greater(std::move(col_key), primitive.value.double_value);
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            query.greater(std::move(col_key), primitive.dnum);
             break;
-        case realm::PropertyType::Date:
-        case realm::PropertyType::Date | realm::PropertyType::Nullable:
-            query.greater(std::move(col_key), from_ticks(primitive.value.int_value));
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            query.greater(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm::PropertyType::Decimal:
-        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.greater(std::move(col_key), realm::Decimal128(primitive.value.decimal_bits));
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            query.greater(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm::PropertyType::ObjectId:
-        case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-            query.greater(std::move(col_key), to_object_id(primitive));
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            query.greater(std::move(col_key), from_capi(primitive.object_id));
             break;
-        default:
-            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 
-REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm, size_t property_index, PrimitiveValue primitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        if (!primitive.has_value) {
-            throw std::runtime_error("Using primitive_greater_equal with null is not supported. If you get this error, please report it to help@realm.io.");
-        }
-
         auto col_key = get_key_for_prop(query, realm, property_index);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
         switch (primitive.type) {
-        case realm::PropertyType::Bool:
-        case realm::PropertyType::Bool | realm::PropertyType::Nullable:
+        case realm_value_type_e::RLM_TYPE_NULL:
+            throw std::runtime_error("Using primitive_greater_equal with null is not supported. If you get this error, please report it to help@realm.io.");
+        case realm_value_type_e::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_greater_equal with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm::PropertyType::Int:
-        case realm::PropertyType::Int | realm::PropertyType::Nullable:
-            query.greater_equal(std::move(col_key), primitive.value.int_value);
+        case realm_value_type_e::RLM_TYPE_INT:
+            query.greater_equal(std::move(col_key), primitive.integer);
             break;
-        case realm::PropertyType::Float:
-        case realm::PropertyType::Float | realm::PropertyType::Nullable:
-            query.greater_equal(std::move(col_key), primitive.value.float_value);
+        case realm_value_type_e::RLM_TYPE_FLOAT:
+            query.greater_equal(std::move(col_key), primitive.fnum);
             break;
-        case realm::PropertyType::Double:
-        case realm::PropertyType::Double | realm::PropertyType::Nullable:
-            query.greater_equal(std::move(col_key), primitive.value.double_value);
+        case realm_value_type_e::RLM_TYPE_DOUBLE:
+            query.greater_equal(std::move(col_key), primitive.dnum);
             break;
-        case realm::PropertyType::Date:
-        case realm::PropertyType::Date | realm::PropertyType::Nullable:
-            query.greater_equal(std::move(col_key), from_ticks(primitive.value.int_value));
+        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+            query.greater_equal(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm::PropertyType::Decimal:
-        case realm::PropertyType::Decimal | realm::PropertyType::Nullable:
-            query.greater_equal(std::move(col_key), realm::Decimal128(primitive.value.decimal_bits));
+        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+            query.greater_equal(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm::PropertyType::ObjectId:
-        case realm::PropertyType::ObjectId | realm::PropertyType::Nullable:
-            query.greater_equal(std::move(col_key), to_object_id(primitive));
+        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+            query.greater_equal(std::move(col_key), from_capi(primitive.object_id));
             break;
-        default:
-            REALM_UNREACHABLE();
         }
-#pragma GCC diagnostic pop
     });
 }
 

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -76,51 +76,51 @@ REALM_EXPORT void query_or(Query& query, NativeException::Marshallable& ex)
     });
 }
 
-REALM_EXPORT void query_string_contains(Query& query, SharedRealm& realm, size_t property_index, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_contains(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        Utf16StringAccessor str(value, value_len);
-        query.contains(get_key_for_prop(query, realm, property_index), str, case_sensitive);
+        REALM_ASSERT(primitive.is_null() || primitive.type == realm_value_type::RLM_TYPE_STRING);
+        query.contains(get_key_for_prop(query, realm, property_index), from_capi(primitive.string), case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_starts_with(Query& query, SharedRealm& realm, size_t property_index, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_starts_with(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        Utf16StringAccessor str(value, value_len);
-        query.begins_with(get_key_for_prop(query, realm, property_index), str, case_sensitive);
+        REALM_ASSERT(primitive.is_null() || primitive.type == realm_value_type::RLM_TYPE_STRING);
+        query.begins_with(get_key_for_prop(query, realm, property_index), from_capi(primitive.string), case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_ends_with(Query& query, SharedRealm& realm, size_t property_index, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_ends_with(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        Utf16StringAccessor str(value, value_len);
-        query.ends_with(get_key_for_prop(query, realm, property_index), str, case_sensitive);
+        REALM_ASSERT(primitive.is_null() || primitive.type == realm_value_type::RLM_TYPE_STRING);
+        query.ends_with(get_key_for_prop(query, realm, property_index), from_capi(primitive.string), case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_equal(Query& query, SharedRealm& realm, size_t property_index, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_equal(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        Utf16StringAccessor str(value, value_len);
-        query.equal(get_key_for_prop(query, realm, property_index), str, case_sensitive);
+        REALM_ASSERT(primitive.is_null() || primitive.type == realm_value_type::RLM_TYPE_STRING);
+        query.equal(get_key_for_prop(query, realm, property_index), from_capi(primitive.string), case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_not_equal(Query& query, SharedRealm& realm, size_t property_index, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_not_equal(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        Utf16StringAccessor str(value, value_len);
-        query.not_equal(get_key_for_prop(query, realm, property_index), str, case_sensitive);
+        REALM_ASSERT(primitive.is_null() || primitive.type == realm_value_type::RLM_TYPE_STRING);
+        query.not_equal(get_key_for_prop(query, realm, property_index), from_capi(primitive.string), case_sensitive);
     });
 }
 
-REALM_EXPORT void query_string_like(Query& query, SharedRealm& realm, size_t property_index, uint16_t* value, size_t value_len, bool case_sensitive, NativeException::Marshallable& ex)
+REALM_EXPORT void query_string_like(Query& query, SharedRealm& realm, size_t property_index, realm_value_t primitive, bool case_sensitive, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
-        Utf16StringAccessor str(value, value_len);
-        query.like(get_key_for_prop(query, realm, property_index), str, case_sensitive);
+        REALM_ASSERT(primitive.is_null() || primitive.type == realm_value_type::RLM_TYPE_STRING);
+        query.like(get_key_for_prop(query, realm, property_index), from_capi(primitive.string), case_sensitive);
     });
 }
 
@@ -129,28 +129,31 @@ REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
         switch (primitive.type) {
-        case realm_value_type_e::RLM_TYPE_NULL:
+        case realm_value_type::RLM_TYPE_NULL:
             throw std::runtime_error("Comparing null values should be done via query_null_equal. If you get this error, please report it to help@realm.io.");
-        case realm_value_type_e::RLM_TYPE_BOOL:
+        case realm_value_type::RLM_TYPE_BOOL:
             query.equal(std::move(col_key), primitive.boolean);
             break;
-        case realm_value_type_e::RLM_TYPE_INT:
+        case realm_value_type::RLM_TYPE_INT:
             query.equal(std::move(col_key), primitive.integer);
             break;
-        case realm_value_type_e::RLM_TYPE_FLOAT:
+        case realm_value_type::RLM_TYPE_FLOAT:
             query.equal(std::move(col_key), primitive.fnum);
             break;
-        case realm_value_type_e::RLM_TYPE_DOUBLE:
+        case realm_value_type::RLM_TYPE_DOUBLE:
             query.equal(std::move(col_key), primitive.dnum);
             break;
-        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+        case realm_value_type::RLM_TYPE_TIMESTAMP:
             query.equal(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+        case realm_value_type::RLM_TYPE_DECIMAL128:
             query.equal(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+        case realm_value_type::RLM_TYPE_OBJECT_ID:
             query.equal(std::move(col_key), from_capi(primitive.object_id));
+            break;
+        case realm_value_type::RLM_TYPE_BINARY:
+            query.equal(std::move(col_key), from_capi(primitive.binary));
             break;
         }
     });
@@ -161,28 +164,31 @@ REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, si
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
         switch (primitive.type) {
-        case realm_value_type_e::RLM_TYPE_NULL:
+        case realm_value_type::RLM_TYPE_NULL:
             throw std::runtime_error("Comparing null values should be done via query_null_equal. If you get this error, please report it to help@realm.io.");
-        case realm_value_type_e::RLM_TYPE_BOOL:
+        case realm_value_type::RLM_TYPE_BOOL:
             query.not_equal(std::move(col_key), primitive.boolean);
             break;
-        case realm_value_type_e::RLM_TYPE_INT:
+        case realm_value_type::RLM_TYPE_INT:
             query.not_equal(std::move(col_key), primitive.integer);
             break;
-        case realm_value_type_e::RLM_TYPE_FLOAT:
+        case realm_value_type::RLM_TYPE_FLOAT:
             query.not_equal(std::move(col_key), primitive.fnum);
             break;
-        case realm_value_type_e::RLM_TYPE_DOUBLE:
+        case realm_value_type::RLM_TYPE_DOUBLE:
             query.not_equal(std::move(col_key), primitive.dnum);
             break;
-        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+        case realm_value_type::RLM_TYPE_TIMESTAMP:
             query.not_equal(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+        case realm_value_type::RLM_TYPE_DECIMAL128:
             query.not_equal(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+        case realm_value_type::RLM_TYPE_OBJECT_ID:
             query.not_equal(std::move(col_key), from_capi(primitive.object_id));
+            break;
+        case realm_value_type::RLM_TYPE_BINARY:
+            query.not_equal(std::move(col_key), from_capi(primitive.binary));
             break;
         }
     });
@@ -193,26 +199,26 @@ REALM_EXPORT void query_primitive_less(Query& query, SharedRealm& realm, size_t 
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
         switch (primitive.type) {
-        case realm_value_type_e::RLM_TYPE_NULL:
+        case realm_value_type::RLM_TYPE_NULL:
             throw std::runtime_error("Using primitive_less with null is not supported. If you get this error, please report it to help@realm.io.");
-        case realm_value_type_e::RLM_TYPE_BOOL:
+        case realm_value_type::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_less with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm_value_type_e::RLM_TYPE_INT:
+        case realm_value_type::RLM_TYPE_INT:
             query.less(std::move(col_key), primitive.integer);
             break;
-        case realm_value_type_e::RLM_TYPE_FLOAT:
+        case realm_value_type::RLM_TYPE_FLOAT:
             query.less(std::move(col_key), primitive.fnum);
             break;
-        case realm_value_type_e::RLM_TYPE_DOUBLE:
+        case realm_value_type::RLM_TYPE_DOUBLE:
             query.less(std::move(col_key), primitive.dnum);
             break;
-        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+        case realm_value_type::RLM_TYPE_TIMESTAMP:
             query.less(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+        case realm_value_type::RLM_TYPE_DECIMAL128:
             query.less(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+        case realm_value_type::RLM_TYPE_OBJECT_ID:
             query.less(std::move(col_key), from_capi(primitive.object_id));
             break;
         }
@@ -224,26 +230,26 @@ REALM_EXPORT void query_primitive_less_equal(Query& query, SharedRealm& realm, s
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
         switch (primitive.type) {
-        case realm_value_type_e::RLM_TYPE_NULL:
+        case realm_value_type::RLM_TYPE_NULL:
             throw std::runtime_error("Using primitive_less_equal with null is not supported. If you get this error, please report it to help@realm.io.");
-        case realm_value_type_e::RLM_TYPE_BOOL:
+        case realm_value_type::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_less_equal with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm_value_type_e::RLM_TYPE_INT:
+        case realm_value_type::RLM_TYPE_INT:
             query.less_equal(std::move(col_key), primitive.integer);
             break;
-        case realm_value_type_e::RLM_TYPE_FLOAT:
+        case realm_value_type::RLM_TYPE_FLOAT:
             query.less_equal(std::move(col_key), primitive.fnum);
             break;
-        case realm_value_type_e::RLM_TYPE_DOUBLE:
+        case realm_value_type::RLM_TYPE_DOUBLE:
             query.less_equal(std::move(col_key), primitive.dnum);
             break;
-        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+        case realm_value_type::RLM_TYPE_TIMESTAMP:
             query.less_equal(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+        case realm_value_type::RLM_TYPE_DECIMAL128:
             query.less_equal(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+        case realm_value_type::RLM_TYPE_OBJECT_ID:
             query.less_equal(std::move(col_key), from_capi(primitive.object_id));
             break;
         }
@@ -255,26 +261,26 @@ REALM_EXPORT void query_primitive_greater(Query& query, SharedRealm& realm, size
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
         switch (primitive.type) {
-        case realm_value_type_e::RLM_TYPE_NULL:
+        case realm_value_type::RLM_TYPE_NULL:
             throw std::runtime_error("Using primitive_greater with null is not supported. If you get this error, please report it to help@realm.io.");
-        case realm_value_type_e::RLM_TYPE_BOOL:
+        case realm_value_type::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_greater with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm_value_type_e::RLM_TYPE_INT:
+        case realm_value_type::RLM_TYPE_INT:
             query.greater(std::move(col_key), primitive.integer);
             break;
-        case realm_value_type_e::RLM_TYPE_FLOAT:
+        case realm_value_type::RLM_TYPE_FLOAT:
             query.greater(std::move(col_key), primitive.fnum);
             break;
-        case realm_value_type_e::RLM_TYPE_DOUBLE:
+        case realm_value_type::RLM_TYPE_DOUBLE:
             query.greater(std::move(col_key), primitive.dnum);
             break;
-        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+        case realm_value_type::RLM_TYPE_TIMESTAMP:
             query.greater(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+        case realm_value_type::RLM_TYPE_DECIMAL128:
             query.greater(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+        case realm_value_type::RLM_TYPE_OBJECT_ID:
             query.greater(std::move(col_key), from_capi(primitive.object_id));
             break;
         }
@@ -286,43 +292,29 @@ REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
         switch (primitive.type) {
-        case realm_value_type_e::RLM_TYPE_NULL:
+        case realm_value_type::RLM_TYPE_NULL:
             throw std::runtime_error("Using primitive_greater_equal with null is not supported. If you get this error, please report it to help@realm.io.");
-        case realm_value_type_e::RLM_TYPE_BOOL:
+        case realm_value_type::RLM_TYPE_BOOL:
             throw std::runtime_error("Using primitive_greater_equal with bool value is not supported. If you get this error, please report it to help@realm.io");
-        case realm_value_type_e::RLM_TYPE_INT:
+        case realm_value_type::RLM_TYPE_INT:
             query.greater_equal(std::move(col_key), primitive.integer);
             break;
-        case realm_value_type_e::RLM_TYPE_FLOAT:
+        case realm_value_type::RLM_TYPE_FLOAT:
             query.greater_equal(std::move(col_key), primitive.fnum);
             break;
-        case realm_value_type_e::RLM_TYPE_DOUBLE:
+        case realm_value_type::RLM_TYPE_DOUBLE:
             query.greater_equal(std::move(col_key), primitive.dnum);
             break;
-        case realm_value_type_e::RLM_TYPE_TIMESTAMP:
+        case realm_value_type::RLM_TYPE_TIMESTAMP:
             query.greater_equal(std::move(col_key), from_capi(primitive.timestamp));
             break;
-        case realm_value_type_e::RLM_TYPE_DECIMAL128:
+        case realm_value_type::RLM_TYPE_DECIMAL128:
             query.greater_equal(std::move(col_key), from_capi(primitive.decimal128));
             break;
-        case realm_value_type_e::RLM_TYPE_OBJECT_ID:
+        case realm_value_type::RLM_TYPE_OBJECT_ID:
             query.greater_equal(std::move(col_key), from_capi(primitive.object_id));
             break;
         }
-    });
-}
-
-REALM_EXPORT void query_binary_equal(Query& query, SharedRealm& realm, size_t property_index, char* buffer, size_t buffer_length, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.equal(get_key_for_prop(query, realm, property_index), BinaryData(buffer, buffer_length));
-    });
-}
-
-REALM_EXPORT void query_binary_not_equal(Query& query, SharedRealm& realm, size_t property_index, char* buffer, size_t buffer_length, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.not_equal(get_key_for_prop(query, realm, property_index), BinaryData(buffer, buffer_length));
     });
 }
 

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -328,7 +328,7 @@ REALM_EXPORT void query_null_equal(Query& query, SharedRealm& realm, size_t prop
 {
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
-        if (query.get_table()->get_column_type(col_key) == DataType::type_Link) {
+        if (query.get_table()->get_column_type(col_key) == type_Link) {
             query.and_query(query.get_table()->column<Link>(col_key).is_null());
         }
         else {
@@ -341,7 +341,7 @@ REALM_EXPORT void query_null_not_equal(Query& query, SharedRealm& realm, size_t 
 {
     handle_errors(ex, [&]() {
         auto col_key = get_key_for_prop(query, realm, property_index);
-        if (query.get_table()->get_column_type(col_key) == DataType::type_Link) {
+        if (query.get_table()->get_column_type(col_key) == type_Link) {
             query.and_query(query.get_table()->column<Link>(col_key).is_not_null());
         }
         else {

--- a/wrappers/src/query_cs.cpp
+++ b/wrappers/src/query_cs.cpp
@@ -155,6 +155,9 @@ REALM_EXPORT void query_primitive_equal(Query& query, SharedRealm& realm, size_t
         case realm_value_type::RLM_TYPE_BINARY:
             query.equal(std::move(col_key), from_capi(primitive.binary));
             break;
+        case realm_value_type::RLM_TYPE_LINK:
+            query.links_to(std::move(col_key), primitive.link.object->obj().get_key());
+            break;
         }
     });
 }
@@ -189,6 +192,9 @@ REALM_EXPORT void query_primitive_not_equal(Query& query, SharedRealm& realm, si
             break;
         case realm_value_type::RLM_TYPE_BINARY:
             query.not_equal(std::move(col_key), from_capi(primitive.binary));
+            break;
+        case realm_value_type::RLM_TYPE_LINK:
+            query.Not().links_to(std::move(col_key), primitive.link.object->obj().get_key());
             break;
         }
     });
@@ -315,13 +321,6 @@ REALM_EXPORT void query_primitive_greater_equal(Query& query, SharedRealm& realm
             query.greater_equal(std::move(col_key), from_capi(primitive.object_id));
             break;
         }
-    });
-}
-
-REALM_EXPORT void query_object_equal(Query& query, SharedRealm& realm, size_t property_index, Object& object, NativeException::Marshallable& ex)
-{
-    handle_errors(ex, [&]() {
-        query.links_to(get_key_for_prop(query, realm, property_index), object.obj().get_key());
     });
 }
 

--- a/wrappers/src/realm_error_type.hpp
+++ b/wrappers/src/realm_error_type.hpp
@@ -76,6 +76,10 @@ namespace realm {
      
         RealmDotNetExceptionDuringMigration = 30,
 
+        NotNullableProperty = 31,
+        
+        PropertyMismatch = 32,
+
         StdArgumentOutOfRange = 100,
 
         StdIndexOutOfRange = 101,

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -89,16 +89,6 @@ REALM_EXPORT void results_get_primitive(Results& results, size_t ndx, realm_valu
     });
 }
 
-REALM_EXPORT size_t results_get_string(Results& results, size_t ndx, uint16_t* value, size_t value_len, bool* is_null, NativeException::Marshallable& ex)
-{
-    return collection_get_string(results, ndx, value, value_len, is_null, ex);
-}
-
-REALM_EXPORT size_t results_get_binary(Results& results, size_t ndx, char* return_buffer, size_t buffer_size, bool* is_null, NativeException::Marshallable& ex)
-{
-    return collection_get_binary(results, ndx, return_buffer, buffer_size, is_null, ex);
-}
-
 REALM_EXPORT void results_clear(Results& results, SharedRealm& realm, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -60,10 +60,16 @@ REALM_EXPORT void results_get_value(Results& results, size_t ndx, realm_value_t*
         if (ndx >= count)
             throw IndexOutOfRangeException("Get from RealmResults", ndx, count);
 
-        auto val = results.get<Mixed>(ndx);
-
-        std::string object_type = results.get_type() == PropertyType::Object ? results.get_object_schema().name : std::string();
-        *value = to_capi(val, results.get_realm(), object_type);
+        switch (results.get_type() & ~PropertyType::Flags) {
+        case PropertyType::Object:
+            *value = to_capi(new Object(results.get_realm(), results.get_object_schema(), results.get(ndx)));
+            break;
+        case PropertyType::Mixed:
+            REALM_TERMINATE("Mixed not supported yet");
+        default:
+            *value = to_capi(results.get_any(ndx));
+            break;
+        }
     });
 }
 

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -77,9 +77,18 @@ REALM_EXPORT Object* results_get_object(Results& results, size_t ndx, NativeExce
     });
 }
 
-REALM_EXPORT void results_get_primitive(Results& results, size_t ndx, PrimitiveValue& value, NativeException::Marshallable& ex)
+REALM_EXPORT void results_get_primitive(Results& results, size_t ndx, realm_value_t* value, NativeException::Marshallable& ex)
 {
-    collection_get_primitive(results, ndx, value, ex);
+    handle_errors(ex, [&]() {
+        const size_t count = results.size();
+        if (ndx >= count)
+            throw IndexOutOfRangeException("Get from Collection", ndx, count);
+
+        throw std::runtime_error("implement me!!");
+
+        //auto val = results.get<Mixed>(ndx);
+        //*value = to_capi(val);
+    });
 }
 
 REALM_EXPORT size_t results_get_string(Results& results, size_t ndx, uint16_t* value, size_t value_len, bool* is_null, NativeException::Marshallable& ex)

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -35,18 +35,6 @@
 using namespace realm;
 using namespace realm::binding;
 
-template<typename T>
-inline T get(Results& results, size_t ndx, NativeException::Marshallable& ex)
-{
-    return handle_errors(ex, [&]() {
-        const size_t count = results.size();
-        if (ndx >= count)
-            throw IndexOutOfRangeException("Get from RealmResults", ndx, count);
-
-        return results.get<T>(ndx);
-    });
-}
-
 extern "C" {
 
 REALM_EXPORT void results_destroy(Results* results)

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -84,10 +84,8 @@ REALM_EXPORT void results_get_primitive(Results& results, size_t ndx, realm_valu
         if (ndx >= count)
             throw IndexOutOfRangeException("Get from Collection", ndx, count);
 
-        throw std::runtime_error("implement me!!");
-
-        //auto val = results.get<Mixed>(ndx);
-        //*value = to_capi(val);
+        auto val = results.get<Mixed>(ndx);
+        *value = to_capi(val);
     });
 }
 

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -65,7 +65,7 @@ REALM_EXPORT void results_get_value(Results& results, size_t ndx, realm_value_t*
         }
         else {
             auto val = results.get_any(ndx);
-            if (!val.is_null() && val.get_type() == DataType::type_TypedLink) {
+            if (!val.is_null() && val.get_type() == type_TypedLink) {
                 *value = to_capi(new Object(results.get_realm(), val.get<ObjLink>()));
             }
             else {

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -374,7 +374,7 @@ REALM_EXPORT Object* shared_realm_create_object_unique(const SharedRealm& realm,
             throw PropertyTypeMismatchException(object_schema.name, primary_key_property.name, to_string(primary_key_property.type), to_string(primitive.type));
         }
 
-        auto val = from_capi(primitive, false);
+        auto val = from_capi(primitive);
         auto obj_key = table->find_first(primary_key_property.column_key, val);
 
         Obj obj;

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -374,7 +374,7 @@ REALM_EXPORT Object* shared_realm_create_object_unique(const SharedRealm& realm,
             throw PropertyTypeMismatchException(object_schema.name, primary_key_property.name, to_string(primary_key_property.type), to_string(primitive.type));
         }
 
-        auto val = from_capi(primitive);
+        auto val = from_capi(primitive, false);
         auto obj_key = table->find_first(primary_key_property.column_key, val);
 
         Obj obj;

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -398,36 +398,35 @@ REALM_EXPORT Object* shared_realm_create_object(SharedRealm& realm, TableRef& ta
     });
 }
 
-REALM_EXPORT Object* shared_realm_create_object_primitive_unique(const SharedRealm& realm, TableRef& table, PrimitiveValue primitive, bool try_update, bool& is_new, NativeException::Marshallable& ex)
+REALM_EXPORT Object* shared_realm_create_object_primitive_unique(const SharedRealm& realm, TableRef& table, realm_value_t primitive, bool try_update, bool& is_new, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
-        switch (primitive.type) {
-        case PropertyType::Int:
-            REALM_ASSERT(primitive.has_value);
+        realm->verify_in_write();
+        const ObjectSchema& object_schema(find_schema(realm, table));
 
-            return create_object_unique(realm, table, primitive.value.int_value, try_update, is_new);
+        const Property& primary_key_property = *object_schema.primary_key_property();
 
-        case PropertyType::Int | PropertyType::Nullable:
-            return create_object_unique(realm, table, primitive.has_value ? util::some<int64_t>(primitive.value.int_value) : null(), try_update, is_new);
+        auto val = from_capi(primitive);
+        auto obj_key = table->find_first(primary_key_property.column_key, val);
 
-        case PropertyType::ObjectId:
-            REALM_ASSERT(primitive.has_value);
-
-            return create_object_unique(realm, table, to_object_id(primitive), try_update, is_new);
-
-        case PropertyType::ObjectId | PropertyType::Nullable:
-            // HACK: https://github.com/realm/realm-core/issues/3919 - this should eventually be
-            //return create_object_unique(realm, table, primitive.has_value ? util::some<ObjectId>(to_object_id(primitive)) : null(), try_update, is_new);
-
-            if (primitive.has_value) {
-                return create_object_unique(realm, table, to_object_id(primitive), try_update, is_new);
-            }
-
-            return create_object_unique(realm, table, util::Optional<int64_t>(), try_update, is_new);
-
-        default:
-            REALM_UNREACHABLE();
+        Obj obj;
+        if (!obj_key) {
+            is_new = true;
+            obj = table->create_object_with_primary_key(val);
         }
+        else if (!try_update) {
+            std::ostringstream string_builder;
+            string_builder << val;
+            throw SetDuplicatePrimaryKeyValueException(object_schema.name,
+                primary_key_property.name,
+                string_builder.str());
+        }
+        else {
+            obj = table->get_object(obj_key);
+            is_new = false;
+        }
+
+        return new Object(realm, object_schema, obj);
     });
 }
 

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -348,10 +348,10 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_fetch(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_fetch(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
-            app->provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(to_object_id(id), user, [tcs_ptr](App::UserAPIKey api_key, util::Optional<AppError> err) {
+            app->provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(from_capi(id.object_id), user, [tcs_ptr](App::UserAPIKey api_key, util::Optional<AppError> err) {
                 invoke_api_key_callback(tcs_ptr, api_key, err);
             });
         });
@@ -366,24 +366,24 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_delete(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_delete(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
-            app->provider_client<App::UserAPIKeyProviderClient>().delete_api_key(to_object_id(id), user, get_callback_handler(tcs_ptr));
+            app->provider_client<App::UserAPIKeyProviderClient>().delete_api_key(from_capi(id.object_id), user, get_callback_handler(tcs_ptr));
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_disable(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_disable(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
-            app->provider_client<App::UserAPIKeyProviderClient>().disable_api_key(to_object_id(id), user, get_callback_handler(tcs_ptr));
+            app->provider_client<App::UserAPIKeyProviderClient>().disable_api_key(from_capi(id.object_id), user, get_callback_handler(tcs_ptr));
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_enable(SharedSyncUser& user, SharedApp& app, PrimitiveValue id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_enable(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
-            app->provider_client<App::UserAPIKeyProviderClient>().enable_api_key(to_object_id(id), user, get_callback_handler(tcs_ptr));
+            app->provider_client<App::UserAPIKeyProviderClient>().enable_api_key(from_capi(id.object_id), user, get_callback_handler(tcs_ptr));
         });
     }
 

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -348,7 +348,7 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_fetch(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_fetch(SharedSyncUser& user, SharedApp& app, realm_value_t id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(from_capi(id.object_id), user, [tcs_ptr](App::UserAPIKey api_key, util::Optional<AppError> err) {
@@ -366,21 +366,21 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_delete(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_delete(SharedSyncUser& user, SharedApp& app, realm_value_t id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().delete_api_key(from_capi(id.object_id), user, get_callback_handler(tcs_ptr));
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_disable(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_disable(SharedSyncUser& user, SharedApp& app, realm_value_t id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().disable_api_key(from_capi(id.object_id), user, get_callback_handler(tcs_ptr));
         });
     }
 
-    REALM_EXPORT void realm_syncuser_api_key_enable(SharedSyncUser& user, SharedApp& app, realm_value_t& id, void* tcs_ptr, NativeException::Marshallable& ex)
+    REALM_EXPORT void realm_syncuser_api_key_enable(SharedSyncUser& user, SharedApp& app, realm_value_t id, void* tcs_ptr, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
             app->provider_client<App::UserAPIKeyProviderClient>().enable_api_key(from_capi(id.object_id), user, get_callback_handler(tcs_ptr));

--- a/wrappers/src/table_cs.cpp
+++ b/wrappers/src/table_cs.cpp
@@ -95,9 +95,8 @@ REALM_EXPORT Object* table_get_object_for_primarykey(TableRef& table, SharedReal
             throw PropertyTypeMismatchException(object_schema.name, primary_key_property.name, to_string(primary_key_property.type), to_string(primitive.type));
         }
 
-        auto value = from_capi(primitive, false);
         const ColKey column_key = object_schema.primary_key_property()->column_key;
-        const ObjKey obj_key = table->find_first(column_key, value);
+        const ObjKey obj_key = table->find_first(column_key, from_capi(primitive));
         if (!obj_key)
             return nullptr;
 

--- a/wrappers/src/table_cs.cpp
+++ b/wrappers/src/table_cs.cpp
@@ -95,7 +95,7 @@ REALM_EXPORT Object* table_get_object_for_primarykey(TableRef& table, SharedReal
             throw PropertyTypeMismatchException(object_schema.name, primary_key_property.name, to_string(primary_key_property.type), to_string(primitive.type));
         }
 
-        auto value = from_capi(primitive);
+        auto value = from_capi(primitive, false);
         const ColKey column_key = object_schema.primary_key_property()->column_key;
         const ObjKey obj_key = table->find_first(column_key, value);
         if (!obj_key)


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## Description

This is WIP effort to consolidate all data access around Core's Mixed.

##  TODO

* [ ] Changelog entry
* [x] Tests (if applicable)
* [x] Get collections to use Mixed
* [x] Weaver should not pass in the property type for GetPrimitive

## Benchmark results

<details>
  <summary>.NET 461</summary>
### Query Tests - before

|    Method | ObjectCount |        Mean |     Error |    StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|---------- |------------ |------------:|----------:|----------:|--------:|-------:|------:|----------:|
|     **Count** |          **10** |   **474.77 μs** | **120.98 μs** |  **6.632 μs** |  **3.4180** | **1.4648** |     **-** |     **22 KB** |
|     Count |         100 |   469.02 μs |  26.79 μs |  1.468 μs |  3.4180 | 1.4648 |     - |     22 KB |
|     Count |        1000 |   487.27 μs |  47.05 μs |  2.579 μs |  3.4180 | 1.4648 |     - |     22 KB |
| **Enumerate** |          **10** |    **82.72 μs** |  **13.49 μs** |  **0.739 μs** |  **0.8545** | **0.3662** |     **-** |   **6.07 KB** |
| Enumerate |         100 |   169.37 μs |  58.31 μs |  3.196 μs |  2.1973 | 0.7324 |     - |  14.78 KB |
| Enumerate |        1000 | 1,102.97 μs | 450.41 μs | 24.689 μs | 13.6719 | 3.9063 |     - |  99.47 KB |

### Query Tests - now

|    Method | ObjectCount |        Mean |      Error |    StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|---------- |------------ |------------:|-----------:|----------:|--------:|-------:|------:|----------:|
|     **Count** |          **10** |   **486.47 μs** |  **27.526 μs** |  **1.509 μs** |  **3.4180** | **1.4648** |     **-** |  **22.06 KB** |
|     Count |         100 |   483.53 μs |   4.291 μs |  0.235 μs |  3.4180 | 1.4648 |     - |  22.06 KB |
|     Count |        1000 |   492.74 μs |  41.493 μs |  2.274 μs |  2.9297 | 0.9766 |     - |  22.06 KB |
| **Enumerate** |          **10** |    **87.40 μs** |  **16.828 μs** |  **0.922 μs** |  **0.8545** | **0.3662** |     **-** |   **6.14 KB** |
| Enumerate |         100 |   195.65 μs |  37.920 μs |  2.079 μs |  2.1973 | 0.9766 |     - |  14.84 KB |
| Enumerate |        1000 | 1,115.96 μs | 323.258 μs | 17.719 μs | 13.6719 | 3.9063 |     - |  99.53 KB |

### String Tests - before

|           Method | StringSize |        Mean |       Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------- |----------- |------------:|------------:|----------:|-------:|-------:|------:|----------:|
| **GetPropertyValue** |         **20** |    **551.6 ns** |    **70.01 ns** |   **3.84 ns** | **0.0267** |      **-** |     **-** |     **169 B** |
| GetPropertyValue |        100 |  1,499.8 ns |   114.58 ns |   6.28 ns | 0.0496 |      - |     - |     329 B |
| GetPropertyValue |       1000 | 10,780.5 ns |   400.93 ns |  21.98 ns | 0.3204 |      - |     - |    2135 B |
|       **LookupByPK** |         **20** | **12,509.5 ns** | **1,109.19 ns** |  **60.80 ns** | **0.1068** | **0.0458** |     **-** |     **802 B** |
|       LookupByPK |        100 | 13,913.7 ns | 1,549.08 ns |  84.91 ns | 0.1068 | 0.0458 |     - |     802 B |
|       LookupByPK |       1000 | 28,282.4 ns | 2,393.45 ns | 131.19 ns | 0.0916 | 0.0305 |     - |     803 B |
| **SetPropertyValue** |         **20** |    **789.8 ns** |   **937.84 ns** |  **51.41 ns** |      **-** |      **-** |     **-** |         **-** |
| SetPropertyValue |        100 |  1,324.7 ns |   767.67 ns |  42.08 ns |      - |      - |     - |         - |
| SetPropertyValue |       1000 |  9,853.4 ns | 1,690.41 ns |  92.66 ns |      - |      - |     - |         - |

### String Tests - now

|           Method | StringSize |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------- |----------- |----------:|----------:|----------:|-------:|-------:|------:|----------:|
| **GetPropertyValue** |         **20** |  **1.224 μs** | **0.0704 μs** | **0.0039 μs** | **0.0114** |      **-** |     **-** |      **72 B** |
| GetPropertyValue |        100 |  2.185 μs | 0.1584 μs | 0.0087 μs | 0.0343 |      - |     - |     233 B |
| GetPropertyValue |       1000 | 13.535 μs | 0.3974 μs | 0.0218 μs | 0.3052 |      - |     - |    2038 B |
|       **LookupByPK** |         **20** | **15.930 μs** | **2.8805 μs** | **0.1579 μs** | **0.0916** | **0.0305** |     **-** |     **802 B** |
|       LookupByPK |        100 | 16.820 μs | 1.3719 μs | 0.0752 μs | 0.0916 | 0.0305 |     - |     802 B |
|       LookupByPK |       1000 | 28.368 μs | 1.2730 μs | 0.0698 μs | 0.0916 | 0.0305 |     - |     802 B |
| **SetPropertyValue** |         **20** |  **2.179 μs** | **0.7555 μs** | **0.0414 μs** |      **-** |      **-** |     **-** |         **-** |
| SetPropertyValue |        100 |  2.458 μs | 0.7324 μs | 0.0401 μs |      - |      - |     - |         - |
| SetPropertyValue |       1000 |  7.820 μs | 1.2185 μs | 0.0668 μs |      - |      - |     - |         - |

</details>

<details>
  <summary>.NET 5</summary>

### Query Tests - Before

|    Method | ObjectCount |      Mean |        Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|---------- |------------ |----------:|-------------:|----------:|-------:|-------:|------:|----------:|
|     **Count** |          **10** | **310.02 μs** |    **77.564 μs** |  **4.252 μs** | **0.9766** | **0.4883** |     **-** |  **10.21 KB** |
|     Count |         100 | 300.51 μs |    55.585 μs |  3.047 μs | 0.9766 | 0.4883 |     - |  10.21 KB |
|     Count |        1000 | 309.37 μs |    25.188 μs |  1.381 μs | 0.9766 | 0.4883 |     - |  10.21 KB |
| **Enumerate** |          **10** |  **54.31 μs** |     **6.241 μs** |  **0.342 μs** | **0.4272** | **0.1831** |     **-** |   **4.86 KB** |
| Enumerate |         100 | 125.48 μs |    18.002 μs |  0.987 μs | 1.2207 | 0.4883 |     - |  13.16 KB |
| Enumerate |        1000 | 890.51 μs | 1,080.203 μs | 59.210 μs | 8.7891 | 3.9063 |     - |  94.16 KB |


### Query Tests - Now

|    Method | ObjectCount |        Mean |      Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|---------- |------------ |------------:|-----------:|----------:|-------:|-------:|------:|----------:|
|     **Count** |          **10** |   **312.55 μs** |  **29.928 μs** |  **1.640 μs** | **0.9766** | **0.4883** |     **-** |  **10.51 KB** |
|     Count |         100 |   309.76 μs |  21.335 μs |  1.169 μs | 0.9766 | 0.4883 |     - |  10.51 KB |
|     Count |        1000 |   318.40 μs |  18.547 μs |  1.017 μs | 0.9766 | 0.4883 |     - |  10.51 KB |
| **Enumerate** |          **10** |    **59.23 μs** |   **8.044 μs** |  **0.441 μs** | **0.4272** | **0.1831** |     **-** |   **4.92 KB** |
| Enumerate |         100 |   146.15 μs |  54.151 μs |  2.968 μs | 1.2207 | 0.4883 |     - |  13.22 KB |
| Enumerate |        1000 | 1,047.85 μs | 582.947 μs | 31.953 μs | 8.7891 | 3.9063 |     - |  94.22 KB |

### String Tests - Before

|           Method | StringSize |        Mean |       Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------- |----------- |------------:|------------:|---------:|-------:|-------:|------:|----------:|
| **GetPropertyValue** |         **20** |    **565.9 ns** |    **38.21 ns** |  **2.09 ns** | **0.0153** |      **-** |     **-** |     **160 B** |
| GetPropertyValue |        100 |  1,436.5 ns |    45.15 ns |  2.47 ns | 0.0305 |      - |     - |     320 B |
| GetPropertyValue |       1000 | 10,825.9 ns |   761.05 ns | 41.72 ns | 0.1984 |      - |     - |    2120 B |
|       **LookupByPK** |         **20** |  **7,751.8 ns** |   **732.31 ns** | **40.14 ns** | **0.0458** | **0.0153** |     **-** |     **520 B** |
|       LookupByPK |        100 |  9,017.9 ns | 1,451.12 ns | 79.54 ns | 0.0458 | 0.0153 |     - |     520 B |
|       LookupByPK |       1000 | 22,900.3 ns |   925.12 ns | 50.71 ns | 0.0305 |      - |     - |     520 B |
| **SetPropertyValue** |         **20** |    **911.8 ns** |   **959.16 ns** | **52.58 ns** |      **-** |      **-** |     **-** |         **-** |
| SetPropertyValue |        100 |  1,763.2 ns |   846.25 ns | 46.39 ns |      - |      - |     - |         - |
| SetPropertyValue |       1000 |  9,915.7 ns | 1,425.61 ns | 78.14 ns |      - |      - |     - |         - |

### String Tests - Now

|           Method | StringSize |        Mean |       Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------- |----------- |------------:|------------:|----------:|-------:|-------:|------:|----------:|
| **GetPropertyValue** |         **20** |    **501.8 ns** |    **97.56 ns** |   **5.35 ns** | **0.0057** |      **-** |     **-** |      **64 B** |
| GetPropertyValue |        100 |  1,319.9 ns |    74.95 ns |   4.11 ns | 0.0210 |      - |     - |     224 B |
| GetPropertyValue |       1000 | 12,038.2 ns | 1,377.86 ns |  75.52 ns | 0.1831 |      - |     - |    2024 B |
|       **LookupByPK** |         **20** | **10,021.3 ns** | **1,494.43 ns** |  **81.91 ns** | **0.0458** | **0.0153** |     **-** |     **520 B** |
|       LookupByPK |        100 | 10,765.2 ns |   575.19 ns |  31.53 ns | 0.0458 | 0.0153 |     - |     520 B |
|       LookupByPK |       1000 | 20,537.9 ns | 2,616.38 ns | 143.41 ns | 0.0305 |      - |     - |     520 B |
| **SetPropertyValue** |         **20** |  **1,150.7 ns** |   **823.67 ns** |  **45.15 ns** |      **-** |      **-** |     **-** |         **-** |
| SetPropertyValue |        100 |  1,343.5 ns | 1,021.64 ns |  56.00 ns |      - |      - |     - |         - |
| SetPropertyValue |       1000 |  5,821.0 ns | 1,144.98 ns |  62.76 ns |      - |      - |     - |         - |

</details>