### PR TITLE
Fix a few nits with generators

### DIFF
--- a/Realm.Generator/RealmPropertiesGenerator.cs
+++ b/Realm.Generator/RealmPropertiesGenerator.cs
@@ -56,7 +56,7 @@ namespace Realm.Generator
             var model = context.Compilation.GetSemanticModel(classNode.SyntaxTree);
 
             var className = classNode.Identifier.ValueText;
-            var namespaceName = (model.GetDeclaredSymbol(syntaxReceiver.NamespaceDeclaration) as INamespaceSymbol).ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+            var namespaceName = model.GetDeclaredSymbol(syntaxReceiver.NamespaceDeclaration).ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
 
             var usingsSource = GenerateUsingStrings(syntaxReceiver.UsingDeclarations);
 

--- a/Tests/Realm.Tests/Database/GeneratorTests.cs
+++ b/Tests/Realm.Tests/Database/GeneratorTests.cs
@@ -1,26 +1,22 @@
-﻿// ////////////////////////////////////////////////////////////////////////////
-// //
-// // Copyright 2021 Realm Inc.
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License")
-// // you may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// // http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
-// //
-// ////////////////////////////////////////////////////////////////////////////
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Realm.Generator;
 


### PR DESCRIPTION
## Description

Fixes a few minor things I discovered while studying the generator changes:
* Uses `ToDisplayString()` for the symbol type - this basically changes `Int32` to `int` and so on.
* Renames the generated source name to `*className*.Generated.cs` - I believe this is the common practice.
* Removes the leading trivia from using declarations. Ultimately, I'd like to add code to remove the unused usings, but haven't figured out a way to do that yet. Stripping the leading trivia removes the header, which we'd probably want to replace with something indicating that the file is generated and should not be manually edited.
* Removes a superficial cast to `RealmValue` in the property setter.