### PR TITLE
Provide fallback for Unity on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ Realm/Realm.Unity/Runtime/**/*.framework/*
 Realm/Realm.Unity/Runtime/Dependencies/*.meta
 Realm/Realm.Unity/Runtime/Dependencies.meta
 Tests/PerformanceTests/BenchmarkDotNet.Artifacts/
+Realm/Realm.Unity/**/*.tgz

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ stage('Unity Package') {
 
     def packagePath = findFiles(glob: "Realm.${packageVersion}.nupkg")[0].path
 
-    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- -p ${packagePath}"
+    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- --path ${packagePath}"
     dir('Realm/Realm.Unity') {
       sh "npm version ${packageVersion} --allow-same-version"
       sh 'npm pack'
@@ -195,7 +195,7 @@ stage('Unity Package') {
       sh "rm realm.unity-${packageVersion}.tgz"
     }
 
-    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- -p ${packagePath} -f"
+    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- --path ${packagePath} -f"
     dir('Realm/Realm.Unity') {
       sh 'npm pack'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,19 +186,14 @@ stage('Unity Package') {
 
     def packagePath = findFiles(glob: "Realm.${packageVersion}.nupkg")[0].path
 
-    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- --path ${packagePath}"
+    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- --path ${packagePath} --pack"
     dir('Realm/Realm.Unity') {
-      sh "npm version ${packageVersion} --allow-same-version"
-      sh 'npm pack'
-
       archiveArtifacts "realm.unity-${packageVersion}.tgz"
       sh "rm realm.unity-${packageVersion}.tgz"
     }
 
-    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- --path ${packagePath} -f"
+    sh "dotnet run --project Tools/SetupUnityPackage/SetupUnityPackage/ -- --path ${packagePath} --include-dependencies --pack"
     dir('Realm/Realm.Unity') {
-      sh 'npm pack'
-
       archiveArtifacts "*.tgz"
     }
   }

--- a/Realm/Realm.Unity/Runtime/UnityUtils.dll.meta
+++ b/Realm/Realm.Unity/Runtime/UnityUtils.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 203a253bb199f45a9b2ae773e9821a39
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Realm/Realm.Unity/Runtime/iOS/realm-wrappers.framework.meta
+++ b/Realm/Realm.Unity/Runtime/iOS/realm-wrappers.framework.meta
@@ -72,7 +72,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        AddToEmbeddedBinaries: false
+        AddToEmbeddedBinaries: true
         CPU: AnyCPU
         CompileFlags: 
         FrameworkDependencies: 

--- a/Tools/SetupUnityPackage/SetupUnityPackage.sln
+++ b/Tools/SetupUnityPackage/SetupUnityPackage.sln
@@ -1,7 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetupUnityPackage", "SetupUnityPackage\SetupUnityPackage.csproj", "{32143B0E-FF13-4EFD-A487-0667C970ECFD}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30717.126
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SetupUnityPackage", "SetupUnityPackage\SetupUnityPackage.csproj", "{32143B0E-FF13-4EFD-A487-0667C970ECFD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnityUtils", "UnityUtils\UnityUtils.csproj", "{D47C5E2C-710D-45C8-8203-9952B54E5634}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,5 +16,15 @@ Global
 		{32143B0E-FF13-4EFD-A487-0667C970ECFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{32143B0E-FF13-4EFD-A487-0667C970ECFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32143B0E-FF13-4EFD-A487-0667C970ECFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D47C5E2C-710D-45C8-8203-9952B54E5634}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D47C5E2C-710D-45C8-8203-9952B54E5634}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D47C5E2C-710D-45C8-8203-9952B54E5634}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D47C5E2C-710D-45C8-8203-9952B54E5634}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E6282079-A30E-4403-A4AE-92ABAB7CCE5F}
 	EndGlobalSection
 EndGlobal

--- a/Tools/SetupUnityPackage/SetupUnityPackage/Program.cs
+++ b/Tools/SetupUnityPackage/SetupUnityPackage/Program.cs
@@ -128,7 +128,7 @@ namespace SetupUnityPackage
 
             UpdatePackageJson(opts.IncludeDependencies);
 
-            if (opts.Pack || true)
+            if (opts.Pack)
             {
                 Console.WriteLine("Preparing npm package...");
 
@@ -244,7 +244,7 @@ namespace SetupUnityPackage
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 fileName = "cmd";
-                arguments = $"npm {command}";
+                arguments = $"/c npm {command}";
             }
             else
             {
@@ -256,7 +256,7 @@ namespace SetupUnityPackage
             {
                 FileName = fileName,
                 WorkingDirectory = Path.GetFullPath(Path.Combine(GetUnityPackagePath(), "..")),
-                Arguments = arguments
+                Arguments = arguments,
             });
 
             npmRunner.WaitForExit();

--- a/Tools/SetupUnityPackage/SetupUnityPackage/SetupUnityPackage.csproj
+++ b/Tools/SetupUnityPackage/SetupUnityPackage/SetupUnityPackage.csproj
@@ -14,6 +14,9 @@
     <Folder Include="MetaFiles\Dependencies\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\UnityUtils\UnityUtils.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="MetaFiles\Dependencies.meta">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Tools/SetupUnityPackage/UnityUtils/FileHelper.cs
+++ b/Tools/SetupUnityPackage/UnityUtils/FileHelper.cs
@@ -1,0 +1,48 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+
+using System;
+using UnityEngine;
+
+namespace UnityUtils
+{
+    public static class FileHelper
+    {
+        public static string GetInternalStorage()
+        {
+            if (Application.platform != RuntimePlatform.Android)
+            {
+                return Application.persistentDataPath;
+            }
+
+            // On Android persistentDataPath returns the external folder, where the app may not have permissions to write.
+            // we use reflection to call File.getAbsolutePath(currentActivity.getFilesDir())
+            using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            using (var currentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
+            {
+                var getFilesDir = AndroidJNIHelper.GetMethodID(AndroidJNI.FindClass("android/content/ContextWrapper"), "getFilesDir", "()Ljava/io/File;");
+                var internalFilesDir = AndroidJNI.CallObjectMethod(currentActivity.GetRawObject(), getFilesDir, Array.Empty<jvalue>());
+                var getAbsolutePath = AndroidJNIHelper.GetMethodID(AndroidJNI.FindClass("java/io/File"), "getAbsolutePath", "()Ljava/lang/String;");
+
+                var path = AndroidJNI.CallStringMethod(internalFilesDir, getAbsolutePath, Array.Empty<jvalue>());
+                return path ?? $"/data/data/{Application.identifier}/files";
+            }
+        }
+    }
+}

--- a/Tools/SetupUnityPackage/UnityUtils/UnityUtils.csproj
+++ b/Tools/SetupUnityPackage/UnityUtils/UnityUtils.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Unity3D.SDK" Version="2020.1.15.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This adds an extra Unity-only project that we can use to put functionality rather than relying on reflection. Right now it only has one method which returns the internal files location for the app.

Fixes https://github.com/realm/realm-dotnet/issues/2132
Fixes https://github.com/realm/realm-dotnet/issues/2134