### PR TITLE
Add dynamic support for dictionaries

### DIFF
--- a/Realm/Realm/DatabaseTypes/IMetadataObject.cs
+++ b/Realm/Realm/DatabaseTypes/IMetadataObject.cs
@@ -1,6 +1,6 @@
 ﻿////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2017 Realm Inc.
+// Copyright 2021 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,23 +19,13 @@
 namespace Realms
 {
     /// <summary>
-    /// An interface representing a thread confined object.
+    /// Represents a database object (object/collection/query) that has metadata.
     /// </summary>
-    internal interface IThreadConfined : IMetadataObject
+    internal interface IMetadataObject
     {
         /// <summary>
-        /// Gets a value indicating whether the object is managed.
+        /// Gets a value representing the object's metadata.
         /// </summary>
-        bool IsManaged { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the object is still valid (i.e. its Realm isn't closed and the object isn't deleted).
-        /// </summary>
-        bool IsValid { get; }
-
-        /// <summary>
-        /// Gets a value representing the native handle for that object.
-        /// </summary>
-        IThreadConfinedHandle Handle { get; }
+        RealmObjectBase.Metadata Metadata { get; }
     }
 }

--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -36,7 +36,8 @@ namespace Realms
     public abstract class RealmCollectionBase<T>
         : NotificationsHelper.INotifiable,
           IRealmCollection<T>,
-          IThreadConfined
+          IThreadConfined,
+          IMetadataObject
     {
         protected static readonly RealmValueType _argumentType = typeof(T).ToPropertyType(out _).ToRealmValueType();
         protected static readonly bool _isEmbedded = typeof(T).IsEmbeddedObject();
@@ -103,7 +104,7 @@ namespace Realms
 
         public ObjectSchema ObjectSchema => Metadata?.Schema;
 
-        RealmObjectBase.Metadata IThreadConfined.Metadata => Metadata;
+        RealmObjectBase.Metadata IMetadataObject.Metadata => Metadata;
 
         public bool IsManaged => Realm != null;
 
@@ -514,5 +515,18 @@ namespace Realms
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// IRealmList is only implemented by RealmList and serves to expose the ListHandle without knowing the generic param.
+    /// </summary>
+    /// <typeparam name="THandle">The type of the handle for the collection.</typeparam>
+    internal interface IRealmCollectionBase<THandle> : IMetadataObject
+        where THandle : CollectionHandleBase
+    {
+        /// <summary>
+        /// Gets the native handle for that collection.
+        /// </summary>
+        THandle NativeHandle { get; }
     }
 }

--- a/Realm/Realm/DatabaseTypes/RealmDictionary.cs
+++ b/Realm/Realm/DatabaseTypes/RealmDictionary.cs
@@ -23,6 +23,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Linq.Expressions;
+using Realms.Dynamic;
 using Realms.Helpers;
 
 namespace Realms
@@ -31,7 +32,7 @@ namespace Realms
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This should not be directly accessed by users.")]
     [DebuggerDisplay("Count = {Count}")]
-    public class RealmDictionary<TValue> : RealmCollectionBase<KeyValuePair<string, TValue>>, IDictionary<string, TValue>, IDynamicMetaObjectProvider
+    public class RealmDictionary<TValue> : RealmCollectionBase<KeyValuePair<string, TValue>>, IDictionary<string, TValue>, IDynamicMetaObjectProvider, IRealmCollectionBase<DictionaryHandle>
     {
         private readonly DictionaryHandle _dictionaryHandle;
 
@@ -82,6 +83,8 @@ namespace Realms
             }
         }
 
+        DictionaryHandle IRealmCollectionBase<DictionaryHandle>.NativeHandle => _dictionaryHandle;
+
         internal RealmDictionary(Realm realm, DictionaryHandle adoptedDictionary, RealmObjectBase.Metadata metadata)
             : base(realm, metadata)
         {
@@ -108,10 +111,7 @@ namespace Realms
 
         public bool ContainsKey(string key) => key != null && _dictionaryHandle.ContainsKey(key);
 
-        public DynamicMetaObject GetMetaObject(Expression parameter)
-        {
-            throw new NotImplementedException();
-        }
+        DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression expression) => new MetaRealmDictionary(expression, this);
 
         public override int IndexOf(KeyValuePair<string, TValue> value) => throw new NotSupportedException();
 

--- a/Realm/Realm/DatabaseTypes/RealmList.cs
+++ b/Realm/Realm/DatabaseTypes/RealmList.cs
@@ -40,7 +40,7 @@ namespace Realms
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This should not be directly accessed by users.")]
     [DebuggerDisplay("Count = {Count}")]
-    public class RealmList<T> : RealmCollectionBase<T>, IList<T>, IDynamicMetaObjectProvider, IRealmList
+    public class RealmList<T> : RealmCollectionBase<T>, IList<T>, IDynamicMetaObjectProvider, IRealmCollectionBase<ListHandle>
     {
         private readonly ListHandle _listHandle;
 
@@ -51,9 +51,7 @@ namespace Realms
 
         internal override CollectionHandleBase GetOrCreateHandle() => _listHandle;
 
-        ListHandle IRealmList.NativeHandle => _listHandle;
-
-        RealmObjectBase.Metadata IRealmList.Metadata => Metadata;
+        ListHandle IRealmCollectionBase<ListHandle>.NativeHandle => _listHandle;
 
         [IndexerName("Item")]
         public new T this[int index]
@@ -174,21 +172,5 @@ namespace Realms
         protected override T GetValueAtIndex(int index) => _listHandle.GetValueAtIndex(index, Metadata, Realm).As<T>();
 
         DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression expression) => new MetaRealmList(expression, this);
-    }
-
-    /// <summary>
-    /// IRealmList is only implemented by RealmList and serves to expose the ListHandle without knowing the generic param.
-    /// </summary>
-    internal interface IRealmList
-    {
-        /// <summary>
-        /// Gets the native handle for that list.
-        /// </summary>
-        ListHandle NativeHandle { get; }
-
-        /// <summary>
-        /// Gets the metadata for the objects contained in the list.
-        /// </summary>
-        RealmObjectBase.Metadata Metadata { get; }
     }
 }

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -146,7 +146,7 @@ namespace Realms
         }
 
         /// <inheritdoc/>
-        Metadata IThreadConfined.Metadata => ObjectMetadata;
+        Metadata IMetadataObject.Metadata => ObjectMetadata;
 
         /// <inheritdoc/>
         IThreadConfinedHandle IThreadConfined.Handle => ObjectHandle;

--- a/Realm/Realm/Dynamic/MetaRealmDictionary.cs
+++ b/Realm/Realm/Dynamic/MetaRealmDictionary.cs
@@ -1,0 +1,55 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Dynamic;
+using System.Linq.Expressions;
+
+namespace Realms.Dynamic
+{
+    internal class MetaRealmDictionary : DynamicMetaObject
+    {
+        internal MetaRealmDictionary(Expression expression, object value) : base(expression, BindingRestrictions.Empty, value)
+        {
+        }
+
+        public override DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
+        {
+            if (Value is IRealmCollection<EmbeddedObject>)
+            {
+                throw new NotSupportedException("Can't set embedded objects directly. Instead use Realm.DynamicApi.SetEmbeddedObjectInDictionary.");
+            }
+
+            return base.BindSetIndex(binder, indexes, value);
+        }
+
+        public override DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)
+        {
+            if (Value is IRealmCollection<EmbeddedObject>)
+            {
+                switch (binder.Name)
+                {
+                    case nameof(RealmDictionary<EmbeddedObject>.Add):
+                        throw new NotSupportedException("Can't add embedded objects directly. Instead use Realm.DynamicApi.AddEmbeddedObjectToDictionary.");
+                }
+            }
+
+            return base.BindInvokeMember(binder, args);
+        }
+    }
+}

--- a/Realm/Realm/Handles/DictionaryHandle.cs
+++ b/Realm/Realm/Handles/DictionaryHandle.cs
@@ -68,6 +68,12 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_dictionary_add", CallingConvention = CallingConvention.Cdecl)]
             public static extern void add_value(DictionaryHandle handle, PrimitiveValue key, PrimitiveValue value, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_dictionary_add_embedded", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr add_embedded(DictionaryHandle handle, PrimitiveValue key, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_dictionary_set_embedded", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr set_embedded(DictionaryHandle handle, PrimitiveValue key, out NativeException ex);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_dictionary_contains_key", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool contains_key(DictionaryHandle handle, PrimitiveValue key, out NativeException ex);
@@ -223,6 +229,30 @@ namespace Realms
             handles?.Dispose();
             keyHandles?.Dispose();
             nativeException.ThrowIfNecessary();
+        }
+
+        public ObjectHandle AddEmbedded(string key)
+        {
+            RealmValue keyValue = key;
+            var (primitiveKey, keyHandles) = keyValue.ToNative();
+
+            var result = NativeMethods.add_embedded(this, primitiveKey, out var nativeException);
+            keyHandles?.Dispose();
+            nativeException.ThrowIfNecessary();
+
+            return new ObjectHandle(Root, result);
+        }
+
+        public ObjectHandle SetEmbedded(string key)
+        {
+            RealmValue keyValue = key;
+            var (primitiveKey, keyHandles) = keyValue.ToNative();
+
+            var result = NativeMethods.set_embedded(this, primitiveKey, out var nativeException);
+            keyHandles?.Dispose();
+            nativeException.ThrowIfNecessary();
+
+            return new ObjectHandle(Root, result);
         }
 
         public unsafe bool ContainsKey(string key)

--- a/Tests/Realm.Tests/Database/DynamicRelationshipTests.cs
+++ b/Tests/Realm.Tests/Database/DynamicRelationshipTests.cs
@@ -35,6 +35,9 @@ namespace Realms.Tests.Database
     [Preserve(AllMembers = true)]
     public class DynamicRelationshipTests : RealmInstanceTest
     {
+        private const string BilbosName = "Bilbo Fleabaggins";
+        private const string EarlsName = "Earl Yippington III";
+
         private class DynamicDog : RealmObject
         {
             public string Name { get; set; }
@@ -56,6 +59,10 @@ namespace Realms.Tests.Database
             public IList<DynamicDog> Dogs { get; }
 
             public IList<string> Tags { get; }
+
+            public IDictionary<string, DynamicDog> DogsDictionary { get; }
+
+            public IDictionary<string, string> TagsDictionary { get; }
         }
 
         private readonly DynamicTestObjectType _mode;
@@ -84,15 +91,19 @@ namespace Realms.Tests.Database
                 o1.Name = "Tim";
 
                 var d1 = _realm.DynamicApi.CreateObject("DynamicDog", null);
-                d1.Name = "Bilbo Fleabaggins";
+                d1.Name = BilbosName;
                 d1.Color = "Black";
                 o1.TopDog = d1;  // set a one-one relationship
                 o1.Dogs.Add(d1);
+                o1.DogsDictionary.Add(d1.Name, d1);
+                o1.TagsDictionary.Add(d1.Name, "great");
 
                 var d2 = _realm.DynamicApi.CreateObject("DynamicDog", null);
-                d2.Name = "Earl Yippington III";
+                d2.Name = EarlsName;
                 d2.Color = "White";
                 o1.Dogs.Add(d2);
+                o1.DogsDictionary.Add(d2.Name, d2);
+                o1.TagsDictionary.Add(d2.Name, "playful");
 
                 // lonely people and dogs
                 var o2 = _realm.DynamicApi.CreateObject("DynamicOwner", null);
@@ -108,7 +119,7 @@ namespace Realms.Tests.Database
         public void TimHasATopDog()
         {
             var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
-            Assert.That(tim.TopDog.Name, Is.EqualTo("Bilbo Fleabaggins"));
+            Assert.That(tim.TopDog.Name, Is.EqualTo(BilbosName));
         }
 
         [Test]
@@ -123,7 +134,7 @@ namespace Realms.Tests.Database
                 dogNames.Add(dog.Name);
             }
 
-            Assert.That(dogNames, Is.EquivalentTo(new[] { "Bilbo Fleabaggins", "Earl Yippington III" }));
+            Assert.That(dogNames, Is.EquivalentTo(new[] { BilbosName, EarlsName }));
         }
 
         /// <summary>
@@ -140,7 +151,7 @@ namespace Realms.Tests.Database
                 dogNames.Add(dog.Name);
             }
 
-            Assert.That(dogNames, Is.EquivalentTo(new[] { "Bilbo Fleabaggins", "Earl Yippington III" }));
+            Assert.That(dogNames, Is.EquivalentTo(new[] { BilbosName, EarlsName }));
         }
 
         [Test]
@@ -189,7 +200,7 @@ namespace Realms.Tests.Database
             var tim2 = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
             Assert.That(tim2.Dogs.Count, Is.EqualTo(3));
             Assert.That(tim2.Dogs[1].Name, Is.EqualTo("Maggie Mongrel"));
-            Assert.That(tim2.Dogs[2].Name, Is.EqualTo("Earl Yippington III"));
+            Assert.That(tim2.Dogs[2].Name, Is.EqualTo(EarlsName));
         }
 
         [Test]
@@ -205,7 +216,7 @@ namespace Realms.Tests.Database
 
             var tim2 = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
             Assert.That(tim2.Dogs.Count, Is.EqualTo(1));
-            Assert.That(tim2.Dogs[0].Name, Is.EqualTo("Earl Yippington III"));
+            Assert.That(tim2.Dogs[0].Name, Is.EqualTo(EarlsName));
             using (var trans = _realm.BeginWrite())
             {
                 tim.Dogs.RemoveAt(0);
@@ -235,7 +246,7 @@ namespace Realms.Tests.Database
         [Test]
         public void TimLosesBilbo()
         {
-            var bilbo = _realm.DynamicApi.All("DynamicDog").ToArray().Single(p => p.Name == "Bilbo Fleabaggins");
+            var bilbo = _realm.DynamicApi.All("DynamicDog").ToArray().Single(p => p.Name == BilbosName);
             var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
             Assert.That(tim.Dogs.Count, Is.EqualTo(2));
             using (var trans = _realm.BeginWrite())
@@ -246,7 +257,7 @@ namespace Realms.Tests.Database
 
             var tim2 = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
             Assert.That(tim2.Dogs.Count, Is.EqualTo(1));
-            Assert.That(tim2.Dogs[0].Name, Is.EqualTo("Earl Yippington III"));
+            Assert.That(tim2.Dogs[0].Name, Is.EqualTo(EarlsName));
         }
 
         [Test]
@@ -275,7 +286,7 @@ namespace Realms.Tests.Database
         {
             var dani = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Dani");
             Assert.Throws<ArgumentOutOfRangeException>(() => dani.Dogs.RemoveAt(0));
-            var bilbo = _realm.DynamicApi.All("DynamicDog").ToArray().Single(p => p.Name == "Bilbo Fleabaggins");
+            var bilbo = _realm.DynamicApi.All("DynamicDog").ToArray().Single(p => p.Name == BilbosName);
             dynamic scratch;  // for assignment in following getters
             Assert.Throws<ArgumentOutOfRangeException>(() => dani.Dogs.Insert(-1, bilbo));
             Assert.Throws<ArgumentOutOfRangeException>(() => dani.Dogs.Insert(1, bilbo));
@@ -299,7 +310,7 @@ namespace Realms.Tests.Database
         {
             var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
             Assert.Throws<ArgumentOutOfRangeException>(() => tim.Dogs.RemoveAt(4));
-            var bilbo = _realm.DynamicApi.All("DynamicDog").ToArray().Single(p => p.Name == "Bilbo Fleabaggins");
+            var bilbo = _realm.DynamicApi.All("DynamicDog").ToArray().Single(p => p.Name == BilbosName);
             dynamic scratch;  // for assignment in following getters
             Assert.Throws<ArgumentOutOfRangeException>(() => tim.Dogs.Insert(-1, bilbo));
             Assert.Throws<ArgumentOutOfRangeException>(() => tim.Dogs.Insert(3, bilbo));
@@ -369,6 +380,221 @@ namespace Realms.Tests.Database
             });
 
             Assert.That(tim.Tags, Is.Empty);
+        }
+
+        [Test]
+        public void Dictionary_TryGetValue()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+
+            var bilbo = TryGetValue(tim.DogsDictionary, BilbosName, out bool hasBilbo);
+            Assert.That(hasBilbo, Is.True);
+            Assert.That(bilbo, Is.Not.Null);
+
+            var pipi = TryGetValue(tim.DogsDictionary, "Pipilotta", out bool hasPipi);
+            Assert.That(hasPipi, Is.False);
+            Assert.That(pipi, Is.Null);
+
+            var bilbosTag = TryGetValue(tim.TagsDictionary, BilbosName, out bool hasBilbosTag);
+            Assert.That(hasBilbosTag, Is.True);
+            Assert.That(bilbosTag, Is.EqualTo("great"));
+
+            var pipisTag = TryGetValue(tim.TagsDictionary, "Pipilotta", out bool hasPipisTag);
+            Assert.That(hasPipisTag, Is.False);
+            Assert.That(pipisTag, Is.Null);
+        }
+
+        [Test]
+        public void Dictionary_Count()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(2));
+            Assert.That(tim.TagsDictionary.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Dictionary_Get()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+
+            var bilbo = tim.DogsDictionary[BilbosName];
+            Assert.That(bilbo, Is.Not.Null);
+            Assert.That(bilbo.Name, Is.EqualTo(BilbosName));
+
+            var bilbosTag = tim.TagsDictionary[BilbosName];
+            Assert.That(bilbosTag, Is.EqualTo("great"));
+
+            Assert.Throws<KeyNotFoundException>(() => _ = tim.DogsDictionary["Pipilotta"]);
+            Assert.Throws<KeyNotFoundException>(() => _ = tim.TagsDictionary["Pipilotta"]);
+        }
+
+        [Test]
+        public void Dictionary_Set()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+
+            _realm.Write(() =>
+            {
+                var pipi = _realm.DynamicApi.CreateObject("DynamicDog", null);
+                pipi.Name = "Pipilotta";
+                pipi.Color = "Orange";
+
+                tim.DogsDictionary[pipi.Name] = pipi;
+                tim.TagsDictionary[pipi.Name] = "cheerful";
+            });
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.DogsDictionary["Pipilotta"].Name, Is.EqualTo("Pipilotta"));
+
+            Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.TagsDictionary["Pipilotta"], Is.EqualTo("cheerful"));
+
+            _realm.Write(() =>
+            {
+                tim.DogsDictionary["Pipilotta"] = null;
+                tim.TagsDictionary["Pipilotta"] = null;
+            });
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.DogsDictionary["Pipilotta"], Is.Null);
+
+            Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.TagsDictionary["Pipilotta"], Is.Null);
+        }
+
+        [Test]
+        public void Dictionary_Add()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+
+            _realm.Write(() =>
+            {
+                var pipi = _realm.DynamicApi.CreateObject("DynamicDog", null);
+                pipi.Name = "Pipilotta";
+                pipi.Color = "Orange";
+
+                tim.DogsDictionary.Add("Pipilotta", pipi);
+                tim.TagsDictionary.Add("Pipilotta", "cheerful");
+            });
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.DogsDictionary["Pipilotta"].Name, Is.EqualTo("Pipilotta"));
+
+            Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.TagsDictionary["Pipilotta"], Is.EqualTo("cheerful"));
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _realm.Write(() =>
+                {
+                    tim.DogsDictionary.Add("Pipilotta", null);
+                });
+            }, $"An item with the key 'Pipilotta' has already been added.");
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _realm.Write(() =>
+                {
+                    tim.TagsDictionary.Add("Pipilotta", null);
+                });
+            }, $"An item with the key 'Pipilotta' has already been added.");
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.DogsDictionary["Pipilotta"], Is.Not.Null);
+
+            Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
+            Assert.That(tim.TagsDictionary["Pipilotta"], Is.EqualTo("cheerful"));
+
+            _realm.Write(() =>
+            {
+                tim.DogsDictionary.Add("Void", null);
+                tim.TagsDictionary.Add("Void", null);
+            });
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(4));
+            Assert.That(tim.DogsDictionary["Void"], Is.Null);
+
+            Assert.That(tim.TagsDictionary.Count, Is.EqualTo(4));
+            Assert.That(tim.TagsDictionary["Void"], Is.Null);
+        }
+
+        [Test]
+        public void Dictionary_Keys()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+            Assert.That(tim.DogsDictionary.Keys, Is.EquivalentTo(new[] { BilbosName, EarlsName }));
+            Assert.That(tim.TagsDictionary.Keys, Is.EquivalentTo(new[] { BilbosName, EarlsName }));
+        }
+
+        [Test]
+        public void Dictionary_Values()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+
+            var dogNames = new List<string>();
+
+            foreach (var dog in tim.DogsDictionary.Values)
+            {
+                dogNames.Add(dog.Name);
+            }
+
+            Assert.That(dogNames, Is.EquivalentTo(new[] { BilbosName, EarlsName }));
+            Assert.That(tim.TagsDictionary.Values, Is.EquivalentTo(new[] { "great", "playful" }));
+        }
+
+        [Test]
+        public void Dictionary_Iteration()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+            var dogNames = new List<string>();
+            var dogColors = new List<string>();
+
+            foreach (var kvp in tim.DogsDictionary)
+            {
+                dogNames.Add(kvp.Key);
+                dogColors.Add(kvp.Value.Color);
+            }
+
+            Assert.That(dogNames, Is.EquivalentTo(new[] { BilbosName, EarlsName }));
+            Assert.That(dogColors, Is.EquivalentTo(new[] { "Black", "White" }));
+
+            var tags = new List<string>();
+            dogNames.Clear();
+
+            foreach (var kvp in tim.TagsDictionary)
+            {
+                dogNames.Add(kvp.Key);
+                tags.Add(kvp.Value);
+            }
+
+            Assert.That(dogNames, Is.EquivalentTo(new[] { BilbosName, EarlsName }));
+            Assert.That(tags, Is.EquivalentTo(new[] { "great", "playful" }));
+        }
+
+        [Test]
+        public void Dictionary_Remove()
+        {
+            var tim = _realm.DynamicApi.All("DynamicOwner").ToArray().Single(p => p.Name == "Tim");
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(2));
+
+            _realm.Write(() =>
+            {
+                tim.DogsDictionary.Remove(BilbosName);
+                tim.TagsDictionary.Remove(BilbosName);
+            });
+
+            Assert.That(tim.DogsDictionary.Count, Is.EqualTo(1));
+            Assert.That(tim.TagsDictionary.Count, Is.EqualTo(1));
+        }
+
+        // Suggested https://stackoverflow.com/a/10021436/1649102
+        private static TValue TryGetValue<TKey, TValue>(IDictionary<TKey, TValue> dict, TKey value, out bool found)
+        {
+            TValue result;
+            found = dict.TryGetValue(value, out result);
+            return result;
         }
     }
 }

--- a/Tests/Realm.Tests/Database/DynamicRelationshipTests.cs
+++ b/Tests/Realm.Tests/Database/DynamicRelationshipTests.cs
@@ -37,6 +37,7 @@ namespace Realms.Tests.Database
     {
         private const string BilbosName = "Bilbo Fleabaggins";
         private const string EarlsName = "Earl Yippington III";
+        private const string PipilottasName = "Pipilotta";
 
         private class DynamicDog : RealmObject
         {
@@ -391,7 +392,7 @@ namespace Realms.Tests.Database
             Assert.That(hasBilbo, Is.True);
             Assert.That(bilbo, Is.Not.Null);
 
-            var pipi = TryGetValue(tim.DogsDictionary, "Pipilotta", out bool hasPipi);
+            var pipi = TryGetValue(tim.DogsDictionary, PipilottasName, out bool hasPipi);
             Assert.That(hasPipi, Is.False);
             Assert.That(pipi, Is.Null);
 
@@ -399,7 +400,7 @@ namespace Realms.Tests.Database
             Assert.That(hasBilbosTag, Is.True);
             Assert.That(bilbosTag, Is.EqualTo("great"));
 
-            var pipisTag = TryGetValue(tim.TagsDictionary, "Pipilotta", out bool hasPipisTag);
+            var pipisTag = TryGetValue(tim.TagsDictionary, PipilottasName, out bool hasPipisTag);
             Assert.That(hasPipisTag, Is.False);
             Assert.That(pipisTag, Is.Null);
         }
@@ -425,8 +426,8 @@ namespace Realms.Tests.Database
             var bilbosTag = tim.TagsDictionary[BilbosName];
             Assert.That(bilbosTag, Is.EqualTo("great"));
 
-            Assert.Throws<KeyNotFoundException>(() => _ = tim.DogsDictionary["Pipilotta"]);
-            Assert.Throws<KeyNotFoundException>(() => _ = tim.TagsDictionary["Pipilotta"]);
+            Assert.Throws<KeyNotFoundException>(() => _ = tim.DogsDictionary[PipilottasName]);
+            Assert.Throws<KeyNotFoundException>(() => _ = tim.TagsDictionary[PipilottasName]);
         }
 
         [Test]
@@ -437,7 +438,7 @@ namespace Realms.Tests.Database
             _realm.Write(() =>
             {
                 var pipi = _realm.DynamicApi.CreateObject("DynamicDog", null);
-                pipi.Name = "Pipilotta";
+                pipi.Name = PipilottasName;
                 pipi.Color = "Orange";
 
                 tim.DogsDictionary[pipi.Name] = pipi;
@@ -445,22 +446,22 @@ namespace Realms.Tests.Database
             });
 
             Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.DogsDictionary["Pipilotta"].Name, Is.EqualTo("Pipilotta"));
+            Assert.That(tim.DogsDictionary[PipilottasName].Name, Is.EqualTo(PipilottasName));
 
             Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.TagsDictionary["Pipilotta"], Is.EqualTo("cheerful"));
+            Assert.That(tim.TagsDictionary[PipilottasName], Is.EqualTo("cheerful"));
 
             _realm.Write(() =>
             {
-                tim.DogsDictionary["Pipilotta"] = null;
-                tim.TagsDictionary["Pipilotta"] = null;
+                tim.DogsDictionary[PipilottasName] = null;
+                tim.TagsDictionary[PipilottasName] = null;
             });
 
             Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.DogsDictionary["Pipilotta"], Is.Null);
+            Assert.That(tim.DogsDictionary[PipilottasName], Is.Null);
 
             Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.TagsDictionary["Pipilotta"], Is.Null);
+            Assert.That(tim.TagsDictionary[PipilottasName], Is.Null);
         }
 
         [Test]
@@ -471,24 +472,24 @@ namespace Realms.Tests.Database
             _realm.Write(() =>
             {
                 var pipi = _realm.DynamicApi.CreateObject("DynamicDog", null);
-                pipi.Name = "Pipilotta";
+                pipi.Name = PipilottasName;
                 pipi.Color = "Orange";
 
-                tim.DogsDictionary.Add("Pipilotta", pipi);
-                tim.TagsDictionary.Add("Pipilotta", "cheerful");
+                tim.DogsDictionary.Add(PipilottasName, pipi);
+                tim.TagsDictionary.Add(PipilottasName, "cheerful");
             });
 
             Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.DogsDictionary["Pipilotta"].Name, Is.EqualTo("Pipilotta"));
+            Assert.That(tim.DogsDictionary[PipilottasName].Name, Is.EqualTo(PipilottasName));
 
             Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.TagsDictionary["Pipilotta"], Is.EqualTo("cheerful"));
+            Assert.That(tim.TagsDictionary[PipilottasName], Is.EqualTo("cheerful"));
 
             Assert.Throws<ArgumentException>(() =>
             {
                 _realm.Write(() =>
                 {
-                    tim.DogsDictionary.Add("Pipilotta", null);
+                    tim.DogsDictionary.Add(PipilottasName, null);
                 });
             }, $"An item with the key 'Pipilotta' has already been added.");
 
@@ -496,15 +497,15 @@ namespace Realms.Tests.Database
             {
                 _realm.Write(() =>
                 {
-                    tim.TagsDictionary.Add("Pipilotta", null);
+                    tim.TagsDictionary.Add(PipilottasName, null);
                 });
             }, $"An item with the key 'Pipilotta' has already been added.");
 
             Assert.That(tim.DogsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.DogsDictionary["Pipilotta"], Is.Not.Null);
+            Assert.That(tim.DogsDictionary[PipilottasName], Is.Not.Null);
 
             Assert.That(tim.TagsDictionary.Count, Is.EqualTo(3));
-            Assert.That(tim.TagsDictionary["Pipilotta"], Is.EqualTo("cheerful"));
+            Assert.That(tim.TagsDictionary[PipilottasName], Is.EqualTo("cheerful"));
 
             _realm.Write(() =>
             {


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Will rebase after https://github.com/realm/realm-dotnet/pull/2214 is merged.

Adds support for dynamic dictionaries except dictionaries of embedded objects. This will come later.

Fixes https://github.com/realm/realm-dotnet/issues/2208.

##  TODO

* [ ] Changelog entry
* [x] Tests (if applicable)
