### PR TITLE
Some project cleanup

### DIFF
--- a/Tests/Benchmarks/Benchmarks.iOS/Benchmarks.iOS.csproj
+++ b/Tests/Benchmarks/Benchmarks.iOS/Benchmarks.iOS.csproj
@@ -62,6 +62,8 @@
     <MtouchArch>ARM64</MtouchArch>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchExtraArgs>--nosymbolstrip --nolinkaway</MtouchExtraArgs>
+    <MtouchLink>Full</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -91,7 +93,7 @@
       <Name>Benchmarks</Name>
     </ProjectReference>
   </ItemGroup>
-    <ItemGroup Condition="'$(UseRealmNupkgsWithVersion)' == ''">
+  <ItemGroup Condition="'$(UseRealmNupkgsWithVersion)' == ''">
     <NativeReference Include="..\..\..\wrappers\build\iOS\$(Configuration)\realm-wrappers.framework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>

--- a/Tests/Benchmarks/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks/Benchmarks.csproj
@@ -22,7 +22,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Realm\Realm\Realm.csproj" />
     <ProjectReference Include="..\PerformanceTests\PerformanceTests.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This adds full linking for release iPhone builds (otherwise, I was hitting link-time errors about missing methods). It also removes the `Realm` reference from the shared XF project as that doesn't seem like something we need to reference.