### PR TITLE
Pass in correct schema type for explicit and autodiscovered types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixed
 * Fixed an issue that would result in UWP apps being rejected from the Microsoft Store due to an unsupported API (`__C_specific_handler`) being used. (Issue [#2235](https://github.com/realm/realm-dotnet/issues/2235))
 * Fixed a bug where applying multiple `OrderBy` clauses on a query would result in the clauses being appended to each other as if they were `.ThenBy` rather than the last clause replacing the preceding ones. (PR [#2255](https://github.com/realm/realm-dotnet/issues/2255))
-* Fixed proper selection of Additive mode (Explicit or Discovered) to pass to the schema builder. This selection is based on whether or not the user has provided a subset of classes to the Realm Schema. More info about this subject can be found [here](https://docs.mongodb.com/realm/dotnet/objects/#provide-a-subset-of-classes-to-your-realm-schema). (PR [#2259](https://github.com/realm/realm-dotnet/pull/2259))
+* When explicitly specifying `SyncConfiguration.ObjectTypes`, added a check to validate the schema and ensure all `EmbeddedObject` classes are reachable from a class inheriting from `RealmObject`. More info about this subject can be found [here](https://docs.mongodb.com/realm/dotnet/objects/#provide-a-subset-of-classes-to-your-realm-schema). (PR [#2259](https://github.com/realm/realm-dotnet/pull/2259))
 
 ### Enhancements
 * Add support for the `Guid` data type. It can be used as primary key and is indexable. (PR [#2120](https://github.com/realm/realm-dotnet/pull/2120))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 * Fixed an issue that would result in UWP apps being rejected from the Microsoft Store due to an unsupported API (`__C_specific_handler`) being used. (Issue [#2235](https://github.com/realm/realm-dotnet/issues/2235))
 * Fixed a bug where applying multiple `OrderBy` clauses on a query would result in the clauses being appended to each other as if they were `.ThenBy` rather than the last clause replacing the preceding ones. (PR [#2255](https://github.com/realm/realm-dotnet/issues/2255))
+* Fixed proper selection of Additive mode (Explicit or Discovered) to pass to the schema builder. This selection is based on whether or not the user has provided a subset of classes to the Realm Schema. More info about this subject can be found [here](https://docs.mongodb.com/realm/dotnet/objects/#provide-a-subset-of-classes-to-your-realm-schema). (PR [#2259](https://github.com/realm/realm-dotnet/pull/2259))
 
 ### Enhancements
 * Add support for the `Guid` data type. It can be used as primary key and is indexable. (PR [#2120](https://github.com/realm/realm-dotnet/pull/2120))

--- a/Realm/Realm/Configurations/InMemoryConfiguration.cs
+++ b/Realm/Realm/Configurations/InMemoryConfiguration.cs
@@ -49,7 +49,7 @@ namespace Realms
 
         internal override Realm CreateRealm(RealmSchema schema)
         {
-            var configuration = CreateConfiguration();
+            var configuration = CreateNativeConfiguration();
             configuration.in_memory = true;
 
             var srPtr = SharedRealmHandle.Open(configuration, schema, EncryptionKey);

--- a/Realm/Realm/Configurations/RealmConfiguration.cs
+++ b/Realm/Realm/Configurations/RealmConfiguration.cs
@@ -125,7 +125,7 @@ namespace Realms
 
         internal override Realm CreateRealm(RealmSchema schema)
         {
-            var configuration = CreateConfiguration();
+            var configuration = CreateNativeConfiguration();
             configuration.delete_if_migration_needed = ShouldDeleteIfMigrationNeeded;
             configuration.read_only = IsReadOnly;
 

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -150,7 +150,7 @@ namespace Realms
 
         internal abstract Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken);
 
-        internal Native.Configuration CreateConfiguration()
+        internal Native.Configuration CreateNativeConfiguration()
         {
             return new Native.Configuration
             {

--- a/Realm/Realm/Configurations/SyncConfiguration.cs
+++ b/Realm/Realm/Configurations/SyncConfiguration.cs
@@ -122,9 +122,8 @@ namespace Realms.Sync
 
         internal override Realm CreateRealm(RealmSchema schema)
         {
-            var configuration = CreateConfiguration();
-            var syncConfiguration = CreateSyncConfiguration();
-            syncConfiguration.schema_mode = ObjectClasses == null ? SchemaMode.AdditiveDiscovered : SchemaMode.AdditiveExplicit;
+            var configuration = CreateNativeConfiguration();
+            var syncConfiguration = CreateNativeSyncConfiguration();
 
             var srHandle = SharedRealmHandle.OpenWithSync(configuration, syncConfiguration, schema, EncryptionKey);
             if (IsDynamic && !schema.Any())
@@ -138,9 +137,8 @@ namespace Realms.Sync
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The Realm instance will own its handle")]
         internal override async Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken)
         {
-            var configuration = CreateConfiguration();
-            var syncConfiguration = CreateSyncConfiguration();
-            syncConfiguration.schema_mode = ObjectClasses == null ? SchemaMode.AdditiveDiscovered : SchemaMode.AdditiveExplicit;
+            var configuration = CreateNativeConfiguration();
+            var syncConfiguration = CreateNativeSyncConfiguration();
 
             var tcs = new TaskCompletionSource<ThreadSafeReferenceHandle>();
             var tcsHandle = GCHandle.Alloc(tcs);
@@ -191,13 +189,14 @@ namespace Realms.Sync
             }
         }
 
-        internal Native.SyncConfiguration CreateSyncConfiguration()
+        internal Native.SyncConfiguration CreateNativeSyncConfiguration()
         {
             return new Native.SyncConfiguration
             {
                 SyncUserHandle = User.Handle,
                 Partition = Partition.ToNativeJson(),
                 session_stop_policy = SessionStopPolicy,
+                schema_mode = ObjectClasses == null ? SchemaMode.AdditiveDiscovered : SchemaMode.AdditiveExplicit,
             };
         }
     }

--- a/Realm/Realm/Configurations/SyncConfiguration.cs
+++ b/Realm/Realm/Configurations/SyncConfiguration.cs
@@ -123,7 +123,7 @@ namespace Realms.Sync
         internal override Realm CreateRealm(RealmSchema schema)
         {
             var configuration = CreateConfiguration();
-            configuration.additive_discovered = ObjectClasses.Length == 0;
+            configuration.additive_discovered = ObjectClasses == null ? true : false;
 
             var srHandle = SharedRealmHandle.OpenWithSync(configuration, ToNative(), schema, EncryptionKey);
             if (IsDynamic && !schema.Any())

--- a/Realm/Realm/Configurations/SyncConfiguration.cs
+++ b/Realm/Realm/Configurations/SyncConfiguration.cs
@@ -138,7 +138,7 @@ namespace Realms.Sync
         internal override async Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken)
         {
             var configuration = CreateConfiguration();
-            configuration.additive_discovered = ObjectClasses.Length == 0;
+            configuration.additive_discovered = ObjectClasses == null ? true : false;
 
             var tcs = new TaskCompletionSource<ThreadSafeReferenceHandle>();
             var tcsHandle = GCHandle.Alloc(tcs);

--- a/Realm/Realm/Configurations/SyncConfiguration.cs
+++ b/Realm/Realm/Configurations/SyncConfiguration.cs
@@ -123,6 +123,7 @@ namespace Realms.Sync
         internal override Realm CreateRealm(RealmSchema schema)
         {
             var configuration = CreateConfiguration();
+            configuration.additive_discovered = ObjectClasses.Length == 0;
 
             var srHandle = SharedRealmHandle.OpenWithSync(configuration, ToNative(), schema, EncryptionKey);
             if (IsDynamic && !schema.Any())
@@ -137,6 +138,7 @@ namespace Realms.Sync
         internal override async Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken)
         {
             var configuration = CreateConfiguration();
+            configuration.additive_discovered = ObjectClasses.Length == 0;
 
             var tcs = new TaskCompletionSource<ThreadSafeReferenceHandle>();
             var tcsHandle = GCHandle.Alloc(tcs);

--- a/Realm/Realm/Exceptions/RealmException.cs
+++ b/Realm/Realm/Exceptions/RealmException.cs
@@ -104,6 +104,9 @@ namespace Realms.Exceptions
                 case RealmExceptionCodes.RealmClosed:
                     return new RealmClosedException(message);
 
+                case RealmExceptionCodes.RealmSchemaValidation:
+                    return new RealmSchemaValidationException(message);
+
                 case RealmExceptionCodes.NotNullableProperty:
                 case RealmExceptionCodes.PropertyMismatch:
                     return new RealmException(message);

--- a/Realm/Realm/Exceptions/RealmExceptionCodes.cs
+++ b/Realm/Realm/Exceptions/RealmExceptionCodes.cs
@@ -36,6 +36,8 @@ namespace Realms.Exceptions
         RealmInvalidTransaction = 10,
         RealmFormatUpgradeRequired = 13,
         RealmSchemaMismatch = 14,
+        RealmSchemaValidation = 15,
+
         RealmRowDetached = 21,
         RealmTableHasNoPrimaryKey = 22,
         RealmDuplicatePrimaryKeyValue = 23,

--- a/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
+++ b/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2021 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 namespace Realms.Exceptions
 {
     /// <summary>
-    /// Exception thrown when you're trying to use <see cref="Realm.Add{T}(T, bool)"/> but the object is already managed by a
-    /// different <see cref="Realm"/>.
+    /// Exception thrown when the current schema doesn't respect Realm's set of rule. The details in the message helps to understand what the broken rule is.
+    /// More general info about Realm's schema can be found <see href="https://docs.mongodb.com/realm/dotnet/realms/#std-label-dotnet-realm-schema">here</see>.
     /// </summary>
     public class RealmSchemaValidationException : RealmException
     {

--- a/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
+++ b/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
@@ -22,7 +22,7 @@ namespace Realms.Exceptions
     /// Exception thrown when the schema specified in your C# models doesn't pass validation for the type of Realm you're trying to open.
     /// The message contains information about the validation errors and how to correct them.
     /// </summary>
-    /// <seealso href = "https://docs.mongodb.com/realm/dotnet/realms/#std-label-dotnet-realm-schema" >
+    /// <seealso href="https://docs.mongodb.com/realm/dotnet/realms/#std-label-dotnet-realm-schema">
     /// General information about Realm's schema.
     /// </seealso>
     public class RealmSchemaValidationException : RealmException

--- a/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
+++ b/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Realms.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when you're trying to use <see cref="Realm.Add{T}(T, bool)"/> but the object is already managed by a
+    /// different <see cref="Realm"/>.
+    /// </summary>
+    public class RealmSchemaValidationException : RealmException
+    {
+        internal RealmSchemaValidationException(string detailMessage) : base(detailMessage)
+        {
+        }
+    }
+}

--- a/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
+++ b/Realm/Realm/Exceptions/RealmSchemaValidationException.cs
@@ -19,7 +19,7 @@
 namespace Realms.Exceptions
 {
     /// <summary>
-    /// Exception thrown when the schema specified in your C# models don't pass validation for the type of Realm you're trying to open.
+    /// Exception thrown when the schema specified in your C# models doesn't pass validation for the type of Realm you're trying to open.
     /// The message contains information about the validation errors and how to correct them.
     /// </summary>
     /// <seealso href = "https://docs.mongodb.com/realm/dotnet/realms/#std-label-dotnet-realm-schema" >

--- a/Realm/Realm/Native/Configuration.cs
+++ b/Realm/Realm/Native/Configuration.cs
@@ -51,9 +51,6 @@ namespace Realms.Native
         internal bool in_memory;
 
         [MarshalAs(UnmanagedType.U1)]
-        internal bool additive_discovered;
-
-        [MarshalAs(UnmanagedType.U1)]
         internal bool delete_if_migration_needed;
 
         internal ulong schema_version;

--- a/Realm/Realm/Native/Configuration.cs
+++ b/Realm/Realm/Native/Configuration.cs
@@ -51,6 +51,9 @@ namespace Realms.Native
         internal bool in_memory;
 
         [MarshalAs(UnmanagedType.U1)]
+        internal bool additive_discovered;
+
+        [MarshalAs(UnmanagedType.U1)]
         internal bool delete_if_migration_needed;
 
         internal ulong schema_version;

--- a/Realm/Realm/Native/SyncConfiguration.cs
+++ b/Realm/Realm/Native/SyncConfiguration.cs
@@ -49,5 +49,7 @@ namespace Realms.Sync.Native
         }
 
         internal SessionStopPolicy session_stop_policy;
+
+        internal SchemaMode schema_mode;
     }
 }

--- a/Realm/Realm/Sync/SchemaMode.cs
+++ b/Realm/Realm/Sync/SchemaMode.cs
@@ -19,12 +19,11 @@
 namespace Realms.Sync
 {
     /// <summary>
-    /// To see details of each mode check its mirroring definition in <see href="https://github.com/realm/realm-core/blob/0976706c26ce24866e6be6c165b6c6192fb663ed/src/realm/object-store/shared_realm.hpp#L61">core</see>.
+    /// To see details of each mode check its mirroring definition in core.
     /// </summary>
     internal enum SchemaMode : byte
     {
-        // N.B. the values must match their representation in core!
         AdditiveDiscovered = 4,
-        AdditiveExplicit
+        AdditiveExplicit = 5
     }
 }

--- a/Realm/Realm/Sync/SchemaMode.cs
+++ b/Realm/Realm/Sync/SchemaMode.cs
@@ -19,7 +19,7 @@
 namespace Realms.Sync
 {
     /// <summary>
-    /// To see details of each mode check its mirroring definition in <see href="https://github.com/realm/realm-core/blob/0976706c26ce24866e6be6c165b6c6192fb663ed/src/realm/object-store/shared_realm.hpp#L61"> core</see>.
+    /// To see details of each mode check its mirroring definition in <see href="https://github.com/realm/realm-core/blob/0976706c26ce24866e6be6c165b6c6192fb663ed/src/realm/object-store/shared_realm.hpp#L61">core</see>.
     /// </summary>
     internal enum SchemaMode : byte
     {

--- a/Realm/Realm/Sync/SchemaMode.cs
+++ b/Realm/Realm/Sync/SchemaMode.cs
@@ -19,7 +19,7 @@
 namespace Realms.Sync
 {
     /// <summary>
-    /// To see details of each mode check their mirroring definition <see href="https://github.com/realm/realm-core/blob/0976706c26ce24866e6be6c165b6c6192fb663ed/src/realm/object-store/shared_realm.hpp#L61">in core</see>
+    /// To see details of each mode check its mirroring definition in <see href="https://github.com/realm/realm-core/blob/0976706c26ce24866e6be6c165b6c6192fb663ed/src/realm/object-store/shared_realm.hpp#L61"> core</see>.
     /// </summary>
     internal enum SchemaMode : byte
     {

--- a/Realm/Realm/Sync/SchemaMode.cs
+++ b/Realm/Realm/Sync/SchemaMode.cs
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////
+﻿////////////////////////////////////////////////////////////////////////////
 //
 // Copyright 2021 Realm Inc.
 //
@@ -16,19 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-namespace Realms.Exceptions
+namespace Realms.Sync
 {
     /// <summary>
-    /// Exception thrown when the schema specified in your C# models don't pass validation for the type of Realm you're trying to open.
-    /// The message contains information about the validation errors and how to correct them.
+    /// To see details of each mode check their mirroring definition <see href="https://github.com/realm/realm-core/blob/0976706c26ce24866e6be6c165b6c6192fb663ed/src/realm/object-store/shared_realm.hpp#L61">in core</see>
     /// </summary>
-    /// <seealso href = "https://docs.mongodb.com/realm/dotnet/realms/#std-label-dotnet-realm-schema" >
-    /// General information about Realm's schema.
-    /// </seealso>
-    public class RealmSchemaValidationException : RealmException
+    internal enum SchemaMode : byte
     {
-        internal RealmSchemaValidationException(string detailMessage) : base(detailMessage)
-        {
-        }
+        // N.B. the values must match their representation in core!
+        AdditiveDiscovered = 4,
+        AdditiveExplicit
     }
 }

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Realms.Exceptions;
 using Realms.Schema;
 using Realms.Sync;
 using Realms.Sync.Exceptions;
@@ -269,6 +270,18 @@ namespace Realms.Tests.Sync
 
                 Assert.That(File.Exists(realmPath), Is.False);
             });
+        }
+
+        [Test]
+        public void Adding_OrphanEmbeddedObj()
+        {
+            var conf = new SyncConfiguration("foo-bar", GetFakeUser())
+            {
+                SessionStopPolicy = SessionStopPolicy.Immediately,
+                ObjectClasses = new[] { typeof(EmbeddedLevel3) }
+            };
+
+            Assert.Throws<RealmMigrationNeededException>(() => Realm.GetInstance(conf));
         }
 
         private const int DummyDataSize = 100;

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -281,7 +281,7 @@ namespace Realms.Tests.Sync
                 ObjectClasses = new[] { typeof(EmbeddedLevel3) }
             };
 
-            Assert.Throws<RealmSchemaValidationException>(() => Realm.GetInstance(conf));
+            Assert.Throws<RealmSchemaValidationException>(() => Realm.GetInstance(conf), $"Embedded object {nameof(EmbeddedLevel3)} is unreachable by any link path from top level objects");
         }
 
         private const int DummyDataSize = 100;

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -273,7 +273,7 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
-        public void Adding_OrphanEmbeddedObj()
+        public void EmbeddedObject_WhenAdditiveExplicit_ShouldThrow()
         {
             var conf = new SyncConfiguration("foo-bar", GetFakeUser())
             {
@@ -281,7 +281,7 @@ namespace Realms.Tests.Sync
                 ObjectClasses = new[] { typeof(EmbeddedLevel3) }
             };
 
-            Assert.Throws<RealmMigrationNeededException>(() => Realm.GetInstance(conf));
+            Assert.Throws<RealmSchemaValidationException>(() => Realm.GetInstance(conf));
         }
 
         private const int DummyDataSize = 100;

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -275,11 +275,8 @@ namespace Realms.Tests.Sync
         [Test]
         public void EmbeddedObject_WhenAdditiveExplicit_ShouldThrow()
         {
-            var conf = new SyncConfiguration("foo-bar", GetFakeUser())
-            {
-                SessionStopPolicy = SessionStopPolicy.Immediately,
-                ObjectClasses = new[] { typeof(EmbeddedLevel3) }
-            };
+            var conf = GetFakeConfig();
+            conf.ObjectClasses = new[] { typeof(EmbeddedLevel3) };
 
             Assert.Throws<RealmSchemaValidationException>(() => Realm.GetInstance(conf), $"Embedded object {nameof(EmbeddedLevel3)} is unreachable by any link path from top level objects");
         }

--- a/wrappers/src/error_handling.cpp
+++ b/wrappers/src/error_handling.cpp
@@ -62,8 +62,8 @@ namespace realm {
                 return { RealmErrorType::RealmError, e.what() };
             }
         }
-        catch (const SchemaValidationException& e) { // an ObjectStore exception mapped onto same code as older core
-            return { RealmErrorType::RealmFormatUpgradeRequired, e.what() };
+        catch (const SchemaValidationException& e) {
+            return { RealmErrorType::RealmSchemaValidation, e.what() };
         }
         catch (const MismatchedConfigException& e) {
             return { RealmErrorType::RealmMismatchedConfig, e.what() };

--- a/wrappers/src/realm_error_type.hpp
+++ b/wrappers/src/realm_error_type.hpp
@@ -64,6 +64,8 @@ namespace realm {
 
         RealmSchemaMismatch = 14,
 
+        RealmSchemaValidation = 15,
+
         RealmRowDetached = 21,
 
         RealmTableHasNoPrimaryKey = 22,

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -71,7 +71,7 @@ public:
 Realm::Config get_shared_realm_config(Configuration configuration, SyncConfiguration sync_configuration, SchemaObject* objects, int objects_length, SchemaProperty* properties, uint8_t* encryption_key)
 {
     Realm::Config config;
-    config.schema_mode = configuration.additive_discovered ? SchemaMode::AdditiveDiscovered : SchemaMode::AdditiveExplicit;
+    config.schema_mode = sync_configuration.schema_mode;
 
     if (objects_length > 0) {
         config.schema = create_schema(objects, objects_length, properties);

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -70,8 +70,8 @@ public:
 
 Realm::Config get_shared_realm_config(Configuration configuration, SyncConfiguration sync_configuration, SchemaObject* objects, int objects_length, SchemaProperty* properties, uint8_t* encryption_key)
 {
-    Realm::Config config;
-    config.schema_mode = SchemaMode::AdditiveDiscovered;
+    Realm::Config config;    
+    config.schema_mode = configuration.additive_discovered ? SchemaMode::AdditiveDiscovered : SchemaMode::AdditiveExplicit;
 
     if (objects_length > 0) {
         config.schema = create_schema(objects, objects_length, properties);

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -70,7 +70,7 @@ public:
 
 Realm::Config get_shared_realm_config(Configuration configuration, SyncConfiguration sync_configuration, SchemaObject* objects, int objects_length, SchemaProperty* properties, uint8_t* encryption_key)
 {
-    Realm::Config config;    
+    Realm::Config config;
     config.schema_mode = configuration.additive_discovered ? SchemaMode::AdditiveDiscovered : SchemaMode::AdditiveExplicit;
 
     if (objects_length > 0) {

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -50,6 +50,8 @@ struct Configuration
     bool read_only;
     
     bool in_memory;
+
+    bool additive_discovered;
     
     bool delete_if_migration_needed;
     

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -50,8 +50,6 @@ struct Configuration
     bool read_only;
     
     bool in_memory;
-
-    bool additive_discovered;
     
     bool delete_if_migration_needed;
     
@@ -75,6 +73,8 @@ struct SyncConfiguration
     size_t url_len;
 
     SyncSessionStopPolicy session_stop_policy;
+
+    SchemaMode schema_mode;
 };
 
 inline const TableRef get_table(const SharedRealm& realm, TableKey table_key)


### PR DESCRIPTION
## Description
Based on `RealmConfigurationBase.ObjectClasses` "AdditiveDiscovered" or "AdditiveExplicit" is now appropriately selected and passed to core.
Currently, because of the way core did it, this is a detail only relevant for synced scenarios. I'll talk to James Stone to understand better the why's'.
This PR also adds an additional exception to have a more precise error category when an issue with the schema validation arises.
 
==================================
UPDATE
I talked with James and he explained that the 2 types of Additive behaviours are purposedly used only for sync-d realms because unreachable embeddedObjects are only problematic for the server. Hence, when the client doesn't sync, there's no reason to check for them as these unreachable objs don't really create an issue; although being logically useless. He added that the only reason why such check had to end up in the client, although only bothering the server, is that when the server received such object,s the message sent back to the client was too obscure for the user to be of help. 

Fixes #2193

##  TODO

* [x] Changelog entry
* [x] Tests