### PR TITLE
Assorted test-related improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Fixed an issue that would result in UWP apps being rejected from the Microsoft Store due to an unsupported API (`__C_specific_handler`) being used. (Issue [#2235](https://github.com/realm/realm-dotnet/issues/2235))
+* Fixed a bug where applying multiple `OrderBy` clauses on a query would result in the clauses being appended to each other as if they were `.ThenBy` rather than the last clause replacing the preceding ones. (PR [#2255](https://github.com/realm/realm-dotnet/issues/2255))
 
 ### Enhancements
 * Add support for the `Guid` data type. It can be used as primary key and is indexable. (PR [#2120](https://github.com/realm/realm-dotnet/pull/2120))

--- a/Realm/Realm/Exceptions/RealmException.cs
+++ b/Realm/Realm/Exceptions/RealmException.cs
@@ -86,8 +86,6 @@ namespace Realms.Exceptions
                     return new RealmInvalidTransactionException(message);
 
                 case RealmExceptionCodes.RealmFormatUpgradeRequired:
-                    return new RealmException(message);  // rare unrecoverable case for now
-
                 case RealmExceptionCodes.RealmSchemaMismatch:
                     return new RealmMigrationNeededException(message);
 

--- a/Realm/Realm/Handles/SortDescriptorHandle.cs
+++ b/Realm/Realm/Handles/SortDescriptorHandle.cs
@@ -32,7 +32,7 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "sort_descriptor_add_clause", CallingConvention = CallingConvention.Cdecl)]
             public static extern void add_clause(SortDescriptorHandle descriptor, TableKey table_key, SharedRealmHandle realm,
                 [MarshalAs(UnmanagedType.LPArray), In] IntPtr[] property_index_chain, IntPtr column_keys_count,
-                [MarshalAs(UnmanagedType.U1)] bool ascending,
+                [MarshalAs(UnmanagedType.U1)] bool ascending, [MarshalAs(UnmanagedType.U1)] bool replacing,
                 out NativeException ex);
         }
 
@@ -40,9 +40,9 @@ namespace Realms
         {
         }
 
-        public void AddClause(SharedRealmHandle realm, TableKey tableKey, IntPtr[] propertyIndexChain, bool ascending)
+        public void AddClause(SharedRealmHandle realm, TableKey tableKey, IntPtr[] propertyIndexChain, bool ascending, bool replacing)
         {
-            NativeMethods.add_clause(this, tableKey, realm, propertyIndexChain, (IntPtr)propertyIndexChain.Length, ascending, out var nativeException);
+            NativeMethods.add_clause(this, tableKey, realm, propertyIndexChain, (IntPtr)propertyIndexChain.Length, ascending, replacing, out var nativeException);
             nativeException.ThrowIfNecessary();
         }
 

--- a/Tests/Realm.Tests/Database/CollectionTests.cs
+++ b/Tests/Realm.Tests/Database/CollectionTests.cs
@@ -246,7 +246,7 @@ namespace Realms.Tests.Database
             Assert.That(items, Is.EqualTo(Enumerable.Range(0, 10)));
         }
 
-        [Test, Ignore("Regression in Core, unignore when https://github.com/realm/realm-core/pull/4122 is merged.")]
+        [Test]
         public void ObjectList_WhenEnumeratingAndRemovingFromRealm_ShouldBeStable()
         {
             var container = new ContainerObject();

--- a/Tests/Realm.Tests/Database/ConfigurationTests.cs
+++ b/Tests/Realm.Tests/Database/ConfigurationTests.cs
@@ -21,7 +21,6 @@ using System.IO;
 using NUnit.Framework;
 using Realms;
 using Realms.Exceptions;
-using TestExplicitAttribute = NUnit.Framework.ExplicitAttribute;
 
 namespace Realms.Tests.Database
 {
@@ -188,7 +187,7 @@ namespace Realms.Tests.Database
             Assert.That(() => GetRealm(_configuration), Throws.TypeOf<RealmFileNotFoundException>());
         }
 
-        [Test, TestExplicit("Currently, a RealmMismatchedConfigException is thrown. Registered as #580")]
+        [Test]
         public void ReadOnlyRealmsWillNotAutoMigrate()
         {
             // Arrange

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -315,21 +315,21 @@ namespace Realms.Tests.Database
             });
         }
 
-        [Test, Ignore("Currently doesn't work. Ref #947")]
-        public void Compact_WhenOpenOnSameThread_ShouldReturnFalse()
+        [Test]
+        public void Compact_WhenOpenOnSameThread_ShouldReturnTrue()
         {
-            // TODO: enable when we implement instance caching (#947)
-            // This works because of caching of native instances in ObjectStore.
-            // Technically, we get the same native instance, so Compact goes through.
-            // However, this invalidates the opened realm, but we have no way of communicating that.
-            // That is why, things seem fine until we try to run queries on the opened realm.
-            // Once we handle caching in managed, we should reenable the test.
             using var realm = GetRealm();
 
             var initialSize = new FileInfo(realm.Config.DatabasePath).Length;
-            Assert.That(() => Realm.Compact(), Is.False);
+            Assert.That(() => Realm.Compact(), Is.True);
             var finalSize = new FileInfo(realm.Config.DatabasePath).Length;
-            Assert.That(finalSize, Is.EqualTo(initialSize));
+            Assert.That(finalSize, Is.LessThanOrEqualTo(initialSize));
+
+            // Test that the Realm instance is still valid and we can write to it
+            realm.Write(() =>
+            {
+                realm.Add(new Person());
+            });
         }
 
         [Test]

--- a/Tests/Realm.Tests/Database/LifetimeTests.cs
+++ b/Tests/Realm.Tests/Database/LifetimeTests.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Realms.Tests.Database
@@ -34,8 +35,6 @@ namespace Realms.Tests.Database
         [Test]
         public void RealmObjectsShouldKeepRealmAlive()
         {
-            TestHelpers.IgnoreOnWindows("GC blocks on Windows");
-
             // Arrange
             var realm = GetWeakRealm();
             Person person = null;
@@ -60,8 +59,6 @@ namespace Realms.Tests.Database
         [Test]
         public void FinalizedRealmsShouldNotInvalidateSiblingRealms()
         {
-            TestHelpers.IgnoreOnWindows("GC blocks on Windows");
-
             // Arrange
             using var realm = Realm.GetInstance(RealmConfiguration.DefaultConfiguration.DatabasePath);
             var realmThatWillBeFinalized = GetWeakRealm();
@@ -83,14 +80,12 @@ namespace Realms.Tests.Database
         [Test]
         public void TransactionShouldHoldStrongReferenceToRealm()
         {
-            TestHelpers.IgnoreOnWindows("GC blocks on Windows");
-
             TestHelpers.RunAsyncTest(async () =>
             {
                 var realm = GetWeakRealm();
                 var transaction = CreateTransaction();
 
-                await System.Threading.Tasks.Task.Yield();
+                await Task.Yield();
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();

--- a/Tests/Realm.Tests/Database/ObjectIntegrationTests.cs
+++ b/Tests/Realm.Tests/Database/ObjectIntegrationTests.cs
@@ -17,40 +17,15 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using Realms.Exceptions;
-using TestExplicitAttribute = NUnit.Framework.ExplicitAttribute;
 
 namespace Realms.Tests.Database
 {
     [TestFixture, Preserve(AllMembers = true)]
     public class ObjectIntegrationTests : PeopleTestsBase
     {
-        [Test, TestExplicit("Manual test for debugging")]
-        public void SimpleTest()
-        {
-            MakeThreePeople();
-            var allPeople = _realm.All<Person>().Count();
-            Debug.WriteLine($"There are {allPeople} in total");
-
-            var interestingPeople = from p in _realm.All<Person>() where p.IsInteresting select p;
-
-            Debug.WriteLine("Interesting people include:");
-            foreach (var p in interestingPeople)
-            {
-                Debug.WriteLine(" - " + p.FullName + " (" + p.Email + ")");
-            }
-
-            var johns = from p in _realm.All<Person>() where p.FirstName == "John" select p;
-            Debug.WriteLine("People named John:");
-            foreach (var p in johns)
-            {
-                Debug.WriteLine(" - " + p.FullName + " (" + p.Email + ")");
-            }
-        }
-
         // Test added to ensure there were no side-effects immedately after a Rollback
         [Test]
         public void CreateObjectAfterRollbackTest()

--- a/Tests/Realm.Tests/Database/Person.cs
+++ b/Tests/Realm.Tests/Database/Person.cs
@@ -107,5 +107,7 @@ namespace Realms.Tests.Database
         }
 
         public IList<Person> Friends { get; }
+
+        public override string ToString() => $"{FirstName} {LastName}";
     }
 }

--- a/Tests/Realm.Tests/Database/PropertyChangedTests.cs
+++ b/Tests/Realm.Tests/Database/PropertyChangedTests.cs
@@ -241,8 +241,6 @@ namespace Realms.Tests.Database
         [Test]
         public void MultipleManagedObjects()
         {
-            TestHelpers.IgnoreOnWindows("ExternalCommitHelper hangs on Windows in this test. Reenable when we have proper condvar.");
-
             var firstNotifiedPropertyNames = new List<string>();
             var secondNotifiedPropertyNames = new List<string>();
             var first = new Person();
@@ -405,33 +403,29 @@ namespace Realms.Tests.Database
         [Test]
         public void ManagedObject_WhenHandleIsReleased_ShouldNotReceiveNotifications()
         {
-            TestHelpers.IgnoreOnWindows("GC blocks on Windows");
-
             TestHelpers.RunAsyncTest(async () =>
             {
                 var notifiedPropertyNames = new List<string>();
                 WeakReference personReference = null;
-                new Action(() =>
+                var person = new Person();
+                _realm.Write(() => _realm.Add(person));
+
+                person.PropertyChanged += (sender, e) =>
                 {
-                    var person = new Person();
-                    _realm.Write(() => _realm.Add(person));
+                    notifiedPropertyNames.Add(e.PropertyName);
+                };
 
-                    person.PropertyChanged += (sender, e) =>
-                    {
-                        notifiedPropertyNames.Add(e.PropertyName);
-                    };
+                personReference = new WeakReference(person);
 
-                    personReference = new WeakReference(person);
+                _realm.Write(() => person.FirstName = "Peter");
 
-                    _realm.Write(() => person.FirstName = "Peter");
-
-                    // Sanity check
-                    _realm.Refresh();
-                    Assert.That(notifiedPropertyNames, Is.EquivalentTo(new[] { nameof(Person.FirstName) }));
-                })();
+                // Sanity check
+                _realm.Refresh();
+                Assert.That(notifiedPropertyNames, Is.EquivalentTo(new[] { nameof(Person.FirstName) }));
 
                 notifiedPropertyNames.Clear();
 
+                person = null;
                 while (personReference.IsAlive)
                 {
                     await Task.Yield();
@@ -688,7 +682,7 @@ namespace Realms.Tests.Database
             person.PropertyChanged -= handler;
         }
 
-        [Test, NUnit.Framework.Explicit("After remove + rollback, the object handle is invalid - https://github.com/realm/realm-dotnet/issues/1332")]
+        [Test, Ignore("After remove + rollback, the object handle is invalid - https://github.com/realm/realm-dotnet/issues/1332")]
         public void ManagedObject_WhenSubscribedDuringDeletion_AfterRollback_ShouldReceiveNotifications()
         {
             var notifiedPropertyNames = new List<string>();

--- a/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
@@ -20,7 +20,6 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using Realms.Exceptions;
-using TestExplicitAttribute = NUnit.Framework.ExplicitAttribute;
 
 namespace Realms.Tests.Database
 {
@@ -1044,23 +1043,6 @@ namespace Realms.Tests.Database
             Assert.That(query.ElementAt(0).FullName, Is.EqualTo(arr[0].FullName));
             Assert.That(query.ElementAt(1).FullName, Is.EqualTo(arr[1].FullName));
             Assert.That(query.ElementAt(2).FullName, Is.EqualTo(arr[2].FullName));
-        }
-
-        // note that DefaultIfEmpty returns a collection of one item
-        [Test, TestExplicit("Currently broken and hard to implement")]
-        public void DefaultIfEmptyReturnsDefault()
-        {
-            /*
-             * This is comprehensively broken and awkward to fix in our current architecture.
-             * Looking at the test code below, the Count is invoked on a RealmResults and directly
-             * invokes its query handle, which of course has zero elements.
-             * One posible approach is to toggle the RealmResults into a special state where
-             * it acts as a generator for a single null pointer.*
-             */
-            var expectCollectionOfOne = _realm.All<Person>().Where(p => p.FirstName == "Just Some Guy").DefaultIfEmpty();
-            Assert.That(expectCollectionOfOne.Count(), Is.EqualTo(1));
-            var expectedDef = expectCollectionOfOne.Single();
-            Assert.That(expectedDef, Is.Null);
         }
 
         [Test]

--- a/Tests/Realm.Tests/Sync/SyncTestBase.cs
+++ b/Tests/Realm.Tests/Sync/SyncTestBase.cs
@@ -56,12 +56,12 @@ namespace Realms.Tests.Sync
 
         protected override void CustomTearDown()
         {
-            base.CustomTearDown();
-
             foreach (var session in _sessions)
             {
                 session?.CloseHandle();
             }
+
+            base.CustomTearDown();
 
             foreach (var app in _apps)
             {

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -215,8 +214,7 @@ namespace Realms.Tests.Sync
             Assert.That(realm.Schema, Is.Empty);
         }
 
-        [Test]
-        [Ignore("doesn't work due to a OS bug")]
+        [Test, Ignore("Doesn't work due to a OS bug")]
         public void InvalidSchemaChange_RaisesClientReset()
         {
             SyncTestHelpers.RunBaasTestAsync(async () =>
@@ -270,42 +268,6 @@ namespace Realms.Tests.Sync
                 Assert.That(clientEx.InitiateClientReset(), Is.True);
 
                 Assert.That(File.Exists(realmPath), Is.False);
-            });
-        }
-
-        [Test, NUnit.Framework.Explicit("Requires debugger and a lot of manual steps")]
-        public void TestManualClientResync()
-        {
-            SyncTestHelpers.RunBaasTestAsync(async () =>
-            {
-                var config = await GetIntegrationConfigAsync();
-
-                Realm.DeleteRealm(config);
-                using (var realm = await Realm.GetInstanceAsync(config))
-                {
-                    realm.Write(() =>
-                    {
-                        realm.Add(new IntPrimaryKeyWithValueObject());
-                    });
-
-                    await WaitForUploadAsync(realm);
-                }
-
-                // Delete Realm in ROS
-                Debugger.Break();
-
-                Exception ex = null;
-                Session.Error += (s, e) =>
-                {
-                    ex = e.Exception;
-                };
-
-                using (var realm = Realm.GetInstance(config))
-                {
-                    await Task.Delay(100);
-                }
-
-                Assert.That(ex, Is.InstanceOf<ClientResetException>());
             });
         }
 

--- a/Tests/Realm.Tests/Sync/UserManagementTests.cs
+++ b/Tests/Realm.Tests/Sync/UserManagementTests.cs
@@ -425,11 +425,11 @@ namespace Realms.Tests.Sync
                 Assert.That(user.Profile.MaxAge, Is.EqualTo("90"));
                 Assert.That(user.Profile.PictureUrl.AbsoluteUri, Is.EqualTo("https://doe.com/mypicture"));
 
-                // TODO: add other checks once https://github.com/realm/realm-object-store/issues/1123 is implemented.
+                // TODO: add other checks once https://github.com/realm/realm-core/issues/4131 is implemented.
             });
         }
 
-        [Test, NUnit.Framework.Explicit("Requires manually getting a fb token")]
+        [Test, Ignore("Requires manually getting a fb token")]
         public void User_Facebook_LogsInAndReadsDataFromFacebook()
         {
             SyncTestHelpers.RunBaasTestAsync(async () =>

--- a/Tests/Realm.Tests/TestHelpers.cs
+++ b/Tests/Realm.Tests/TestHelpers.cs
@@ -142,14 +142,6 @@ namespace Realms.Tests
             }
         }
 
-        public static void IgnoreOnWindows(string message)
-        {
-            if (IsWindows)
-            {
-                Assert.Ignore(message);
-            }
-        }
-
         public static void IgnoreOnAOT(string message)
         {
             if (IsAOTTarget)

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -388,17 +388,6 @@ namespace RealmWeaver
         }
 
         [Test]
-        [Ignore("IList property tests still missing")]
-        public void SetManyRelationship()
-        {
-            // Arrange
-            var o = (dynamic)Activator.CreateInstance(_assembly.GetType("AssemblyToProcess.Person"));
-            var pn1 = (dynamic)Activator.CreateInstance(_assembly.GetType("AssemblyToProcess.PhoneNumber"));
-            var pn2 = (dynamic)Activator.CreateInstance(_assembly.GetType("AssemblyToProcess.PhoneNumber"));
-            o.IsManaged = true;
-        }
-
-        [Test]
         public void ShouldNotWeaveIgnoredProperties()
         {
             // Arrange

--- a/wrappers/android.Dockerfile
+++ b/wrappers/android.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:21.04
 
 # Keep the packages in alphabetical order to make it easy to avoid duplication
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \

--- a/wrappers/src/sort_descriptor_cs.cpp
+++ b/wrappers/src/sort_descriptor_cs.cpp
@@ -35,7 +35,7 @@ REALM_EXPORT void sort_descriptor_destroy(DescriptorOrdering* descriptor)
     delete descriptor;
 }
 
-REALM_EXPORT void sort_descriptor_add_clause(DescriptorOrdering& descriptor, TableKey table_key, SharedRealm& realm, size_t* property_chain, size_t properties_count, bool ascending, NativeException::Marshallable& ex)
+REALM_EXPORT void sort_descriptor_add_clause(DescriptorOrdering& descriptor, TableKey table_key, SharedRealm& realm, size_t* property_chain, size_t properties_count, bool ascending, bool replacing, NativeException::Marshallable& ex)
 {
     handle_errors(ex, [&]() {
         std::vector<ColKey> column_keys;
@@ -52,7 +52,7 @@ REALM_EXPORT void sort_descriptor_add_clause(DescriptorOrdering& descriptor, Tab
             }
         }
 
-        descriptor.append_sort(SortDescriptor({ column_keys }, { ascending }), SortDescriptor::MergeMode::append);
+        descriptor.append_sort(SortDescriptor({ column_keys }, { ascending }), replacing ? SortDescriptor::MergeMode::replace : SortDescriptor::MergeMode::append);
     });
 }
 


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This is mostly a cleanup PR that achieves the following:
* Fixes `OrderBy(...).OrderBy(...)` query chains by having the last clause replace all preceding ones.
* Reenables all previously disabled Windows tests. They seem to pass locally.
* Reenable all previously explicit tests that have been fixed. Explicit tests that haven't been fixed are [Ignore]-d
* Reenable some previously [Ignore]-d tests that have been fixed.
* Throws `RealmMigrationNeededException` when opening a readonly file that uses an old core format.

##  TODO

* [x] Changelog entry
