### PR TITLE
Remove Realm states dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Internal
 * Using Core 11.0.4.
+* Removed the RealmStates dictionary that used to hold a threadlocal dictionary of all the states for the opened Realms. It was only used for detecting open Realms during deletion and that is now handled by the native `delete_realm_files` method. (PR [#2251](https://github.com/realm/realm-dotnet/pull/2251))
 
 ## 10.3.0 (2021-07-07)
 

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -220,7 +220,7 @@ namespace Realms
         {
         }
 
-        public virtual bool CanCache => true;
+        public virtual bool OwnsNativeRealm => true;
 
         protected override void Unbind()
         {

--- a/Realm/Realm/Handles/UnownedRealmHandle.cs
+++ b/Realm/Realm/Handles/UnownedRealmHandle.cs
@@ -28,7 +28,7 @@ namespace Realms
         {
         }
 
-        public override bool CanCache => false;
+        public override bool OwnsNativeRealm => false;
 
         protected override void Unbind()
         {

--- a/Realm/Realm/Helpers/Operator.tt
+++ b/Realm/Realm/Helpers/Operator.tt
@@ -41,7 +41,7 @@ namespace Realms.Helpers
         private static IDictionary<(Type, Type), IConverter> _valueConverters = new Dictionary<(Type, Type), IConverter>
         {
 <#
-            var realmValueContents = GetFileContents("..\\DatabaseTypes\\RealmValue.cs");
+            var realmValueContents = GetFileContents("../DatabaseTypes/RealmValue.cs");
             var implicitToRealmValueTypes = GetMatchedGroups(realmValueContents, _implicitTypeToRealmValueRegex, "fromType");
             foreach (var type in implicitToRealmValueTypes)
             {

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -233,7 +233,7 @@ namespace Realms
         {
             Config = config;
 
-            if (config.EnableCache && sharedRealmHandle.CanCache)
+            if (config.EnableCache && sharedRealmHandle.OwnsNativeRealm)
             {
                 var statePtr = sharedRealmHandle.GetManagedStateHandle();
                 if (statePtr != IntPtr.Zero)
@@ -355,7 +355,11 @@ namespace Realms
         {
             if (!IsClosed)
             {
-                _state.RemoveRealm(this);
+                if (SharedRealmHandle.OwnsNativeRealm)
+                {
+                    _state.RemoveRealm(this);
+                }
+
                 _state = null;
                 SharedRealmHandle.Close();  // Note: this closes the *handle*, it does not trigger realm::Realm::close().
             }

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -245,7 +245,7 @@ namespace Realms
             if (_state == null)
             {
                 _state = new State();
-                sharedRealmHandle.SetManagedStateHandle(GCHandle.ToIntPtr(_state.GCHandle));
+                sharedRealmHandle.SetManagedStateHandle(_state);
             }
 
             _state.AddRealm(this);


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

While investigating https://github.com/realm/realm-dotnet/issues/2224, I spent quite some time convincing myself that the Realm lifecycle is correct. While I couldn't find issues with it, I noticed that the `_states` dictionary approach was wrong. It relied on a ThreadLocal dictionary to hold the states for the current thread, but that is no longer safe since a Realm file may be opened/used across different threads as long as the synchronization context is the same. This was only used for the open Realm detection which should be moved to OS once https://github.com/realm/realm-core/issues/4424 is merged.

Fixes https://github.com/realm/realm-dotnet/issues/2198 (doesn't do anything to fix it per se, but adds a thorough explanation why it's not a problem).

##  TODO

* [x] Changelog entry
* [ ] Tests (if applicable)
