### PR TITLE
Move all realm.io links to mongodb docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,7 +648,7 @@ add as many subscriptions to a synced Realm as necessary. ([#1580](https://githu
 - Added a check to verify there are no duplicate object names when creating the schema. ([#1502](https://github.com/realm/realm-dotnet/pull/1502))
 - Added more comprehensive error messages when passing an invalid url scheme to `SyncConfiguration` or `User.LoginAsync`. ([#1501](https://github.com/realm/realm-dotnet/pull/1501))
 - Added more meaningful error information to exceptions thrown by `Realm.GetInstanceAsync`. ([#1503](https://github.com/realm/realm-dotnet/pull/1503))
-- Added a new type - `RealmInteger<T>` to expose Realm-specific API over base integral types. It can be used to implement [counter functionality](https://IDontThinkThisExists) in synced realms. ([#1466](https://github.com/realm/realm-dotnet/pull/1466))
+- Added a new type - `RealmInteger<T>` to expose Realm-specific API over base integral types. It can be used to implement [counter functionality](https://docs.mongodb.com/realm-legacy/docs/dotnet/latest/index.html) in synced realms. ([#1466](https://github.com/realm/realm-dotnet/pull/1466))
 - Added `PermissionCondition.Default` to apply default permissions for existing and new users. ([#1511](https://github.com/realm/realm-dotnet/pull/1511))
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,7 +648,7 @@ add as many subscriptions to a synced Realm as necessary. ([#1580](https://githu
 - Added a check to verify there are no duplicate object names when creating the schema. ([#1502](https://github.com/realm/realm-dotnet/pull/1502))
 - Added more comprehensive error messages when passing an invalid url scheme to `SyncConfiguration` or `User.LoginAsync`. ([#1501](https://github.com/realm/realm-dotnet/pull/1501))
 - Added more meaningful error information to exceptions thrown by `Realm.GetInstanceAsync`. ([#1503](https://github.com/realm/realm-dotnet/pull/1503))
-- Added a new type - `RealmInteger<T>` to expose Realm-specific API over base integral types. It can be used to implement [counter functionality](https://realm.io/docs/realm-object-server/#counters) in synced realms. ([#1466](https://github.com/realm/realm-dotnet/pull/1466))
+- Added a new type - `RealmInteger<T>` to expose Realm-specific API over base integral types. It can be used to implement [counter functionality](https://IDontThinkThisExists) in synced realms. ([#1466](https://github.com/realm/realm-dotnet/pull/1466))
 - Added `PermissionCondition.Default` to apply default permissions for existing and new users. ([#1511](https://github.com/realm/realm-dotnet/pull/1511))
 
 ### Bug fixes
@@ -789,7 +789,7 @@ After about a year and a half of hard work, we are proud to call this a 1.0 rele
 
 ### Sync
 Realm Xamarin now works with the Realm Mobile Platform. This means that you can write Xamarin apps that synchronize seamlessly with a Realm Object Server, allowing you to write complex apps with Xamarin that are offline-first and automatically synchronised by adding just a few lines of code.
-You can read about this in the [documentation](https://realm.io/docs/xamarin/latest/#sync).
+You can read about this in the [documentation](https://docs.mongodb.com/realm/sync/get-started/).
 
 ### Windows Desktop
 Realm Xamarin is no longer iOS and Android only. You can now use it to write .NET programs for Windows Desktop. Add the NuGet package to your regular .NET project and start using Realm. Some features are not supported on Windows yet. Most notably, sync does not yet work for Windows, but also encryption and notifications across processes are missing. We are working on it and you can expect support soon.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository holds the source code for the .NET / C# versions of Realm. Curre
 ## Features
 
 * **Mobile-first:** Realm is the first database built from the ground up to run directly inside phones, tablets, and wearables.
-* **Simple:** Data is directly [exposed as objects](https://docs.mongodb.com/realm/dotnet/objects/) and [queryable by code](https://docs.mongodb.com/realm/dotnet/query-engine/), removing the need for ORM's riddled with performance & maintenance issues. Plus, we've worked hard to [keep our API down to just 3 common classes](https://docs.mongodb.com/realm-sdks/dotnet/latest/) (RealmObject, EmbeddedObject and Realm): most of our users pick it up intuitively, getting simple apps up & running in minutes.
+* **Simple:** Data is directly [exposed as objects](https://docs.mongodb.com/realm/dotnet/objects/) and [queryable by code](https://docs.mongodb.com/realm/dotnet/query-engine/), removing the need for ORM's riddled with performance & maintenance issues. Plus, we've worked hard to [keep our API down to just a few common classes](https://docs.mongodb.com/realm-sdks/dotnet/latest/): most of our users pick it up intuitively, getting simple apps up & running in minutes.
 * **Modern:** Realm supports relationships, generics, vectorization and modern C# idioms.
 * **Fast:** Realm is faster than even raw SQLite on common operations while maintaining an extremely rich feature set.
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 Realm is a mobile database that runs directly on phones, tablets or wearables.
 
-This repository holds the source code for the .NET / C# versions of Realm. Currently, we support all major mobile and desktop operating systems, such as iOS, Android, UWP, macOS, Linux, and Windows. For a full list of supported platforms and their versions, check out the [Prerequisites](https://realm.io/docs/dotnet/latest/#prerequisites) section in the documentation.
+This repository holds the source code for the .NET / C# versions of Realm. Currently, we support all major mobile and desktop operating systems, such as iOS, Android, UWP, macOS, Linux, and Windows. For a full list of supported platforms and their versions, check out the [Supported Platforms](https://docs.mongodb.com/realm/dotnet/#supported-platforms) sub-section in the documentation.
 
 ## Features
 
 * **Mobile-first:** Realm is the first database built from the ground up to run directly inside phones, tablets, and wearables.
-* **Simple:** Data is directly [exposed as objects](https://realm.io/docs/dotnet/latest/#models) and [queryable by code](https://realm.io/docs/dotnet/latest/#queries), removing the need for ORM's riddled with performance & maintenance issues. Plus, we've worked hard to [keep our API down to just 2 common classes](https://realm.io/docs/dotnet/latest/api/) (RealmObject and Realm): most of our users pick it up intuitively, getting simple apps up & running in minutes.
+* **Simple:** Data is directly [exposed as objects](https://docs.mongodb.com/realm/dotnet/objects/) and [queryable by code](https://docs.mongodb.com/realm/dotnet/query-engine/), removing the need for ORM's riddled with performance & maintenance issues. Plus, we've worked hard to [keep our API down to just 2 common classes](https://docs.mongodb.com/realm-sdks/dotnet/latest/) (RealmObject and Realm): most of our users pick it up intuitively, getting simple apps up & running in minutes.
 * **Modern:** Realm supports relationships, generics, vectorization and modern C# idioms.
 * **Fast:** Realm is faster than even raw SQLite on common operations while maintaining an extremely rich feature set.
 
 ## Getting Started
 
-Please see the detailed instructions in our [User Guide](https://realm.io/docs/dotnet/latest/#installation) to add Realm to your solution.
+Please see the detailed instructions in our [User Guide](https://docs.mongodb.com/realm/dotnet/install/) to add Realm to your solution.
 
 ## Documentation
 
-The documentation can be found at [realm.io/docs/dotnet/latest](https://realm.io/docs/dotnet/latest).
-The API reference is located at [realm.io/docs/dotnet/latest/api](https://realm.io/docs/dotnet/latest/api).
+The documentation can be found at [docs.mongodb.com/realm/dotnet/](https://docs.mongodb.com/realm/dotnet/).
+The API reference is located at [docs.mongodb.com/realm-sdks/dotnet/latest/](https://docs.mongodb.com/realm-sdks/dotnet/latest/).
 
 ## Getting Help
 
@@ -41,7 +41,7 @@ commit to the [GitHub packages](https://github.com/realm/realm-dotnet/packages) 
 
 ## Building Realm
 
-We highly recommend [using our pre-built binaries via NuGet](https://realm.io/docs/dotnet/latest/#installation) but you can also build from source.
+We highly recommend [using our pre-built binaries via NuGet](https://docs.mongodb.com/realm/dotnet/install/#open-the-nuget-package-manager) but you can also build from [source](https://github.com/realm/realm-dotnet).
 
 Prerequisites:
 
@@ -61,7 +61,7 @@ If you are actively testing code against the Realm source, see also the unit tes
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details!
 
-This project adheres to the [Contributor Covenant Code of Conduct](https://realm.io/conduct).
+This project adheres to the [Contributor Covenant Code of Conduct](https://www.mongodb.com/community-code-of-conduct).
 By participating, you are expected to uphold this code. Please report
 unacceptable behavior to [info@realm.io](mailto:info@realm.io).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository holds the source code for the .NET / C# versions of Realm. Curre
 ## Features
 
 * **Mobile-first:** Realm is the first database built from the ground up to run directly inside phones, tablets, and wearables.
-* **Simple:** Data is directly [exposed as objects](https://docs.mongodb.com/realm/dotnet/objects/) and [queryable by code](https://docs.mongodb.com/realm/dotnet/query-engine/), removing the need for ORM's riddled with performance & maintenance issues. Plus, we've worked hard to [keep our API down to just 2 common classes](https://docs.mongodb.com/realm-sdks/dotnet/latest/) (RealmObject and Realm): most of our users pick it up intuitively, getting simple apps up & running in minutes.
+* **Simple:** Data is directly [exposed as objects](https://docs.mongodb.com/realm/dotnet/objects/) and [queryable by code](https://docs.mongodb.com/realm/dotnet/query-engine/), removing the need for ORM's riddled with performance & maintenance issues. Plus, we've worked hard to [keep our API down to just 3 common classes](https://docs.mongodb.com/realm-sdks/dotnet/latest/) (RealmObject, EmbeddedObject and Realm): most of our users pick it up intuitively, getting simple apps up & running in minutes.
 * **Modern:** Realm supports relationships, generics, vectorization and modern C# idioms.
 * **Fast:** Realm is faster than even raw SQLite on common operations while maintaining an extremely rich feature set.
 

--- a/Realm/Realm.Unity/package.json
+++ b/Realm/Realm.Unity/package.json
@@ -14,8 +14,7 @@
       "mongodb"
     ],
     "author": {
-      "name": "Realm",
-      "email": "help@realm.io",
-      "url": "https://realm.io"
+      "name": "MongoDB Realm",
+      "url": "https://docs.mongodb.com/realm/dotnet/"
     }
   }

--- a/Realm/Realm.Unity/package.json
+++ b/Realm/Realm.Unity/package.json
@@ -14,7 +14,8 @@
       "mongodb"
     ],
     "author": {
-      "name": "MongoDB Realm",
+      "name": "Realm",
+      "email": "something@domain.com",
       "url": "https://docs.mongodb.com/realm/dotnet/"
     }
   }

--- a/Realm/Realm.Unity/package.json
+++ b/Realm/Realm.Unity/package.json
@@ -15,7 +15,7 @@
     ],
     "author": {
       "name": "Realm",
-      "email": "something@domain.com",
+      "email": "realm-help@mongodb.com",
       "url": "https://docs.mongodb.com/realm/dotnet/"
     }
   }

--- a/Realm/Realm/Exceptions/ClientResetException.cs
+++ b/Realm/Realm/Exceptions/ClientResetException.cs
@@ -42,7 +42,7 @@ namespace Realms.Sync.Exceptions
             _originalFilePath = Path.GetFullPath(userInfo[OriginalFilePathKey]);
             _app = app;
             BackupFilePath = Path.GetFullPath(userInfo[BackupFilePathKey]);
-            HelpLink = "https://realm.io/docs/xamarin/latest/#client-reset";
+            HelpLink = "https://docs.mongodb.com/realm/dotnet/client-reset/";
         }
 
         /// <summary>

--- a/Realm/Realm/Exceptions/PermissionDeniedException.cs
+++ b/Realm/Realm/Exceptions/PermissionDeniedException.cs
@@ -51,7 +51,7 @@ namespace Realms.Sync.Exceptions
         {
             _originalFilePath = userInfo[OriginalFilePathKey];
             _app = app;
-            HelpLink = "https://realm.io/docs/xamarin/latest/#access-control";
+            HelpLink = "https://docs.mongodb.com/realm/sync/permissions/";
         }
 
         /// <summary>

--- a/Realm/Realm/Exceptions/RealmClassLacksPrimaryKeyException.cs
+++ b/Realm/Realm/Exceptions/RealmClassLacksPrimaryKeyException.cs
@@ -25,7 +25,7 @@ namespace Realms.Exceptions
     {
         internal RealmClassLacksPrimaryKeyException(string message) : base(message)
         {
-            HelpLink = "https://realm.io/docs/xamarin/latest/#primarykey-properties";
+            HelpLink = "https://docs.mongodb.com/realm/dotnet/objects/#primary-key";
         }
     }
 }

--- a/Realm/Realm/Exceptions/RealmDuplicatePrimaryKeyValueException.cs
+++ b/Realm/Realm/Exceptions/RealmDuplicatePrimaryKeyValueException.cs
@@ -25,7 +25,7 @@ namespace Realms.Exceptions
     {
         internal RealmDuplicatePrimaryKeyValueException(string message) : base(message)
         {
-            HelpLink = "https://realm.io/docs/xamarin/latest/#primarykey-properties";
+            HelpLink = "https://docs.mongodb.com/realm/dotnet/objects/#primary-key";
         }
     }
 }

--- a/Realm/Realm/Exceptions/RealmMigrationNeededException.cs
+++ b/Realm/Realm/Exceptions/RealmMigrationNeededException.cs
@@ -21,12 +21,12 @@ namespace Realms.Exceptions
     /// <summary>
     /// Exception thrown when attempting to open a file whose <see cref="Realms.Schema.RealmSchema"/> differs from your current class declarations.
     /// </summary>
-    /// <seealso href="https://realm.io/docs/xamarin/latest/#migrations">Read more about Migrations.</seealso>
+    /// <seealso href="https://docs.mongodb.com/realm/dotnet/migrations/">Read more about Migrations.</seealso>
     public class RealmMigrationNeededException : RealmFileAccessErrorException
     {
         internal RealmMigrationNeededException(string message) : base(message)
         {
-            HelpLink = "https://realm.io/docs/xamarin/latest/#migrations";
+            HelpLink = "https://docs.mongodb.com/realm/dotnet/migrations/";
         }
     }
 }

--- a/Realm/Realm/Helpers/AsyncHelper.cs
+++ b/Realm/Realm/Helpers/AsyncHelper.cs
@@ -34,7 +34,7 @@ namespace Realms.Helpers
             {
                 throw new NotSupportedException(MissingContextErrorMessage)
                 {
-                    HelpLink = "https://realm.io/docs/dotnet/latest/#threading"
+                    HelpLink = "https://docs.mongodb.com/realm/dotnet/threading/"
                 };
             }
         }

--- a/Realm/Realm/Migration.cs
+++ b/Realm/Realm/Migration.cs
@@ -31,7 +31,7 @@ namespace Realms
     /// You can read from the <see cref="OldRealm"/> and access properties that have been removed from
     /// the classes by using the dynamic API.
     /// </summary>
-    /// <seealso href="https://realm.io/docs/xamarin/latest/#migrations">See more in the migrations section in the documentation.</seealso>
+    /// <seealso href="https://docs.mongodb.com/realm/dotnet/migrations">See more in the migrations section in the documentation.</seealso>
     public class Migration
     {
         private readonly RealmConfiguration _configuration;

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8.0</LangVersion>
     <Title>Realm</Title>
-    <ReleaseNotes>https://realm.io/docs/dotnet/latest/api/CHANGELOG.html</ReleaseNotes>
+    <ReleaseNotes>https://docs.mongodb.com/realm-sdks/dotnet/latest/CHANGELOG.html</ReleaseNotes>
     <CodeAnalysisRuleSet>$(ProjectDir)..\..\global.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/Realm/Realm/Schema/ObjectSchema.cs
+++ b/Realm/Realm/Schema/ObjectSchema.cs
@@ -175,7 +175,7 @@ namespace Realms.Schema
                 if (Count == 0)
                 {
                     throw new InvalidOperationException(
-                        $"No properties in {Name}, has linker stripped it? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");
+                        $"No properties in {Name}, has linker stripped it? See https://thereIsntSuchDocYet");
                 }
 
                 return new ObjectSchema(Name, this.ToDictionary(p => p.Name))

--- a/Realm/Realm/Schema/RealmSchema.cs
+++ b/Realm/Realm/Schema/RealmSchema.cs
@@ -213,7 +213,7 @@ namespace Realms.Schema
                 if (Count == 0)
                 {
                     throw new InvalidOperationException(
-                        "No RealmObjects. Has linker stripped them? See https://realm.io/docs/xamarin/latest/#linker-stripped-schema");
+                        "No RealmObjects. Has linker stripped them? See https://thereIsntSuchDocYet");
                 }
 
                 return new RealmSchema(this);

--- a/Realm/Realm/Schema/RealmSchema.cs
+++ b/Realm/Realm/Schema/RealmSchema.cs
@@ -213,7 +213,7 @@ namespace Realms.Schema
                 if (Count == 0)
                 {
                     throw new InvalidOperationException(
-                        "No RealmObjects. Has linker stripped them? See https://thereIsntSuchDocYet");
+                        "No RealmObjects. Has linker stripped them? See https://docs.mongodb.com/realm-legacy/docs/dotnet/latest/#linker-stripped-schema");
                 }
 
                 return new RealmSchema(this);

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@ The Realm team is here to help you with your Realm-related issues!
 
 ## Documentation
 
-Before asking questions, please familiarize yourself with our [Xamarin (.NET)](https://realm.io/docs/xamarin/latest/) documentation. We also have a number of [Tech Notes](https://realm.io/docs/tech-notes/) which cover various topics that may be of interest.
+Before asking questions, please familiarize yourself with our [.NET SDK](https://docs.mongodb.com/realm/dotnet/) documentation. We also have a number of [Tech Notes](https://IDontThinkThisExists) which cover various topics that may be of interest.
 
 ## Stack Overflow
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@ The Realm team is here to help you with your Realm-related issues!
 
 ## Documentation
 
-Before asking questions, please familiarize yourself with our [.NET SDK](https://docs.mongodb.com/realm/dotnet/) documentation. We also have a number of [Tech Notes](https://IDontThinkThisExists) which cover various topics that may be of interest.
+Before asking questions, please familiarize yourself with our [.NET SDK](https://docs.mongodb.com/realm/dotnet/) documentation.
 
 ## Stack Overflow
 


### PR DESCRIPTION
## Description
Move all realm.io links to mongodb docs

I couldn't find some information, I was thinking to contact the docs team to ask. If you @nirinchev know already that some should not exist anymore, then I'll just rearrange the documents to rephrase/remove the links.

The changes were made on entries coming from the following command:
`grep -rin --exclude-dir={Docs,obj,bin,realm-core} "https://realm.io*" .`
executed at the highest level of realm-dotnet folder.

Fixes #2143 

##  TODO
* [ ] Changelog entry  --> I don't believe there's anything to write
