### PR TITLE
Add workflow to verify code todos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: lint
+"on":
+  pull_request:
+jobs:
+  verify-todos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nirinchev/verify-todo@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          include: "**/*.+(cs|cpp|hpp)"
+          exclude: "wrappers/realm-core/**"
+          pattern: "\\WR[A-Z]+-[0-9]+"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,8 @@ stage('Checkout') {
       versionSuffix = "alpha.${env.BUILD_ID}"
     }
     // TODO: temp for beta releases
-    else if (env.CHANGE_BRANCH != null && env.CHANGE_BRANCH == "release/10.2.0-beta.1") {
-      versionSuffix = "beta.1"
+    else if (env.CHANGE_BRANCH != null && env.CHANGE_BRANCH == "release/10.2.0-beta.2") {
+      versionSuffix = "beta.2"
     }
     else if (env.CHANGE_BRANCH == null || !env.CHANGE_BRANCH.startsWith('release')) {
       versionSuffix = "PR-${env.CHANGE_ID}.${env.BUILD_ID}"


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This is using a very simple action I created during skunkworks - it walks the changed files and emits warnings if there's a `// TODO: blah blah` comment that doesn't have a link to Jira/Github.