### PR TITLE
Ac/retrieve multiple caches ga

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -3,8 +3,8 @@
 
 #@ configuration = "Release"
 #@ androidABIs = [ 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64' ]
-#@ windowsArch = [ 'Win32', 'x64' ]
-#@ windowsUWPArch = [ 'Win32', 'x64', 'ARM' ]
+#@ windowsArchs = [ 'Win32', 'x64' ]
+#@ windowsUWPArchs = [ 'Win32', 'x64', 'ARM' ]
 #@ wrappersCacheCondition = "steps.check-cache.outputs.cache-hit != 'true'"
 
 #@ def checkoutCode():
@@ -54,7 +54,6 @@ if: #@ wrappersCacheCondition + " && steps.check-vcpkg-cache.outputs.cache-hit !
 #@ end
 #@ cacheKey = outputVar + "-" + configuration + "-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
 #@ actualCommand = cmd + configurationParam + ltoParam
-#@ saveOutput = "echo \"::set-output name=cacheKey::" + cacheKey + "\""
 
 steps:
   - #@ checkoutCode()
@@ -65,13 +64,17 @@ steps:
   - name: Build wrappers
     run: #@ actualCommand
     if: #@ wrappersCacheCondition
-  - name: Output cacheKey
-    run: #@ saveOutput
+  - name: Store artifacts
+    uses: actions/upload-artifact@v2
+    with:
+      name: #@ outputVar
+      path: wrappers/build/**
+      retention-days: 1
 #@ end
 
 ---
 name: build and test
-on:
+"on":
   push:
     branches:
       - main
@@ -102,12 +105,83 @@ jobs:
     name: Build Windows wrappers
     strategy:
       matrix:
-        arch: #@ windowsArch
+        arch: #@ windowsArchs
     _: #@ template.replace(buildWrappers("powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }}", "wrappers-windows-${{ matrix.arch }}", [ cacheVcpkg(), setupVcpkg() ]))
   build-wrappers-windows-uwp:
     runs-on: windows-latest
     name: Build Windows UWP wrappers
     strategy:
       matrix:
-        arch: #@ windowsUWPArch
+        arch: #@ windowsUWPArchs
     _: #@ template.replace(buildWrappers("powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }}", "wrappers-windows-uwp-${{ matrix.arch }}", [ cacheVcpkg(), setupVcpkg() ]))
+  build-package:
+    runs-on: windows-latest
+    name: Build packages
+    needs:
+      - build-wrappers-windows
+      - build-wrappers-macos
+      - build-wrappers-ios
+      - build-wrappers-android
+      - build-wrappers-linux
+      - build-wrappers-windows-uwp
+    steps:
+      - name: Fetch Artifacts MacOS
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-macos
+          path: wrappers/build
+      - name: Fetch Artifacts iOS
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-ios
+          path: wrappers/build
+      - name: Fetch Artifacts Linux
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-linux
+          path: wrappers/build
+      - name: Fetch Artifacts Android armeabi-v7a
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-android-armeabi-v7a
+          path: wrappers/build
+      - name: Fetch Artifacts Android arm64-v8a
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-android-arm64-v8a
+          path: wrappers/build
+      - name: Fetch Artifacts Android x86
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-android-x86
+          path: wrappers/build
+      - name: Fetch Artifacts Android x86_64
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-android-x86_64
+          path: wrappers/build
+      - name: Fetch Artifacts Windows 32bit
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-windows-Win32
+          path: wrappers/build
+      - name: Fetch Artifacts Windows 64bit
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-windows-x64
+          path: wrappers/build
+      - name: Fetch Artifacts Windows UWP 32bit
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-windows-uwp-Win32
+          path: wrappers/build
+      - name: Fetch Artifacts Windows UWP 64bit
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-windows-uwp-x64
+          path: wrappers/build
+      - name: Fetch Artifacts Windows UWP ARM
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-windows-uwp-ARM
+          path: wrappers/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,222 +2,268 @@ name: build and test
 "on":
   push:
     branches:
-      - main
-      - master
+    - main
+    - master
   pull_request: null
 jobs:
   build-wrappers-macos:
     runs-on: macos-latest
     name: Build macOS wrappers
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: wrappers-macos
-          path: wrappers/build/**
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-macos
+        path: wrappers/build/**
+        retention-days: 1
   build-wrappers-ios:
     runs-on: macos-latest
     name: Build iOS wrappers
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: wrappers-ios
-          path: wrappers/build/**
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-ios
+        path: wrappers/build/**
+        retention-days: 1
   build-wrappers-linux:
     runs-on: ubuntu-20.04
     name: Build Linux wrappers
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: wrappers-linux
-          path: wrappers/build/**
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-linux
+        path: wrappers/build/**
+        retention-days: 1
   build-wrappers-android:
     runs-on: ubuntu-20.04
     name: Build Android wrappers
     strategy:
       matrix:
         arch:
-          - armeabi-v7a
-          - arm64-v8a
-          - x86
-          - x86_64
+        - armeabi-v7a
+        - arm64-v8a
+        - x86
+        - x86_64
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: wrappers-android-${{ matrix.arch }}
-          path: wrappers/build/**
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-android-${{ matrix.arch }}
+        path: wrappers/build/**
+        retention-days: 1
   build-wrappers-windows:
     runs-on: windows-latest
     name: Build Windows wrappers
     strategy:
       matrix:
         arch:
-          - Win32
-          - x64
+        - Win32
+        - x64
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Check Vcpkg cache
-        id: check-vcpkg-cache
-        uses: actions/cache@v2
-        with:
-          path: C:\src
-          key: vcpkg
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Setup Vcpkg
-        run: |
-          Write-Output 'Beginning download...'
-          Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
-          Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
-          Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
-          Write-Output 'Completed!'
-        shell: powershell
-        if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
-      - name: Build wrappers
-        run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: wrappers-windows-${{ matrix.arch }}
-          path: wrappers/build/**
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Check Vcpkg cache
+      id: check-vcpkg-cache
+      uses: actions/cache@v2
+      with:
+        path: C:\src
+        key: vcpkg
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Setup Vcpkg
+      run: |
+        Write-Output 'Beginning download...'
+        Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
+        Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
+        Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
+        Write-Output 'Completed!'
+      shell: powershell
+      if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
+    - name: Build wrappers
+      run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-windows-${{ matrix.arch }}
+        path: wrappers/build/**
+        retention-days: 1
   build-wrappers-windows-uwp:
     runs-on: windows-latest
     name: Build Windows UWP wrappers
     strategy:
       matrix:
         arch:
-          - Win32
-          - x64
-          - ARM
+        - Win32
+        - x64
+        - ARM
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Check Vcpkg cache
-        id: check-vcpkg-cache
-        uses: actions/cache@v2
-        with:
-          path: C:\src
-          key: vcpkg
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Setup Vcpkg
-        run: |
-          Write-Output 'Beginning download...'
-          Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
-          Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
-          Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
-          Write-Output 'Completed!'
-        shell: powershell
-        if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
-      - name: Build wrappers
-        run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: wrappers-windows-uwp-${{ matrix.arch }}
-          path: wrappers/build/**
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Check Vcpkg cache
+      id: check-vcpkg-cache
+      uses: actions/cache@v2
+      with:
+        path: C:\src
+        key: vcpkg
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Setup Vcpkg
+      run: |
+        Write-Output 'Beginning download...'
+        Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
+        Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
+        Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
+        Write-Output 'Completed!'
+      shell: powershell
+      if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
+    - name: Build wrappers
+      run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-windows-uwp-${{ matrix.arch }}
+        path: wrappers/build/**
+        retention-days: 1
   build-package:
     runs-on: windows-latest
     name: Build packages
     needs:
-      - build-wrappers-windows
-      - build-wrappers-macos
-      - build-wrappers-ios
-      - build-wrappers-android
-      - build-wrappers-linux
-      - build-wrappers-windows-uwp
+    - build-wrappers-windows
+    - build-wrappers-macos
+    - build-wrappers-ios
+    - build-wrappers-android
+    - build-wrappers-linux
+    - build-wrappers-windows-uwp
     steps:
-      - name: Fetch Artifacts Linux
-        uses: actions/download-artifact@v2
-        with:
-          name: wrappers-linux
-          path: wrappers/build
-      - name: Fetch Artifacts MacOS
-        uses: actions/download-artifact@v2
-        with:
-          name: wrappers-macos
-          path: wrappers/build
-      - name: Fetch Artifacts Windows 32
-        uses: actions/download-artifact@v2
-        with:
-          name: wrappers-windows-Win32
-          path: wrappers/build
-      - name: Fetch Artifacts Windows 64
-        uses: actions/download-artifact@v2
-        with:
-          name: wrappers-windows-x64
-          path: wrappers/build
-      - name: list folder
-        run: powershell tree /F
+    - name: Fetch Artifacts MacOS
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-macos
+        path: wrappers/build
+    - name: Fetch Artifacts iOS
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-ios
+        path: wrappers/build
+    - name: Fetch Artifacts Linux
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-linux
+        path: wrappers/build
+    - name: Fetch Artifacts Android armeabi-v7a
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-android-armeabi-v7a
+        path: wrappers/build
+    - name: Fetch Artifacts Android arm64-v8a
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-android-arm64-v8a
+        path: wrappers/build
+    - name: Fetch Artifacts Android x86
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-android-x86
+        path: wrappers/build
+    - name: Fetch Artifacts Android x86_64
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-android-x86_64
+        path: wrappers/build
+    - name: Fetch Artifacts Windows 32bit
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-windows-Win32
+        path: wrappers/build
+    - name: Fetch Artifacts Windows 64bit
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-windows-x64
+        path: wrappers/build
+    - name: Fetch Artifacts Windows UWP 32bit
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-windows-uwp-Win32
+        path: wrappers/build
+    - name: Fetch Artifacts Windows UWP 64bit
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-windows-uwp-x64
+        path: wrappers/build
+    - name: Fetch Artifacts Windows UWP ARM
+      uses: actions/download-artifact@v2
+      with:
+        name: wrappers-windows-uwp-ARM
+        path: wrappers/build
+    - name: list folder
+      run: powershell tree /F

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,202 +1,202 @@
 name: build and test
-true:
+on:
   push:
     branches:
-    - main
-    - master
+      - main
+      - master
   pull_request: null
 jobs:
   build-wrappers-macos:
     runs-on: macos-latest
     name: Build macOS wrappers
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Check cache
-      id: check-cache
-      uses: actions/cache@v2
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-    - name: Build wrappers
-      run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wrappers-macos
-        path: wrappers/build/**
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+      - name: Build wrappers
+        run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wrappers-macos
+          path: wrappers/build/**
   build-wrappers-ios:
     runs-on: macos-latest
     name: Build iOS wrappers
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Check cache
-      id: check-cache
-      uses: actions/cache@v2
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-    - name: Build wrappers
-      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wrappers-ios
-        path: wrappers/build/**
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+      - name: Build wrappers
+        run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wrappers-ios
+          path: wrappers/build/**
   build-wrappers-linux:
     runs-on: ubuntu-20.04
     name: Build Linux wrappers
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Check cache
-      id: check-cache
-      uses: actions/cache@v2
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-    - name: Build wrappers
-      run: ./wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wrappers-linux
-        path: wrappers/build/**
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+      - name: Build wrappers
+        run: ./wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wrappers-linux
+          path: wrappers/build/**
   build-wrappers-android:
     runs-on: ubuntu-20.04
     name: Build Android wrappers
     strategy:
       matrix:
         arch:
-        - armeabi-v7a
-        - arm64-v8a
-        - x86
-        - x86_64
+          - armeabi-v7a
+          - arm64-v8a
+          - x86
+          - x86_64
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Check cache
-      id: check-cache
-      uses: actions/cache@v2
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-    - name: Build wrappers
-      run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wrappers-android-${{ matrix.arch }}
-        path: wrappers/build/**
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+      - name: Build wrappers
+        run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wrappers-android-${{ matrix.arch }}
+          path: wrappers/build/**
   build-wrappers-windows:
     runs-on: windows-latest
     name: Build Windows wrappers
     strategy:
       matrix:
         arch:
-        - Win32
-        - x64
+          - Win32
+          - x64
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Check cache
-      id: check-cache
-      uses: actions/cache@v2
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-    - name: Check Vcpkg cache
-      id: check-vcpkg-cache
-      uses: actions/cache@v2
-      with:
-        path: C:\src
-        key: vcpkg
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Setup Vcpkg
-      run: |
-        Write-Output 'Beginning download...'
-        Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
-        Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
-        Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
-        Write-Output 'Completed!'
-      shell: powershell
-      if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
-    - name: Build wrappers
-      run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wrappers-windows-${{ matrix.arch }}
-        path: wrappers/build/**
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+      - name: Check Vcpkg cache
+        id: check-vcpkg-cache
+        uses: actions/cache@v2
+        with:
+          path: C:\src
+          key: vcpkg
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Setup Vcpkg
+        run: |
+          Write-Output 'Beginning download...'
+          Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
+          Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
+          Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
+          Write-Output 'Completed!'
+        shell: powershell
+        if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
+      - name: Build wrappers
+        run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wrappers-windows-${{ matrix.arch }}
+          path: wrappers/build/**
   build-wrappers-windows-uwp:
     runs-on: windows-latest
     name: Build Windows UWP wrappers
     strategy:
       matrix:
         arch:
-        - Win32
-        - x64
-        - ARM
+          - Win32
+          - x64
+          - ARM
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Check cache
-      id: check-cache
-      uses: actions/cache@v2
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-    - name: Check Vcpkg cache
-      id: check-vcpkg-cache
-      uses: actions/cache@v2
-      with:
-        path: C:\src
-        key: vcpkg
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Setup Vcpkg
-      run: |
-        Write-Output 'Beginning download...'
-        Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
-        Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
-        Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
-        Write-Output 'Completed!'
-      shell: powershell
-      if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
-    - name: Build wrappers
-      run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wrappers-windows-uwp-${{ matrix.arch }}
-        path: wrappers/build/**
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+      - name: Check Vcpkg cache
+        id: check-vcpkg-cache
+        uses: actions/cache@v2
+        with:
+          path: C:\src
+          key: vcpkg
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Setup Vcpkg
+        run: |
+          Write-Output 'Beginning download...'
+          Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
+          Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
+          Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
+          Write-Output 'Completed!'
+        shell: powershell
+        if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
+      - name: Build wrappers
+        run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wrappers-windows-uwp-${{ matrix.arch }}
+          path: wrappers/build/**
   build-package:
     runs-on: windows-latest
     name: Build packages
     needs:
-    - build-wrappers-windows
-    - build-wrappers-macos
-    - build-wrappers-ios
-    - build-wrappers-android
-    - build-wrappers-linux
+      - build-wrappers-windows
+      - build-wrappers-macos
+      - build-wrappers-ios
+      - build-wrappers-android
+      - build-wrappers-linux
     steps:
-    - name: Fetch Artifacts
-      uses: actions/download-artifact@v2
+      - name: Fetch Artifacts
+        uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,205 +1,202 @@
 name: build and test
-on:
+true:
   push:
     branches:
-      - main
-      - master
+    - main
+    - master
   pull_request: null
 jobs:
   build-wrappers-macos:
     runs-on: macos-latest
-    outputs:
-      wrappers-macos: ${{ steps.output-cache-key.outputs.wrappers-macos }}
     name: Build macOS wrappers
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Output cacheKey
-        id: output-cache-key
-        run: echo "::set-output name=wrappers-macos::wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-macos
+        path: wrappers/build/**
   build-wrappers-ios:
     runs-on: macos-latest
     name: Build iOS wrappers
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Output cacheKey
-        id: output-cache-key
-        run: echo "::set-output name=wrappers-ios::wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-ios
+        path: wrappers/build/**
   build-wrappers-linux:
     runs-on: ubuntu-20.04
     name: Build Linux wrappers
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Output cacheKey
-        id: output-cache-key
-        run: echo "::set-output name=wrappers-linux::wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-linux
+        path: wrappers/build/**
   build-wrappers-android:
     runs-on: ubuntu-20.04
     name: Build Android wrappers
     strategy:
       matrix:
         arch:
-          - armeabi-v7a
-          - arm64-v8a
-          - x86
-          - x86_64
+        - armeabi-v7a
+        - arm64-v8a
+        - x86
+        - x86_64
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Build wrappers
-        run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Output cacheKey
-        id: output-cache-key
-        run: echo "::set-output name=wrappers-android-${{ matrix.arch }}::wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Build wrappers
+      run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-android-${{ matrix.arch }}
+        path: wrappers/build/**
   build-wrappers-windows:
     runs-on: windows-latest
-    outputs:
-      wrappers-windows-Win32: ${{ steps.output-cache-key.outputs.wrappers-windows-Win32 }}
-      wrappers-windows-x64: ${{ steps.output-cache-key.outputs.wrappers-windows-x64 }}
     name: Build Windows wrappers
     strategy:
       matrix:
         arch:
-          - Win32
-          - x64
+        - Win32
+        - x64
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Check Vcpkg cache
-        id: check-vcpkg-cache
-        uses: actions/cache@v2
-        with:
-          path: C:\src
-          key: vcpkg
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Setup Vcpkg
-        run: |
-          Write-Output 'Beginning download...'
-          Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
-          Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
-          Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
-          Write-Output 'Completed!'
-        shell: powershell
-        if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
-      - name: Build wrappers
-        run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Output cacheKey
-        id: output-cache-key
-        run: echo "::set-output name=wrappers-windows-${{ matrix.arch }}::wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Check Vcpkg cache
+      id: check-vcpkg-cache
+      uses: actions/cache@v2
+      with:
+        path: C:\src
+        key: vcpkg
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Setup Vcpkg
+      run: |
+        Write-Output 'Beginning download...'
+        Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
+        Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
+        Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
+        Write-Output 'Completed!'
+      shell: powershell
+      if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
+    - name: Build wrappers
+      run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-windows-${{ matrix.arch }}
+        path: wrappers/build/**
   build-wrappers-windows-uwp:
     runs-on: windows-latest
     name: Build Windows UWP wrappers
     strategy:
       matrix:
         arch:
-          - Win32
-          - x64
-          - ARM
+        - Win32
+        - x64
+        - ARM
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Check cache
-        id: check-cache
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
-      - name: Check Vcpkg cache
-        id: check-vcpkg-cache
-        uses: actions/cache@v2
-        with:
-          path: C:\src
-          key: vcpkg
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Setup Vcpkg
-        run: |
-          Write-Output 'Beginning download...'
-          Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
-          Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
-          Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
-          Write-Output 'Completed!'
-        shell: powershell
-        if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
-      - name: Build wrappers
-        run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
-        if: steps.check-cache.outputs.cache-hit != 'true'
-      - name: Output cacheKey
-        id: output-cache-key
-        run: echo "::set-output name=wrappers-windows-uwp-${{ matrix.arch }}::wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Check cache
+      id: check-cache
+      uses: actions/cache@v2
+      with:
+        path: ./wrappers/build/**
+        key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+    - name: Check Vcpkg cache
+      id: check-vcpkg-cache
+      uses: actions/cache@v2
+      with:
+        path: C:\src
+        key: vcpkg
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Setup Vcpkg
+      run: |
+        Write-Output 'Beginning download...'
+        Invoke-WebRequest -Uri https://static.realm.io/downloads/vcpkg.zip -OutFile C:\vcpkg.zip
+        Write-Output ((Get-Item C:\vcpkg.zip).length/1MB)
+        Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
+        Write-Output 'Completed!'
+      shell: powershell
+      if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
+    - name: Build wrappers
+      run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wrappers-windows-uwp-${{ matrix.arch }}
+        path: wrappers/build/**
   build-package:
     runs-on: windows-latest
     name: Build packages
     needs:
-      - build-wrappers-windows
-      - build-wrappers-macos
+    - build-wrappers-windows
+    - build-wrappers-macos
+    - build-wrappers-ios
+    - build-wrappers-android
+    - build-wrappers-linux
     steps:
-      - name: Fetch MacOS
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: ${{ needs.build-wrappers-macos.outputs.wrappers-macos }}
-      - name: Fetch Windows x64
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: ${{ needs.build-wrappers-windows.outputs.wrappers-windows-x64 }}
-      - name: Fetch Windows Win32
-        uses: actions/cache@v2
-        with:
-          path: ./wrappers/build/**
-          key: ${{ needs.build-wrappers-windows.outputs.wrappers-windows-Win32 }}
+    - name: Fetch Artifacts
+      uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-wrappers-macos:
     runs-on: macos-latest
+    outputs:
+      wrappers-macos: ${{ steps.output-cache-key.outputs.wrappers-macos }}
     name: Build macOS wrappers
     steps:
       - name: Checkout code
@@ -24,7 +26,8 @@ jobs:
         run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
         if: steps.check-cache.outputs.cache-hit != 'true'
       - name: Output cacheKey
-        run: echo "::set-output name=cacheKey::wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+        id: output-cache-key
+        run: echo "::set-output name=wrappers-macos::wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
   build-wrappers-ios:
     runs-on: macos-latest
     name: Build iOS wrappers
@@ -43,7 +46,8 @@ jobs:
         run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
         if: steps.check-cache.outputs.cache-hit != 'true'
       - name: Output cacheKey
-        run: echo "::set-output name=cacheKey::wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+        id: output-cache-key
+        run: echo "::set-output name=wrappers-ios::wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
   build-wrappers-linux:
     runs-on: ubuntu-20.04
     name: Build Linux wrappers
@@ -62,7 +66,8 @@ jobs:
         run: ./wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
         if: steps.check-cache.outputs.cache-hit != 'true'
       - name: Output cacheKey
-        run: echo "::set-output name=cacheKey::wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+        id: output-cache-key
+        run: echo "::set-output name=wrappers-linux::wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
   build-wrappers-android:
     runs-on: ubuntu-20.04
     name: Build Android wrappers
@@ -88,9 +93,13 @@ jobs:
         run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
         if: steps.check-cache.outputs.cache-hit != 'true'
       - name: Output cacheKey
-        run: echo "::set-output name=cacheKey::wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+        id: output-cache-key
+        run: echo "::set-output name=wrappers-android-${{ matrix.arch }}::wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
   build-wrappers-windows:
     runs-on: windows-latest
+    outputs:
+      wrappers-windows-Win32: ${{ steps.output-cache-key.outputs.wrappers-windows-Win32 }}
+      wrappers-windows-x64: ${{ steps.output-cache-key.outputs.wrappers-windows-x64 }}
     name: Build Windows wrappers
     strategy:
       matrix:
@@ -128,7 +137,8 @@ jobs:
         run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
         if: steps.check-cache.outputs.cache-hit != 'true'
       - name: Output cacheKey
-        run: echo "::set-output name=cacheKey::wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+        id: output-cache-key
+        run: echo "::set-output name=wrappers-windows-${{ matrix.arch }}::wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
   build-wrappers-windows-uwp:
     runs-on: windows-latest
     name: Build Windows UWP wrappers
@@ -169,4 +179,27 @@ jobs:
         run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
         if: steps.check-cache.outputs.cache-hit != 'true'
       - name: Output cacheKey
-        run: echo "::set-output name=cacheKey::wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+        id: output-cache-key
+        run: echo "::set-output name=wrappers-windows-uwp-${{ matrix.arch }}::wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+  build-package:
+    runs-on: windows-latest
+    name: Build packages
+    needs:
+      - build-wrappers-windows
+      - build-wrappers-macos
+    steps:
+      - name: Fetch MacOS
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: ${{ needs.build-wrappers-macos.outputs.wrappers-macos }}
+      - name: Fetch Windows x64
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: ${{ needs.build-wrappers-windows.outputs.wrappers-windows-x64 }}
+      - name: Fetch Windows Win32
+        uses: actions/cache@v2
+        with:
+          path: ./wrappers/build/**
+          key: ${{ needs.build-wrappers-windows.outputs.wrappers-windows-Win32 }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,6 +197,11 @@ jobs:
       - build-wrappers-ios
       - build-wrappers-android
       - build-wrappers-linux
+      - build-wrappers-windows-uwp
     steps:
       - name: Fetch Artifacts
         uses: actions/download-artifact@v2
+        with:
+          path: wrappers/build
+      - name: list folder
+        run: powershell tree /F

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,5 +265,3 @@ jobs:
       with:
         name: wrappers-windows-uwp-ARM
         path: wrappers/build
-    - name: list folder
-      run: powershell tree /F

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: build and test
-on:
+"on":
   push:
     branches:
       - main
@@ -199,9 +199,25 @@ jobs:
       - build-wrappers-linux
       - build-wrappers-windows-uwp
     steps:
-      - name: Fetch Artifacts
+      - name: Fetch Artifacts Linux
         uses: actions/download-artifact@v2
         with:
+          name: wrappers-linux
+          path: wrappers/build
+      - name: Fetch Artifacts MacOS
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-macos
+          path: wrappers/build
+      - name: Fetch Artifacts Windows 32
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-windows-Win32
+          path: wrappers/build
+      - name: Fetch Artifacts Windows 64
+        uses: actions/download-artifact@v2
+        with:
+          name: wrappers-windows-x64
           path: wrappers/build
       - name: list folder
         run: powershell tree /F


### PR DESCRIPTION
## Description
All the binaries of the build wrappers are now stored as Github Action's artifacts. Additionally all the artifacts are fetched, so next time we'll be able to build the final nuget package of realm.

Fixes #2294
