### PR TITLE
Added attr to avoid dll stripping

### DIFF
--- a/Tools/SetupUnityPackage/UnityUtils/FileHelper.cs
+++ b/Tools/SetupUnityPackage/UnityUtils/FileHelper.cs
@@ -19,9 +19,6 @@
 
 using System;
 using UnityEngine;
-using UnityEngine.Scripting;
-
-[assembly: AlwaysLinkAssembly]
 
 namespace UnityUtils
 {

--- a/Tools/SetupUnityPackage/UnityUtils/FileHelper.cs
+++ b/Tools/SetupUnityPackage/UnityUtils/FileHelper.cs
@@ -19,6 +19,9 @@
 
 using System;
 using UnityEngine;
+using UnityEngine.Scripting;
+
+[assembly: AlwaysLinkAssembly]
 
 namespace UnityUtils
 {

--- a/Tools/SetupUnityPackage/UnityUtils/Properties/AssemblyInfo.cs
+++ b/Tools/SetupUnityPackage/UnityUtils/Properties/AssemblyInfo.cs
@@ -1,32 +1,25 @@
-﻿using System.Reflection;
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+
 using UnityEngine.Scripting;
-using System.Runtime.CompilerServices;
-
-// Information about this assembly is defined by the following attributes. 
-// Change them to the values specific to your project.
-
-[assembly: AssemblyTitle("UnityUtils")]
-[assembly: AssemblyDescription("Utils to support the Realm SDK in Unity projects")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Realm")]
-[assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Force UnityLinker to process this assembly regardless of whether or not
-// it is referenced by other assemblies
-// more info at https://docs.unity3d.com/ScriptReference/Scripting.AlwaysLinkAssemblyAttribute.html
+// it is referenced by other assemblies.
+// More info at https://docs.unity3d.com/ScriptReference/Scripting.AlwaysLinkAssemblyAttribute.html
 [assembly: AlwaysLinkAssembly]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion("1.0.*")]
-
-// The following attributes are used to specify the signing key for the assembly, 
-// if desired. See the Mono documentation for more information about signing.
-
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]

--- a/Tools/SetupUnityPackage/UnityUtils/Properties/AssemblyInfo.cs
+++ b/Tools/SetupUnityPackage/UnityUtils/Properties/AssemblyInfo.cs
@@ -1,0 +1,32 @@
+﻿using System.Reflection;
+using UnityEngine.Scripting;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("UnityUtils")]
+[assembly: AssemblyDescription("Utils to support the Realm SDK in Unity projects")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Realm")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Force UnityLinker to process this assembly regardless of whether or not
+// it is referenced by other assemblies
+// more info at https://docs.unity3d.com/ScriptReference/Scripting.AlwaysLinkAssemblyAttribute.html
+[assembly: AlwaysLinkAssembly]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/Tools/SetupUnityPackage/UnityUtils/UnityUtils.csproj
+++ b/Tools/SetupUnityPackage/UnityUtils/UnityUtils.csproj
@@ -3,6 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>UnityUtils</PackageId>
+    <Version>0.0.1</Version>
+    <Company>Realm Inc.</Company>
+    <Description>Utils to support the Realm SDK in Unity projects</Description>
+    <Copyright>Apache License, Version 2.0</Copyright>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Tools/SetupUnityPackage/UnityUtils/UnityUtils.csproj
+++ b/Tools/SetupUnityPackage/UnityUtils/UnityUtils.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>UnityUtils</PackageId>
-    <Version>0.0.1</Version>
+    <Version>1.0.0</Version>
     <Company>Realm Inc.</Company>
     <Description>Utils to support the Realm SDK in Unity projects</Description>
     <Copyright>Apache License, Version 2.0</Copyright>


### PR DESCRIPTION
## Description
The addition of the attribute you, @nirinchev, suggested seems to work.
I say "seems" because the only way I had to test if the change was making a difference was to check the temp/staging area during the building process. It was not possible to use breakpoints because the debugging session was being stopped by unity regularly at the important point.
Anyway, what I could observe was that with the attribute added, the `UnityUtils.dll` was kept in the staging area until the very last step (the one that cleans away all the dll but leaving some pdb but not all). Instead, Without such attribute the dll was initially copied in the staging area but delete almost immediately.
This is not the most scientific way of testing this, but my expectation is that when we've merged my changes for adding the attribute to the module initializer and your changes for fixing the issue on iOS and UWP we should have a clearer indication of how much this change helps.

If you can think of better ways to test this, please advice.

Fixes #2145

##  TODO

* [ ] Changelog entry
* [ ] Tests (if applicable)
