### PR TITLE
Prepare for 10.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 10.0.0-beta.4 (2021-01-18)
+## 10.0.0-beta.5 (2021-01-19)
 ------------------
 ### Breaking Changes
 * Removed `RealmObject.FreezeInPlace`. To freeze a realm object use the `Freeze` extension method. (Issue [#2180](https://github.com/realm/realm-dotnet/issues/2180))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## vNext (TBD)
+## 10.0.0-beta.4 (2021-01-18)
 ------------------
 ### Breaking Changes
 * Removed `RealmObject.FreezeInPlace`. To freeze a realm object use the `Freeze` extension method. (Issue [#2180](https://github.com/realm/realm-dotnet/issues/2180))
@@ -6,6 +6,9 @@
 ### Fixed
 * Worked around an issue with the .NET Native compiler (used in UWP projects) that would result in the following exception being thrown in Release: `Incompatible MarshalAs detected in parameter named 'value'. Please refer to MCG's warning message for more information.`. (Issue [#2169](https://github.com/realm/realm-dotnet/issues/2169))
 * Fixed a bug that could cause a deadlock in a multiprocess scenario where multiple processes share the same Realm file and listen for notifications from the file. (Core upgrade)
+* Fixed an issue where Sync connections would fail on Windows due to `SSL server certificate rejected`. (Core upgrade)
+* Fixed an issue with deleting and recreating objects with embedded objects. (Core upgrade)
+* Fix a race condition which would lead to "uncaught exception in notifier thread: N5realm15InvalidTableRefE: transaction_ended" and a crash when the source Realm was closed or invalidated at a very specific time during the first run of a collection notifier (Core upgrade)
 
 ### Enhancements
 * Add support for the `GUID` data type. It can be used as primary key and is indexable. (PR [#2120](https://github.com/realm/realm-dotnet/pull/2120))
@@ -15,8 +18,8 @@
 * Realm Studio: 10.0.0 or later.
 
 ### Internal
-* Using Core 10.3.0.
-* Migrate to bison parser
+* Using Core 10.3.3.
+* Migrated to bison parser.
 
 ## 10.0.0-beta.3 (2020-12-10)
 ------------------

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,8 +31,8 @@ stage('Checkout') {
     }
     // TODO: temporary add a beta.X suffix for v10 releases
     // Also update in AppHandle.cs
-    else if (env.CHANGE_BRANCH == 'release/10.0.0-beta.4') {
-      versionSuffix = "beta.4"
+    else if (env.CHANGE_BRANCH == 'release/10.0.0-beta.5') {
+      versionSuffix = "beta.5"
     }
 
     stash includes: '**', excludes: 'wrappers/**', name: 'dotnet-source', useDefaultExcludes: false

--- a/Realm/Realm/Handles/AppHandle.cs
+++ b/Realm/Realm/Handles/AppHandle.cs
@@ -182,7 +182,7 @@ namespace Realms.Sync
             // var sdkVersion = typeof(AppHandle).GetTypeInfo().Assembly.GetName().Version.ToString(3);
 
             // TODO: temporarily add -beta.X suffix to the SDK
-            var sdkVersion = "10.0.0-beta.4";
+            var sdkVersion = "10.0.0-beta.5";
 
             NativeMethods.initialize(
                 platform, (IntPtr)platform.Length,


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

The -beta.4 release is cursed, so we're jumping to -beta.5. Supersedes https://github.com/realm/realm-dotnet/pull/2189.

##  TODO

* [x] Changelog entry
