### PR TITLE
Added missing DebuggerDisplay

### DIFF
--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -41,7 +41,7 @@ namespace Realms
     /// </summary>
     [Preserve(AllMembers = true, Conditional = false)]
     [Serializable]
-    [DebuggerDisplay("IsValid={IsValid}")]
+    [DebuggerDisplay("{DebuggerDisplay(),nq}")]
     public abstract class RealmObjectBase
         : INotifyPropertyChanged,
           IThreadConfined,
@@ -66,6 +66,30 @@ namespace Realms
         [field: NonSerialized, XmlIgnore]
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "This is the private event - the public is uppercased.")]
         private event PropertyChangedEventHandler _propertyChanged;
+
+        internal string DebuggerDisplay(bool withTypeName = false)
+        {
+            var typeString = string.Empty;
+
+            if (withTypeName)
+            {
+                typeString = GetType().Name;
+            }
+
+            var pkString = string.Empty;
+
+            var pkProperty = _metadata?.Schema.PrimaryKeyProperty;
+            if (pkProperty != null && _metadata.Helper.TryGetPrimaryKeyValue(this as RealmObject, out var pkValue))
+            {
+                pkString += $"{pkProperty.Value.Name} = {pkValue}";
+            }
+
+            var isValidString = $"IsValid = {IsValid}";
+
+            var strings = new[] { typeString, pkString, isValidString }.Where(s => !string.IsNullOrEmpty(s));
+
+            return string.Join(", ", strings);
+        }
 
         /// <summary>
         /// Occurs when a property value changes.

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -41,6 +41,7 @@ namespace Realms
     /// </summary>
     [Preserve(AllMembers = true, Conditional = false)]
     [Serializable]
+    [DebuggerDisplay("IsValid={IsValid}")]
     public abstract class RealmObjectBase
         : INotifyPropertyChanged,
           IThreadConfined,

--- a/Realm/Realm/DatabaseTypes/RealmValue.cs
+++ b/Realm/Realm/DatabaseTypes/RealmValue.cs
@@ -51,7 +51,7 @@ namespace Realms
     /// </code>
     /// </example>
     [Preserve(AllMembers = true)]
-    [DebuggerDisplay("{DebuggerDisplay(),nq}")]
+    [DebuggerDisplay("Type = {Type}, Value = {ToString(),nq}")]
     public readonly struct RealmValue : IEquatable<RealmValue>
     {
         private readonly PrimitiveValue _primitiveValue;
@@ -117,16 +117,10 @@ namespace Realms
             _objectValue = obj;
         }
 
-        internal string DebuggerDisplay()
-        {
-            var valueString = Type == RealmValueType.Object ? AsRealmObject().DebuggerDisplay(true) : ToString();
-            return $"Type = {Type}, Value = {valueString}";
-        }
-
         /// <summary>
         /// Gets a RealmValue representing <c>null</c>.
         /// </summary>
-        /// <value>A new RealmValue instance of type <see cref="RealmValue.Null"/>.</value>
+        /// <value>A new RealmValue instance of type <see cref="Null"/>.</value>
         public static RealmValue Null => new RealmValue(PrimitiveValue.Null());
 
         private static RealmValue Bool(bool value) => new RealmValue(PrimitiveValue.Bool(value));

--- a/Realm/Realm/DatabaseTypes/RealmValue.cs
+++ b/Realm/Realm/DatabaseTypes/RealmValue.cs
@@ -51,7 +51,7 @@ namespace Realms
     /// </code>
     /// </example>
     [Preserve(AllMembers = true)]
-    [DebuggerDisplay("{Type} - {ToString(),nq}")]
+    [DebuggerDisplay("{DebuggerDisplay(),nq}")]
     public readonly struct RealmValue : IEquatable<RealmValue>
     {
         private readonly PrimitiveValue _primitiveValue;
@@ -115,6 +115,12 @@ namespace Realms
         {
             Type = obj == null ? RealmValueType.Null : RealmValueType.Object;
             _objectValue = obj;
+        }
+
+        internal string DebuggerDisplay()
+        {
+            var valueString = Type == RealmValueType.Object ? AsRealmObject().DebuggerDisplay(true) : ToString();
+            return $"Type = {Type}, Value = {valueString}";
         }
 
         /// <summary>

--- a/Realm/Realm/DatabaseTypes/RealmValue.cs
+++ b/Realm/Realm/DatabaseTypes/RealmValue.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -50,6 +51,7 @@ namespace Realms
     /// </code>
     /// </example>
     [Preserve(AllMembers = true)]
+    [DebuggerDisplay("{Type} - {ToString(),nq}")]
     public readonly struct RealmValue : IEquatable<RealmValue>
     {
         private readonly PrimitiveValue _primitiveValue;


### PR DESCRIPTION
This PR adds DebuggerDisplay to some Realm types. In particular debugger display contains:

- `RealmObjectBase`: `IsValid`
- `RealmValueType`: `Type - ToString()`  --> This can be useful to differentiate between different numerical types with similar string representation, for instance

Regarding the rest of the Realm types:
- Collection types (`Set`, `Dictionary`, `List`, `Result`) and their superclass `RealmCollectionBase` don't have anything meaningful to display in my opinion. For the "proper" collection types (`Set`, `Dictionary`, `List`), the parameter `Count` was already in the `DebuggerDisplay` attribute, and that seems fine.
- RealmInteger already prints the containing value in ToString(), and that also seems fine enough.

Fixes #2047

