### PR TITLE
Use canonical URLs for docs links on overview page

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -22,7 +22,7 @@ To see what is supported, refer to the [LINQ Support](linqsupport.md) page.
 
 Documentation
 -------------
-The documentation can be found at [https://docs.mongodb.com/realm/dotnet](https://docs.mongodb.com/realm/dotnet).
+The documentation can be found at [https://docs.mongodb.com/realm/sdk/dotnet/](https://docs.mongodb.com/realm/sdk/dotnet/).
 
 The API reference is located at [https://docs.mongodb.com/realm-sdks/dotnet/latest/](https://docs.mongodb.com/realm-sdks/dotnet/latest/).
 


### PR DESCRIPTION
These changes resolves a redirect chain that is currently in the dotnet SDK docs and is negatively affecting search engine performance.

(I'm on the Documentation Platform team at MongoDB and this was identified as part of a broader SEO project that we're currently working on, and this seemed like an easy way to fix it 😁.)

cc @nathan-contino-mongo 

## Description

Addresses DOP-1883

##  TODO

None.