### PR TITLE
Wire up some of the native set implementation

### DIFF
--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -187,14 +187,14 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public IntPtr GetLinkList(IntPtr propertyIndex)
+        public IntPtr GetRealmList(IntPtr propertyIndex)
         {
             var result = NativeMethods.get_list(this, propertyIndex, out var nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }
 
-        public IntPtr GetLinkSet(IntPtr propertyIndex)
+        public IntPtr GetRealmSet(IntPtr propertyIndex)
         {
             var result = NativeMethods.get_set(this, propertyIndex, out var nativeException);
             nativeException.ThrowIfNecessary();
@@ -229,13 +229,13 @@ namespace Realms
         public RealmList<T> GetList<T>(Realm realm, IntPtr propertyIndex, string objectType)
         {
             var metadata = objectType == null ? null : realm.Metadata[objectType];
-            var listHandle = new ListHandle(Root, GetLinkList(propertyIndex));
+            var listHandle = new ListHandle(Root, GetRealmList(propertyIndex));
             return new RealmList<T>(realm, listHandle, metadata);
         }
 
         public RealmSet<T> GetSet<T>(Realm realm, IntPtr propertyIndex, string objectType)
         {
-            var setHandle = new SetHandle(Root, GetLinkSet(propertyIndex));
+            var setHandle = new SetHandle(Root, GetRealmSet(propertyIndex));
             var metadata = objectType == null ? null : realm.Metadata[objectType];
             return new RealmSet<T>(realm, setHandle, metadata);
         }

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -31,7 +31,7 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_clear", CallingConvention = CallingConvention.Cdecl)]
             public static extern void clear(SetHandle handle, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_size", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_size", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr size(SetHandle handle, out NativeException ex);
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_destroy", CallingConvention = CallingConvention.Cdecl)]

--- a/Realm/Realm/RealmSet.cs
+++ b/Realm/Realm/RealmSet.cs
@@ -129,12 +129,13 @@ namespace Realms
             }
 
             // intersection of anything with empty set is empty set, so return if count is 0
-            if (Count == 0)
+            var count = Count;
+            if (count == 0)
             {
                 return;
             }
 
-            var otherSet = GetCollection(other);
+            var otherSet = GetSet(other);
 
             // Special case for when other is empty - just clear the set.
             if (otherSet.Count == 0)
@@ -143,22 +144,25 @@ namespace Realms
                 return;
             }
 
-            foreach (var item in this)
+            for (var i = 0; i < count; i++)
             {
+                var item = this[i];
                 if (!otherSet.Contains(item))
                 {
                     Remove(item);
+                    i--;
+                    count--;
                 }
             }
         }
 
-        public bool IsProperSupersetOf(IEnumerable<T> other) => IsSubsetCore(other, proper: true);
-
         public bool IsSubsetOf(IEnumerable<T> other) => IsSubsetCore(other, proper: false);
 
-        public bool IsProperSubsetOf(IEnumerable<T> other) => IsSupersetCore(other, proper: true);
+        public bool IsProperSubsetOf(IEnumerable<T> other) => IsSubsetCore(other, proper: true);
 
         public bool IsSupersetOf(IEnumerable<T> other) => IsSupersetCore(other, proper: false);
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) => IsSupersetCore(other, proper: true);
 
         public bool Overlaps(IEnumerable<T> other)
         {
@@ -203,7 +207,7 @@ namespace Realms
                 return false;
             }
 
-            foreach (var item in other)
+            foreach (var item in otherSet)
             {
                 if (!Contains(item))
                 {
@@ -235,13 +239,15 @@ namespace Realms
                 return;
             }
 
-            // Special case - SymmetricExceptWith for empty set is equivalent to Union
-            foreach (var item in this)
+            var count = Count;
+            for (var i = 0; i < count; i++)
             {
-                if (otherSet.Contains(item))
+                var item = this[i];
+                if (otherSet.Remove(item))
                 {
                     Remove(item);
-                    otherSet.Remove(item);
+                    i--;
+                    count--;
                 }
             }
 
@@ -318,23 +324,25 @@ namespace Realms
                 throw new NotImplementedException();
             }
 
-            // The empty set is a subset of any set.
-            if (Count == 0)
+            var count = Count;
+
+            // The empty set can't be a proper superset
+            if (count == 0 && proper)
             {
-                return true;
+                return false;
             }
 
             var otherSet = GetSet(other);
 
-            var maximumCount = Count;
+            var minimumCount = otherSet.Count;
             if (proper)
             {
-                // Proper subset means at least one element in addition to the subset
-                maximumCount--;
+                // Proper superset means at least one element in addition to the subset
+                minimumCount++;
             }
 
-            // Special case - we can't have a subset if we have more elements than the max count.
-            if (otherSet.Count > maximumCount)
+            // Special case - we can't have a superset if we have less elements than the min count.
+            if (count < minimumCount)
             {
                 return false;
             }
@@ -347,7 +355,7 @@ namespace Realms
                 }
             }
 
-            // We've already established that we have less than the max element count, so we're a subset.
+            // We've already established that we have more than the min element count, so we're a superset.
             return true;
         }
 
@@ -359,16 +367,6 @@ namespace Realms
             }
 
             return new HashSet<T>(enumerable);
-        }
-
-        private static ICollection<T> GetCollection(IEnumerable<T> enumerable)
-        {
-            if (enumerable is ICollection<T> collection)
-            {
-                return collection;
-            }
-
-            return new List<T>(enumerable);
         }
 
         #endregion

--- a/Tests/Realm.Tests/Database/RealmSetTests.cs
+++ b/Tests/Realm.Tests/Database/RealmSetTests.cs
@@ -68,6 +68,18 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableBooleanSet, testData);
         }
 
+        [TestCaseSource(nameof(BoolTestValues))]
+        public void RealmSet_WhenManaged_Bool(TestCaseData<bool> testData)
+        {
+            RunManagedTests(o => o.BooleanSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableBoolTestValues))]
+        public void RealmSet_WhenManaged_NullableBool(TestCaseData<bool?> testData)
+        {
+            RunManagedTests(o => o.NullableBooleanSet, testData);
+        }
+
         #endregion
 
         #region Byte
@@ -123,6 +135,30 @@ namespace Realms.Tests.Database
         public void RealmSet_WhenUnmanaged_NullableByteCounter(TestCaseData<byte?> testData)
         {
             RunUnmanagedTests(o => o.NullableByteCounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(ByteTestValues))]
+        public void RealmSet_WhenManaged_Byte(TestCaseData<byte> testData)
+        {
+            RunManagedTests(o => o.ByteSet, testData);
+        }
+
+        [TestCaseSource(nameof(ByteTestValues))]
+        public void RealmSet_WhenManaged_ByteCounter(TestCaseData<byte> testData)
+        {
+            RunManagedTests(o => o.ByteCounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableByteTestValues))]
+        public void RealmSet_WhenManaged_NullableByte(TestCaseData<byte?> testData)
+        {
+            RunManagedTests(o => o.NullableByteSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableByteTestValues))]
+        public void RealmSet_WhenManaged_NullableByteCounter(TestCaseData<byte?> testData)
+        {
+            RunManagedTests(o => o.NullableByteCounterSet, ToInteger(testData));
         }
 
         #endregion
@@ -182,6 +218,30 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableInt16CounterSet, ToInteger(testData));
         }
 
+        [TestCaseSource(nameof(Int16TestValues))]
+        public void RealmSet_WhenManaged_Int16(TestCaseData<short> testData)
+        {
+            RunManagedTests(o => o.Int16Set, testData);
+        }
+
+        [TestCaseSource(nameof(Int16TestValues))]
+        public void RealmSet_WhenManaged_Int16Counter(TestCaseData<short> testData)
+        {
+            RunManagedTests(o => o.Int16CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableInt16TestValues))]
+        public void RealmSet_WhenManaged_NullableInt16(TestCaseData<short?> testData)
+        {
+            RunManagedTests(o => o.NullableInt16Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableInt16TestValues))]
+        public void RealmSet_WhenManaged_NullableInt16Counter(TestCaseData<short?> testData)
+        {
+            RunManagedTests(o => o.NullableInt16CounterSet, ToInteger(testData));
+        }
+
         #endregion
 
         #region Int32
@@ -237,6 +297,30 @@ namespace Realms.Tests.Database
         public void RealmSet_WhenUnmanaged_NullableInt32Counter(TestCaseData<int?> testData)
         {
             RunUnmanagedTests(o => o.NullableInt32CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(Int32TestValues))]
+        public void RealmSet_WhenManaged_Int32(TestCaseData<int> testData)
+        {
+            RunManagedTests(o => o.Int32Set, testData);
+        }
+
+        [TestCaseSource(nameof(Int32TestValues))]
+        public void RealmSet_WhenManaged_Int32Counter(TestCaseData<int> testData)
+        {
+            RunManagedTests(o => o.Int32CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableInt32TestValues))]
+        public void RealmSet_WhenManaged_NullableInt32(TestCaseData<int?> testData)
+        {
+            RunManagedTests(o => o.NullableInt32Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableInt32TestValues))]
+        public void RealmSet_WhenManaged_NullableInt32Counter(TestCaseData<int?> testData)
+        {
+            RunManagedTests(o => o.NullableInt32CounterSet, ToInteger(testData));
         }
 
         #endregion
@@ -296,6 +380,30 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableInt64CounterSet, ToInteger(testData));
         }
 
+        [TestCaseSource(nameof(Int64TestValues))]
+        public void RealmSet_WhenManaged_Int64(TestCaseData<long> testData)
+        {
+            RunManagedTests(o => o.Int64Set, testData);
+        }
+
+        [TestCaseSource(nameof(Int64TestValues))]
+        public void RealmSet_WhenManaged_Int64Counter(TestCaseData<long> testData)
+        {
+            RunManagedTests(o => o.Int64CounterSet, ToInteger(testData));
+        }
+
+        [TestCaseSource(nameof(NullableInt64TestValues))]
+        public void RealmSet_WhenManaged_NullableInt64(TestCaseData<long?> testData)
+        {
+            RunManagedTests(o => o.NullableInt64Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableInt64TestValues))]
+        public void RealmSet_WhenManaged_NullableInt64Counter(TestCaseData<long?> testData)
+        {
+            RunManagedTests(o => o.NullableInt64CounterSet, ToInteger(testData));
+        }
+
         #endregion
 
         #region Float
@@ -341,6 +449,18 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableSingleSet, testData);
         }
 
+        [TestCaseSource(nameof(FloatTestValues))]
+        public void RealmSet_WhenManaged_Float(TestCaseData<float> testData)
+        {
+            RunManagedTests(o => o.SingleSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableFloatTestValues))]
+        public void RealmSet_WhenManaged_NullableFloat(TestCaseData<float?> testData)
+        {
+            RunManagedTests(o => o.NullableSingleSet, testData);
+        }
+
         #endregion
 
         #region Double
@@ -384,6 +504,18 @@ namespace Realms.Tests.Database
         public void RealmSet_WhenUnmanaged_NullableDouble(TestCaseData<double?> testData)
         {
             RunUnmanagedTests(o => o.NullableDoubleSet, testData);
+        }
+
+        [TestCaseSource(nameof(DoubleTestValues))]
+        public void RealmSet_WhenManaged_Double(TestCaseData<double> testData)
+        {
+            RunManagedTests(o => o.DoubleSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDoubleTestValues))]
+        public void RealmSet_WhenManaged_NullableDouble(TestCaseData<double?> testData)
+        {
+            RunManagedTests(o => o.NullableDoubleSet, testData);
         }
 
         #endregion
@@ -435,6 +567,18 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableDecimalSet, testData);
         }
 
+        [TestCaseSource(nameof(DecimalTestValues))]
+        public void RealmSet_WhenManaged_Decimal(TestCaseData<decimal> testData)
+        {
+            RunManagedTests(o => o.DecimalSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDecimalTestValues))]
+        public void RealmSet_WhenManaged_NullableDecimal(TestCaseData<decimal?> testData)
+        {
+            RunManagedTests(o => o.NullableDecimalSet, testData);
+        }
+
         #endregion
 
         #region Decimal128
@@ -447,8 +591,13 @@ namespace Realms.Tests.Database
             yield return new TestCaseData<Decimal128>(new Decimal128[] { -1, 0, 1.5m }, Array.Empty<Decimal128>());
             yield return new TestCaseData<Decimal128>(Array.Empty<Decimal128>(), new Decimal128[] { 0 });
             yield return new TestCaseData<Decimal128>(new Decimal128[] { 4, 6.6m, 8 }, new Decimal128[] { 12, 43, 2.2m, 5, 6.6m, 4, 8 });
-            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1.0m }, new Decimal128[] { 1, 1, 1 });
-            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128[] { 1.0m, 2, 1.0m });
+
+            // There is a bug in the Decimal128 implementation of GetHashCode, so we can't use the tests below. https://jira.mongodb.org/browse/CSHARP-3288
+            // Once fixed, we should uncomment.
+            // yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1.0m }, new Decimal128[] { 1, 1, 1 });
+            // yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128[] { 1.0m, 2, 1.0m });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128[] { 1, 1, 1 });
+            yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128[] { 1, 2, 1 });
             yield return new TestCaseData<Decimal128>(new Decimal128[] { 1, 2, 2, 1, 1, 1, 1 }, new Decimal128[] { 1, 1, 1 });
             yield return new TestCaseData<Decimal128>(new Decimal128[] { 1.9357683758257382523m }, new Decimal128[] { 1.9357683758257382524m, 1.9357683758257382522m });
             yield return new TestCaseData<Decimal128>(new Decimal128[] { 1.9357683758257382523m, 3.5743857348m, 8.75878832943928m }, new Decimal128[] { 1.9357683758257382523m, 8.75878832943928m });
@@ -462,10 +611,16 @@ namespace Realms.Tests.Database
             yield return new TestCaseData<Decimal128?>(new Decimal128?[] { -1, 0, 1.5m }, Array.Empty<Decimal128?>());
             yield return new TestCaseData<Decimal128?>(Array.Empty<Decimal128?>(), new Decimal128?[] { 0 });
             yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 4, 6.6m, 8 }, new Decimal128?[] { 12, 43, 2.2m, 5, 6.6m, 4, 8 });
-            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1.0m }, new Decimal128?[] { 1, 1, 1 });
-            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128?[] { 1.0m, 2, 1.0m });
+
+            // There is a bug in the Decimal128 implementation of GetHashCode, so we can't use the tests below. https://jira.mongodb.org/browse/CSHARP-3288
+            // Once fixed, we should uncomment.
+            // yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1.0m }, new Decimal128?[] { 1, 1, 1 });
+            // yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128?[] { 1.0m, 2, 1.0m });
+            // yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 2, 2, 1, null, null, null }, new Decimal128?[] { 1.0m, 1.0m, 1.0m, null });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128?[] { 1, 1, 1 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 1, 1, 1, 1, 1, 1 }, new Decimal128?[] { 1, 2, 1 });
+            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 2, 2, 1, null, null, null }, new Decimal128?[] { 1, 1, 1, null });
             yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 2, 2, 1, 1, 1, 1 }, new Decimal128?[] { 1, 1, 1 });
-            yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1, 2, 2, 1, null, null, null }, new Decimal128?[] { 1.0m, 1.0m, 1.0m, null });
             yield return new TestCaseData<Decimal128?>(new Decimal128?[] { null }, new Decimal128?[] { null, null });
             yield return new TestCaseData<Decimal128?>(new Decimal128?[] { null, null }, new Decimal128?[] { null, 6 });
             yield return new TestCaseData<Decimal128?>(new Decimal128?[] { 1.9357683758257382523m }, new Decimal128?[] { 1.9357683758257382524m, 1.9357683758257382522m });
@@ -482,6 +637,18 @@ namespace Realms.Tests.Database
         public void RealmSet_WhenUnmanaged_NullableDecimal128(TestCaseData<Decimal128?> testData)
         {
             RunUnmanagedTests(o => o.NullableDecimal128Set, testData);
+        }
+
+        [TestCaseSource(nameof(Decimal128TestValues))]
+        public void RealmSet_WhenManaged_Decimal128(TestCaseData<Decimal128> testData)
+        {
+            RunManagedTests(o => o.Decimal128Set, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDecimal128TestValues))]
+        public void RealmSet_WhenManaged_NullableDecimal128(TestCaseData<Decimal128?> testData)
+        {
+            RunManagedTests(o => o.NullableDecimal128Set, testData);
         }
 
         #endregion
@@ -538,6 +705,18 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableObjectIdSet, testData);
         }
 
+        [TestCaseSource(nameof(ObjectIdTestValues))]
+        public void RealmSet_WhenManaged_ObjectId(TestCaseData<ObjectId> testData)
+        {
+            RunManagedTests(o => o.ObjectIdSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableObjectIdTestValues))]
+        public void RealmSet_WhenManaged_NullableObjectId(TestCaseData<ObjectId?> testData)
+        {
+            RunManagedTests(o => o.NullableObjectIdSet, testData);
+        }
+
         #endregion
 
         #region DateTimeOffset
@@ -591,6 +770,18 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableDateTimeOffsetSet, testData);
         }
 
+        [TestCaseSource(nameof(DateTimeOffsetTestValues))]
+        public void RealmSet_WhenManaged_DateTimeOffset(TestCaseData<DateTimeOffset> testData)
+        {
+            RunManagedTests(o => o.DateTimeOffsetSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableDateTimeOffsetTestValues))]
+        public void RealmSet_WhenManaged_NullableDateTimeOffset(TestCaseData<DateTimeOffset?> testData)
+        {
+            RunManagedTests(o => o.NullableDateTimeOffsetSet, testData);
+        }
+
         #endregion
 
         #region String
@@ -636,6 +827,18 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.NullableStringSet, testData);
         }
 
+        [TestCaseSource(nameof(StringTestValues))]
+        public void RealmSet_WhenManaged_String(TestCaseData<string> testData)
+        {
+            RunManagedTests(o => o.StringSet, testData);
+        }
+
+        [TestCaseSource(nameof(NullableStringTestValues))]
+        public void RealmSet_WhenManaged_NullableString(TestCaseData<string> testData)
+        {
+            RunManagedTests(o => o.NullableStringSet, testData);
+        }
+
         #endregion
 
         private static void RunUnmanagedTests<T>(Func<SetsObject, ISet<T>> accessor, TestCaseData<T> testData)
@@ -658,6 +861,50 @@ namespace Realms.Tests.Database
             testData.AssertUnionWith(set);
         }
 
+        private void RunManagedTests<T>(Func<SetsObject, ISet<T>> accessor, TestCaseData<T> testData)
+        {
+            var testObject = new SetsObject();
+            var set = accessor(testObject);
+
+            testData.Seed(set);
+
+            _realm.Write(() =>
+            {
+                _realm.Add(testObject);
+            });
+
+            var managedSet = accessor(testObject);
+            Assert.That(set, Is.Not.SameAs(managedSet));
+
+            CollectionAssert.AreEquivalent(managedSet, testData.GetReferenceSet());
+
+            // Now we're testing set operations on RealmSet/HashSet
+            testData.AssertCount(managedSet);
+            testData.AssertExceptWith(managedSet);
+            testData.AssertIntersectWith(managedSet);
+            testData.AssertIsProperSubsetOf(managedSet);
+            testData.AssertIsProperSupersetOf(managedSet);
+            testData.AssertIsSubsetOf(managedSet);
+            testData.AssertIsSupersetOf(managedSet);
+            testData.AssertOverlaps(managedSet);
+            testData.AssertSymmetricExceptWith(managedSet);
+            testData.AssertUnionWith(managedSet);
+
+            // Now we're testing set operations on RealmSet/RealmSet
+            //var othertestObject = _realm.Write(() => _realm.Add(new SetsObject()));
+            //var otherSet = accessor(othertestObject);
+
+            //testData.AssertExceptWith(managedSet, otherSet);
+            //testData.AssertIntersectWith(managedSet, otherSet);
+            //testData.AssertIsProperSubsetOf(managedSet, otherSet);
+            //testData.AssertIsProperSupersetOf(managedSet, otherSet);
+            //testData.AssertIsSubsetOf(managedSet, otherSet);
+            //testData.AssertIsSupersetOf(managedSet, otherSet);
+            //testData.AssertOverlaps(managedSet, otherSet);
+            //testData.AssertSymmetricExceptWith(managedSet, otherSet);
+            //testData.AssertUnionWith(managedSet, otherSet);
+        }
+
         private static TestCaseData<RealmInteger<T>> ToInteger<T>(TestCaseData<T> data)
             where T : struct, IComparable<T>, IFormattable, IConvertible, IEquatable<T>
         {
@@ -676,7 +923,7 @@ namespace Realms.Tests.Database
 
             public T[] OtherCollection { get; }
 
-            public TestCaseData(IEnumerable<T> initialValues, IEnumerable<T> otherCollection)
+            public TestCaseData(IEnumerable<T> initialValues, ICollection<T> otherCollection)
             {
                 InitialValues = initialValues.ToArray();
                 OtherCollection = otherCollection.ToArray();
@@ -696,115 +943,159 @@ namespace Realms.Tests.Database
                 Assert.That(target, Is.EquivalentTo(reference));
             }
 
-            public void AssertUnionWith(ISet<T> target)
+            public void AssertUnionWith(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                target.UnionWith(OtherCollection);
+                WriteIfNecessary(target, () =>
+                {
+                    target.UnionWith(GetOrSeedOtherCollection(otherCollection));
+                });
+
                 reference.UnionWith(OtherCollection);
 
                 Assert.That(target, Is.EquivalentTo(reference));
             }
 
-            public void AssertExceptWith(ISet<T> target)
+            public void AssertExceptWith(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                target.ExceptWith(OtherCollection);
+                WriteIfNecessary(target, () =>
+                {
+                    target.ExceptWith(GetOrSeedOtherCollection(otherCollection));
+                });
+
                 reference.ExceptWith(OtherCollection);
 
                 Assert.That(target, Is.EquivalentTo(reference));
             }
 
-            public void AssertIntersectWith(ISet<T> target)
+            public void AssertIntersectWith(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                target.IntersectWith(OtherCollection);
+                WriteIfNecessary(target, () =>
+                {
+                    target.IntersectWith(GetOrSeedOtherCollection(otherCollection));
+                });
+
                 reference.IntersectWith(OtherCollection);
 
                 Assert.That(target, Is.EquivalentTo(reference));
             }
 
-            public void AssertIsProperSubsetOf(ISet<T> target)
+            public void AssertIsProperSubsetOf(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                var targetResult = target.IsProperSubsetOf(OtherCollection);
+                var targetResult = target.IsProperSubsetOf(GetOrSeedOtherCollection(otherCollection));
                 var referenceResult = reference.IsProperSubsetOf(OtherCollection);
 
                 Assert.That(targetResult, Is.EqualTo(referenceResult));
             }
 
-            public void AssertIsProperSupersetOf(ISet<T> target)
+            public void AssertIsProperSupersetOf(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                var targetResult = target.IsProperSupersetOf(OtherCollection);
+                var targetResult = target.IsProperSupersetOf(GetOrSeedOtherCollection(otherCollection));
                 var referenceResult = reference.IsProperSupersetOf(OtherCollection);
 
                 Assert.That(targetResult, Is.EqualTo(referenceResult));
             }
 
-            public void AssertIsSubsetOf(ISet<T> target)
+            public void AssertIsSubsetOf(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                var targetResult = target.IsSubsetOf(OtherCollection);
+                var targetResult = target.IsSubsetOf(GetOrSeedOtherCollection(otherCollection));
                 var referenceResult = reference.IsSubsetOf(OtherCollection);
 
                 Assert.That(targetResult, Is.EqualTo(referenceResult));
             }
 
-            public void AssertIsSupersetOf(ISet<T> target)
+            public void AssertIsSupersetOf(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                var targetResult = target.IsSupersetOf(OtherCollection);
+                var targetResult = target.IsSupersetOf(GetOrSeedOtherCollection(otherCollection));
                 var referenceResult = reference.IsSupersetOf(OtherCollection);
 
                 Assert.That(targetResult, Is.EqualTo(referenceResult));
             }
 
-            public void AssertOverlaps(ISet<T> target)
+            public void AssertOverlaps(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                var targetResult = target.Overlaps(OtherCollection);
+                var targetResult = target.Overlaps(GetOrSeedOtherCollection(otherCollection));
                 var referenceResult = reference.Overlaps(OtherCollection);
 
                 Assert.That(targetResult, Is.EqualTo(referenceResult));
             }
 
-            public void AssertSymmetricExceptWith(ISet<T> target)
+            public void AssertSymmetricExceptWith(ISet<T> target, ICollection<T> otherCollection = null)
             {
                 Seed(target);
                 var reference = GetReferenceSet();
 
-                target.SymmetricExceptWith(OtherCollection);
+                WriteIfNecessary(target, () =>
+                {
+                    target.SymmetricExceptWith(GetOrSeedOtherCollection(otherCollection));
+                });
+
                 reference.SymmetricExceptWith(OtherCollection);
 
                 Assert.That(target, Is.EquivalentTo(reference));
             }
 
-            private void Seed(ISet<T> target)
+            public void Seed(ICollection<T> target, IEnumerable<T> values = null)
             {
-                target.Clear();
-                foreach (var item in InitialValues)
+                WriteIfNecessary(target, () =>
                 {
-                    target.Add(item);
-                }
+                    target.Clear();
+                    foreach (var item in values ?? InitialValues)
+                    {
+                        target.Add(item);
+                    }
+                });
             }
 
-            private ISet<T> GetReferenceSet() => new HashSet<T>(InitialValues);
+            public ISet<T> GetReferenceSet() => new HashSet<T>(InitialValues);
+
+            private IEnumerable<T> GetOrSeedOtherCollection(ICollection<T> target)
+            {
+                if (target == null)
+                {
+                    return OtherCollection;
+                }
+
+                Seed(target, OtherCollection);
+
+                return target;
+            }
+
+            private static void WriteIfNecessary(IEnumerable<T> collection, Action writeAction)
+            {
+                Transaction transaction = null;
+                if (collection is RealmSet<T> realmSet)
+                {
+                    transaction = realmSet.Realm.BeginWrite();
+                }
+
+                writeAction();
+
+                transaction?.Commit();
+            }
         }
     }
 }

--- a/wrappers/src/CMakeLists.txt
+++ b/wrappers/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     debug.cpp
     error_handling.cpp
     list_cs.cpp
+    set_cs.cpp
     marshalling.cpp
     object_cs.cpp
     query_cs.cpp
@@ -37,6 +38,8 @@ set(HEADERS
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options(-Wno-missing-prototypes)
 endif()
+
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
 
 add_library(realm-wrappers SHARED ${SOURCES} ${HEADERS})
 set_target_properties(realm-wrappers PROPERTIES

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -55,10 +55,19 @@ extern "C" {
 
     REALM_EXPORT List* object_get_list(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
-        return handle_errors(ex, [&]() -> List* {
+        return handle_errors(ex, [&]() {
             verify_can_get(object);
 
             return new List(object.realm(), object.obj(), get_column_key(object, property_ndx));
+        });
+    }
+
+    REALM_EXPORT object_store::Set* object_get_set(const Object& object, size_t property_ndx, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [&]() {
+            verify_can_get(object);
+
+            return new object_store::Set(object.realm(), object.obj(), get_column_key(object, property_ndx));
         });
     }
 

--- a/wrappers/src/set_cs.cpp
+++ b/wrappers/src/set_cs.cpp
@@ -1,0 +1,196 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include <realm.hpp>
+#include <realm/object-store/object_accessor.hpp>
+#include <realm/object-store/thread_safe_reference.hpp>
+
+#include "error_handling.hpp"
+#include "marshalling.hpp"
+#include "realm_export_decls.hpp"
+#include "wrapper_exceptions.hpp"
+#include "notifications_cs.hpp"
+
+using namespace realm;
+using namespace realm::binding;
+
+namespace {
+    inline static void ensure_types(object_store::Set& set, realm_value_t value) {
+        if (value.is_null() && !is_nullable(set.get_type())) {
+            throw NotNullableException();
+        }
+
+        if (!value.is_null() && set.get_type() != PropertyType::Mixed && to_capi(set.get_type()) != value.type) {
+            throw PropertyTypeMismatchException(to_string(set.get_type()), to_string(value.type));
+        }
+    }
+}
+
+extern "C" {
+
+REALM_EXPORT bool realm_set_add_value(object_store::Set& set, realm_value_t value, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        ensure_types(set, value);
+
+        if (value.type == realm_value_type::RLM_TYPE_LINK) {
+            // For Mixed, we need ObjLink, otherwise, ObjKey
+            if ((set.get_type() & ~PropertyType::Flags) == PropertyType::Mixed) {
+                return set.insert_any(ObjLink(value.link.object->get_object_schema().table_key, value.link.object->obj().get_key())).second;
+            }
+
+            return set.insert(value.link.object->obj()).second;
+        }
+
+        return set.insert_any(from_capi(value)).second;
+    });
+}
+
+REALM_EXPORT void realm_set_get_value(object_store::Set& set, size_t ndx, realm_value_t* value, NativeException::Marshallable& ex)
+{
+    handle_errors(ex, [&]() {
+        const size_t count = set.size();
+        if (ndx >= count)
+            throw IndexOutOfRangeException("Get from RealmSet", ndx, count);
+
+        if ((set.get_type() & ~PropertyType::Flags) == PropertyType::Object) {
+            *value = to_capi(new Object(set.get_realm(), set.get_object_schema(), set.get(ndx)));
+        }
+        else {
+            auto val = set.get_any(ndx);
+            if (!val.is_null() && val.get_type() == type_TypedLink) {
+                *value = to_capi(new Object(set.get_realm(), val.get<ObjLink>()));
+            }
+            else {
+                *value = to_capi(std::move(val));
+            }
+        }
+    });
+}
+
+REALM_EXPORT bool realm_set_remove_value(object_store::Set& set, realm_value_t value, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        ensure_types(set, value);
+
+        if (value.type == realm_value_type::RLM_TYPE_LINK) {
+            // For Mixed, we need ObjLink, otherwise, ObjKey
+            if ((set.get_type() & ~PropertyType::Flags) == PropertyType::Mixed) {
+                return set.remove_any(ObjLink(value.link.object->get_object_schema().table_key, value.link.object->obj().get_key())).second;
+            }
+
+            return set.remove(value.link.object->obj()).second;
+        }
+
+        return set.remove_any(from_capi(value)).second;
+    });
+}
+
+REALM_EXPORT bool realm_set_contains_value(object_store::Set& set, realm_value_t value, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        auto set_type = set.get_type();
+        // This doesn't use ensure_types to allow Set<string>.Find(null) to return false
+        if (value.is_null() && !is_nullable(set_type)) {
+            return false;
+        }
+        
+        if (!value.is_null() && set_type != PropertyType::Mixed && to_capi(set_type) != value.type) {
+            throw PropertyTypeMismatchException(to_string(set_type), to_string(value.type));
+        }
+
+        if (value.type == realm_value_type::RLM_TYPE_LINK) {
+            if (set.get_realm() != value.link.object->realm()) {
+                throw ObjectManagedByAnotherRealmException("Can't look up index of an object that belongs to a different Realm.");
+            }
+
+            if ((set_type & PropertyType::Flags) == PropertyType::Mixed) {
+                return set.find_any(ObjLink(value.link.object->get_object_schema().table_key, value.link.object->obj().get_key())) > -1;
+            }
+
+            return set.find(value.link.object->obj()) != realm::not_found;
+        }
+
+        return set.find_any(from_capi(value)) != realm::not_found;
+    });
+}
+
+REALM_EXPORT void realm_set_clear(object_store::Set& set, NativeException::Marshallable& ex)
+{
+    handle_errors(ex, [&]() {
+        set.remove_all();
+    });
+}
+
+REALM_EXPORT size_t realm_set_get_size(object_store::Set& set, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return set.size();
+    });
+}
+
+REALM_EXPORT void realm_set_destroy(object_store::Set* set)
+{
+    delete set;
+}
+
+REALM_EXPORT ManagedNotificationTokenContext* realm_set_add_notification_callback(object_store::Set* set, void* managed_set, ManagedNotificationCallback callback, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [=]() {
+        return subscribe_for_notifications(managed_set, callback, [set](CollectionChangeCallback callback) {
+            return set->add_notification_callback(callback);
+        });
+    });
+}
+
+REALM_EXPORT bool realm_set_get_is_valid(const object_store::Set& set, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return set.is_valid();
+    });
+}
+
+REALM_EXPORT ThreadSafeReference* realm_set_get_thread_safe_reference(const object_store::Set& set, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return new ThreadSafeReference(set);
+    });
+}
+
+REALM_EXPORT Results* realm_set_snapshot(const object_store::Set& set, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return new Results(set.snapshot());
+    });
+}
+
+REALM_EXPORT bool realm_set_get_is_frozen(const object_store::Set& set, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return set.is_frozen();
+    });
+}
+
+REALM_EXPORT object_store::Set* realm_set_freeze(const object_store::Set& set, const SharedRealm& realm, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        return new object_store::Set(set.freeze(realm));
+    });
+}
+
+}   // extern "C"


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Wires up some of the native set implementation - there are still a few missing methods (IsStrictSubset, IsStrictSuperset, SetEquals), and Core hasn't exposed an ability to invoke the Set-specific methods with a non-set collection, but most of the remaining stuff should be there.

##  TODO

* [ ] Changelog entry
* [ ] Tests (if applicable)
