### PR TITLE
Disallow counter collections

### DIFF
--- a/Realm/Realm.Weaver/RealmWeaver.cs
+++ b/Realm/Realm.Weaver/RealmWeaver.cs
@@ -105,18 +105,6 @@ namespace RealmWeaver
             RealmValueTypeName,
         };
 
-        public static readonly HashSet<string> _counterTypes = new HashSet<string>
-        {
-            $"Realms.RealmInteger`1<{ByteTypeName}>",
-            $"Realms.RealmInteger`1<{Int16TypeName}>",
-            $"Realms.RealmInteger`1<{Int32TypeName}>",
-            $"Realms.RealmInteger`1<{Int64TypeName}>",
-            $"System.Nullable`1<Realms.RealmInteger`1<{ByteTypeName}>>",
-            $"System.Nullable`1<Realms.RealmInteger`1<{Int16TypeName}>>",
-            $"System.Nullable`1<Realms.RealmInteger`1<{Int32TypeName}>>",
-            $"System.Nullable`1<Realms.RealmInteger`1<{Int64TypeName}>>",
-        };
-
         private static readonly IEnumerable<string> _primaryKeyTypes = new[]
         {
             StringTypeName,
@@ -405,7 +393,7 @@ Analytics payload
 
                 if (!elementType.Resolve().IsValidRealmObjectBaseInheritor(_references))
                 {
-                    if (_counterTypes.Contains(elementType.FullName))
+                    if (elementType.IsRealmInteger(out _, out _))
                     {
                         return WeavePropertyResult.Error($"{type.Name}.{prop.Name} is an {collectionType}<RealmInteger> which is not supported.");
                     }

--- a/Realm/Realm.Weaver/RealmWeaver.cs
+++ b/Realm/Realm.Weaver/RealmWeaver.cs
@@ -105,6 +105,18 @@ namespace RealmWeaver
             RealmValueTypeName,
         };
 
+        public static readonly HashSet<string> _counterTypes = new HashSet<string>
+        {
+            $"Realms.RealmInteger`1<{ByteTypeName}>",
+            $"Realms.RealmInteger`1<{Int16TypeName}>",
+            $"Realms.RealmInteger`1<{Int32TypeName}>",
+            $"Realms.RealmInteger`1<{Int64TypeName}>",
+            $"System.Nullable`1<Realms.RealmInteger`1<{ByteTypeName}>>",
+            $"System.Nullable`1<Realms.RealmInteger`1<{Int16TypeName}>>",
+            $"System.Nullable`1<Realms.RealmInteger`1<{Int32TypeName}>>",
+            $"System.Nullable`1<Realms.RealmInteger`1<{Int64TypeName}>>",
+        };
+
         private static readonly IEnumerable<string> _primaryKeyTypes = new[]
         {
             StringTypeName,
@@ -390,10 +402,18 @@ Analytics payload
             {
                 var genericArguments = ((GenericInstanceType)prop.PropertyType).GenericArguments;
                 var elementType = genericArguments.Last();
-                if (!elementType.Resolve().IsValidRealmObjectBaseInheritor(_references) &&
-                    !_realmValueTypes.Contains(elementType.FullName))
+
+                if (!elementType.Resolve().IsValidRealmObjectBaseInheritor(_references))
                 {
-                    return WeavePropertyResult.Error($"{type.Name}.{prop.Name} is an {collectionType} but its generic type is {elementType.Name} which is not supported by Realm.");
+                    if (_counterTypes.Contains(elementType.FullName))
+                    {
+                        return WeavePropertyResult.Error($"{type.Name}.{prop.Name} is an {collectionType}<RealmInteger> which is not supported.");
+                    }
+
+                    if (!_realmValueTypes.Contains(elementType.FullName))
+                    {
+                        return WeavePropertyResult.Error($"{type.Name}.{prop.Name} is an {collectionType} but its generic type is {elementType.Name} which is not supported by Realm.");
+                    }
                 }
 
                 if (prop.SetMethod != null)

--- a/Tests/Realm.Tests/Database/ListOfPrimitivesTests.cs
+++ b/Tests/Realm.Tests/Database/ListOfPrimitivesTests.cs
@@ -404,12 +404,6 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(ByteTestValues))]
-        public void Test_ManagedByteCounterList(byte[] values)
-        {
-            RunManagedTests(obj => obj.ByteCounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(ByteTestValues))]
         public void Test_ManagedByteList(byte[] values)
         {
             RunManagedTests(obj => obj.ByteList, values);
@@ -428,33 +422,15 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(Int16TestValues))]
-        public void Test_ManagedInt16CounterList(short[] values)
-        {
-            RunManagedTests(obj => obj.Int16CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(Int16TestValues))]
         public void Test_ManagedInt16List(short[] values)
         {
             RunManagedTests(obj => obj.Int16List, values);
         }
 
         [TestCaseSource(nameof(Int32TestValues))]
-        public void Test_ManagedInt32CounterList(int[] values)
-        {
-            RunManagedTests(obj => obj.Int32CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(Int32TestValues))]
         public void Test_ManagedInt32List(int[] values)
         {
             RunManagedTests(obj => obj.Int32List, values);
-        }
-
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void Test_ManagedInt64CounterList(long[] values)
-        {
-            RunManagedTests(obj => obj.Int64CounterList, values.ToInteger());
         }
 
         [TestCaseSource(nameof(Int64TestValues))]
@@ -500,12 +476,6 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(NullableByteTestValues))]
-        public void Test_ManagedNullableByteCounterList(byte?[] values)
-        {
-            RunManagedTests(obj => obj.NullableByteCounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(NullableByteTestValues))]
         public void Test_ManagedNullableByteList(byte?[] values)
         {
             RunManagedTests(obj => obj.NullableByteList, values);
@@ -524,33 +494,15 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(NullableInt16TestValues))]
-        public void Test_ManagedNullableInt16CounterList(short?[] values)
-        {
-            RunManagedTests(obj => obj.NullableInt16CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(NullableInt16TestValues))]
         public void Test_ManagedNullableInt16List(short?[] values)
         {
             RunManagedTests(obj => obj.NullableInt16List, values);
         }
 
         [TestCaseSource(nameof(NullableInt32TestValues))]
-        public void Test_ManagedNullableInt32CounterList(int?[] values)
-        {
-            RunManagedTests(obj => obj.NullableInt32CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(NullableInt32TestValues))]
         public void Test_ManagedNullableInt32List(int?[] values)
         {
             RunManagedTests(obj => obj.NullableInt32List, values);
-        }
-
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void Test_ManagedNullableInt64CounterList(long?[] values)
-        {
-            RunManagedTests(obj => obj.NullableInt64CounterList, values.ToInteger());
         }
 
         [TestCaseSource(nameof(NullableInt64TestValues))]
@@ -663,12 +615,6 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(ByteTestValues))]
-        public void Test_UnmanagedByteCounterList(byte[] values)
-        {
-            RunUnmanagedTests(o => o.ByteCounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(ByteTestValues))]
         public void Test_UnmanagedByteList(byte[] values)
         {
             RunUnmanagedTests(o => o.ByteList, values);
@@ -687,33 +633,15 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(Int16TestValues))]
-        public void Test_UnmanagedInt16CounterList(short[] values)
-        {
-            RunUnmanagedTests(o => o.Int16CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(Int16TestValues))]
         public void Test_UnmanagedInt16List(short[] values)
         {
             RunUnmanagedTests(o => o.Int16List, values);
         }
 
         [TestCaseSource(nameof(Int32TestValues))]
-        public void Test_UnmanagedInt32CounterList(int[] values)
-        {
-            RunUnmanagedTests(o => o.Int32CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(Int32TestValues))]
         public void Test_UnmanagedInt32List(int[] values)
         {
             RunUnmanagedTests(o => o.Int32List, values);
-        }
-
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void Test_UnmanagedInt64CounterList(long[] values)
-        {
-            RunUnmanagedTests(o => o.Int64CounterList, values.ToInteger());
         }
 
         [TestCaseSource(nameof(Int64TestValues))]
@@ -759,12 +687,6 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(NullableByteTestValues))]
-        public void Test_UnmanagedNullableByteCounterList(byte?[] values)
-        {
-            RunUnmanagedTests(o => o.NullableByteCounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(NullableByteTestValues))]
         public void Test_UnmanagedNullableByteList(byte?[] values)
         {
             RunUnmanagedTests(o => o.NullableByteList, values);
@@ -783,33 +705,15 @@ namespace Realms.Tests.Database
         }
 
         [TestCaseSource(nameof(NullableInt16TestValues))]
-        public void Test_UnmanagedNullableInt16CounterList(short?[] values)
-        {
-            RunUnmanagedTests(o => o.NullableInt16CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(NullableInt16TestValues))]
         public void Test_UnmanagedNullableInt16List(short?[] values)
         {
             RunUnmanagedTests(o => o.NullableInt16List, values);
         }
 
         [TestCaseSource(nameof(NullableInt32TestValues))]
-        public void Test_UnmanagedNullableInt32CounterList(int?[] values)
-        {
-            RunUnmanagedTests(o => o.NullableInt32CounterList, values.ToInteger());
-        }
-
-        [TestCaseSource(nameof(NullableInt32TestValues))]
         public void Test_UnmanagedNullableInt32List(int?[] values)
         {
             RunUnmanagedTests(o => o.NullableInt32List, values);
-        }
-
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void Test_UnmanagedNullableInt64CounterList(long?[] values)
-        {
-            RunUnmanagedTests(o => o.NullableInt64CounterList, values.ToInteger());
         }
 
         [TestCaseSource(nameof(NullableInt64TestValues))]

--- a/Tests/Realm.Tests/Database/RealmDictionaryTests.cs
+++ b/Tests/Realm.Tests/Database/RealmDictionaryTests.cs
@@ -119,22 +119,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.ByteDictionary, testData);
         }
 
-        [TestCaseSource(nameof(ByteTestValues))]
-        public void ByteCounter_Unmanaged(TestCaseData<byte> testData)
-        {
-            RunUnmanagedTests(o => o.ByteCounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableByteTestValues))]
         public void NullableByte_Unmanaged(TestCaseData<byte?> testData)
         {
             RunUnmanagedTests(o => o.NullableByteDictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableByteTestValues))]
-        public void NullableByteCounter_Unmanaged(TestCaseData<byte?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableByteCounterDictionary, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(ByteTestValues))]
@@ -143,22 +131,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.ByteDictionary, testData);
         }
 
-        [TestCaseSource(nameof(ByteTestValues))]
-        public void ByteCounter_Managed(TestCaseData<byte> testData)
-        {
-            RunManagedTests(o => o.ByteCounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableByteTestValues))]
         public void NullableByte_Managed(TestCaseData<byte?> testData)
         {
             RunManagedTests(o => o.NullableByteDictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableByteTestValues))]
-        public void NullableByteCounter_Managed(TestCaseData<byte?> testData)
-        {
-            RunManagedTests(o => o.NullableByteCounterDictionary, ToInteger(testData));
         }
 
         [Test]
@@ -171,18 +147,6 @@ namespace Realms.Tests.Database
         public void NullableByte_Notifications()
         {
             RunManagedNotificationsTests(o => o.NullableByteDictionary, NullableByteTestValues().Last());
-        }
-
-        [Test]
-        public void ByteCounter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.ByteCounterDictionary, ToInteger(ByteTestValues().Last()));
-        }
-
-        [Test]
-        public void NullableByteCounter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.NullableByteCounterDictionary, ToInteger(NullableByteTestValues().Last()));
         }
 
         #endregion
@@ -218,22 +182,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.Int16Dictionary, testData);
         }
 
-        [TestCaseSource(nameof(Int16TestValues))]
-        public void Int16Counter_Unmanaged(TestCaseData<short> testData)
-        {
-            RunUnmanagedTests(o => o.Int16CounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt16TestValues))]
         public void NullableInt16_Unmanaged(TestCaseData<short?> testData)
         {
             RunUnmanagedTests(o => o.NullableInt16Dictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt16TestValues))]
-        public void NullableInt16Counter_Unmanaged(TestCaseData<short?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableInt16CounterDictionary, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(Int16TestValues))]
@@ -242,22 +194,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.Int16Dictionary, testData);
         }
 
-        [TestCaseSource(nameof(Int16TestValues))]
-        public void Int16Counter_Managed(TestCaseData<short> testData)
-        {
-            RunManagedTests(o => o.Int16CounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt16TestValues))]
         public void NullableInt16_Managed(TestCaseData<short?> testData)
         {
             RunManagedTests(o => o.NullableInt16Dictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt16TestValues))]
-        public void NullableInt16Counter_Managed(TestCaseData<short?> testData)
-        {
-            RunManagedTests(o => o.NullableInt16CounterDictionary, ToInteger(testData));
         }
 
         [Test]
@@ -270,18 +210,6 @@ namespace Realms.Tests.Database
         public void NullableInt16_Notifications()
         {
             RunManagedNotificationsTests(o => o.NullableInt16Dictionary, NullableInt16TestValues().Last());
-        }
-
-        [Test]
-        public void Int16Counter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.Int16CounterDictionary, ToInteger(Int16TestValues().Last()));
-        }
-
-        [Test]
-        public void NullableInt16Counter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.NullableInt16CounterDictionary, ToInteger(NullableInt16TestValues().Last()));
         }
 
         #endregion
@@ -317,22 +245,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.Int32Dictionary, testData);
         }
 
-        [TestCaseSource(nameof(Int32TestValues))]
-        public void Int32Counter_Unmanaged(TestCaseData<int> testData)
-        {
-            RunUnmanagedTests(o => o.Int32CounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt32TestValues))]
         public void NullableInt32_Unmanaged(TestCaseData<int?> testData)
         {
             RunUnmanagedTests(o => o.NullableInt32Dictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt32TestValues))]
-        public void NullableInt32Counter_Unmanaged(TestCaseData<int?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableInt32CounterDictionary, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(Int32TestValues))]
@@ -341,22 +257,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.Int32Dictionary, testData);
         }
 
-        [TestCaseSource(nameof(Int32TestValues))]
-        public void Int32Counter_Managed(TestCaseData<int> testData)
-        {
-            RunManagedTests(o => o.Int32CounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt32TestValues))]
         public void NullableInt32_Managed(TestCaseData<int?> testData)
         {
             RunManagedTests(o => o.NullableInt32Dictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt32TestValues))]
-        public void NullableInt32Counter_Managed(TestCaseData<int?> testData)
-        {
-            RunManagedTests(o => o.NullableInt32CounterDictionary, ToInteger(testData));
         }
 
         [Test]
@@ -369,18 +273,6 @@ namespace Realms.Tests.Database
         public void NullableInt32_Notifications()
         {
             RunManagedNotificationsTests(o => o.NullableInt32Dictionary, NullableInt32TestValues().Last());
-        }
-
-        [Test]
-        public void Int32Counter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.Int32CounterDictionary, ToInteger(Int32TestValues().Last()));
-        }
-
-        [Test]
-        public void NullableInt32Counter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.NullableInt32CounterDictionary, ToInteger(NullableInt32TestValues().Last()));
         }
 
         #endregion
@@ -416,22 +308,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.Int64Dictionary, testData);
         }
 
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void Int64Counter_Unmanaged(TestCaseData<long> testData)
-        {
-            RunUnmanagedTests(o => o.Int64CounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt64TestValues))]
         public void NullableInt64_Unmanaged(TestCaseData<long?> testData)
         {
             RunUnmanagedTests(o => o.NullableInt64Dictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void NullableInt64Counter_Unmanaged(TestCaseData<long?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableInt64CounterDictionary, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(Int64TestValues))]
@@ -440,22 +320,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.Int64Dictionary, testData);
         }
 
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void Int64Counter_Managed(TestCaseData<long> testData)
-        {
-            RunManagedTests(o => o.Int64CounterDictionary, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt64TestValues))]
         public void NullableInt64_Managed(TestCaseData<long?> testData)
         {
             RunManagedTests(o => o.NullableInt64Dictionary, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void NullableInt64Counter_Managed(TestCaseData<long?> testData)
-        {
-            RunManagedTests(o => o.NullableInt64CounterDictionary, ToInteger(testData));
         }
 
         [Test]
@@ -468,18 +336,6 @@ namespace Realms.Tests.Database
         public void NullableInt64_Notifications()
         {
             RunManagedNotificationsTests(o => o.NullableInt64Dictionary, NullableInt64TestValues().Last());
-        }
-
-        [Test]
-        public void Int64Counter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.Int64CounterDictionary, ToInteger(Int64TestValues().Last()));
-        }
-
-        [Test]
-        public void NullableInt64Counter_Notifications()
-        {
-            RunManagedNotificationsTests(o => o.NullableInt64CounterDictionary, ToInteger(NullableInt64TestValues().Last()));
         }
         #endregion
 

--- a/Tests/Realm.Tests/Database/RealmSetTests.cs
+++ b/Tests/Realm.Tests/Database/RealmSetTests.cs
@@ -135,22 +135,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.ByteSet, testData);
         }
 
-        [TestCaseSource(nameof(ByteTestValues))]
-        public void RealmSet_WhenUnmanaged_ByteCounter(TestCaseData<byte> testData)
-        {
-            RunUnmanagedTests(o => o.ByteCounterSet, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableByteTestValues))]
         public void RealmSet_WhenUnmanaged_NullableByte(TestCaseData<byte?> testData)
         {
             RunUnmanagedTests(o => o.NullableByteSet, testData);
-        }
-
-        [TestCaseSource(nameof(NullableByteTestValues))]
-        public void RealmSet_WhenUnmanaged_NullableByteCounter(TestCaseData<byte?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableByteCounterSet, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(ByteTestValues))]
@@ -159,22 +147,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.ByteSet, o => o.ByteList, o => o.ByteDict, testData);
         }
 
-        [TestCaseSource(nameof(ByteTestValues))]
-        public void RealmSet_WhenManaged_ByteCounter(TestCaseData<byte> testData)
-        {
-            RunManagedTests(o => o.ByteCounterSet, o => o.ByteCounterList, o => o.ByteCounterDict, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableByteTestValues))]
         public void RealmSet_WhenManaged_NullableByte(TestCaseData<byte?> testData)
         {
             RunManagedTests(o => o.NullableByteSet, o => o.NullableByteList, o => o.NullableByteDict, testData);
-        }
-
-        [TestCaseSource(nameof(NullableByteTestValues))]
-        public void RealmSet_WhenManaged_NullableByteCounter(TestCaseData<byte?> testData)
-        {
-            RunManagedTests(o => o.NullableByteCounterSet, o => o.NullableByteCounterList, o => o.NullableByteCounterDict, ToInteger(testData));
         }
 
         [Test]
@@ -230,22 +206,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.Int16Set, testData);
         }
 
-        [TestCaseSource(nameof(Int16TestValues))]
-        public void RealmSet_WhenUnmanaged_Int16Counter(TestCaseData<short> testData)
-        {
-            RunUnmanagedTests(o => o.Int16CounterSet, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt16TestValues))]
         public void RealmSet_WhenUnmanaged_NullableInt16(TestCaseData<short?> testData)
         {
             RunUnmanagedTests(o => o.NullableInt16Set, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt16TestValues))]
-        public void RealmSet_WhenUnmanaged_NullableInt16Counter(TestCaseData<short?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableInt16CounterSet, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(Int16TestValues))]
@@ -254,22 +218,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.Int16Set, o => o.Int16List, o => o.Int16Dict, testData);
         }
 
-        [TestCaseSource(nameof(Int16TestValues))]
-        public void RealmSet_WhenManaged_Int16Counter(TestCaseData<short> testData)
-        {
-            RunManagedTests(o => o.Int16CounterSet, o => o.Int16CounterList, o => o.Int16CounterDict, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt16TestValues))]
         public void RealmSet_WhenManaged_NullableInt16(TestCaseData<short?> testData)
         {
             RunManagedTests(o => o.NullableInt16Set, o => o.NullableInt16List, o => o.NullableInt16Dict, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt16TestValues))]
-        public void RealmSet_WhenManaged_NullableInt16Counter(TestCaseData<short?> testData)
-        {
-            RunManagedTests(o => o.NullableInt16CounterSet, o => o.NullableInt16CounterList, o => o.NullableInt16CounterDict, ToInteger(testData));
         }
 
         [Test]
@@ -325,22 +277,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.Int32Set, testData);
         }
 
-        [TestCaseSource(nameof(Int32TestValues))]
-        public void RealmSet_WhenUnmanaged_Int32Counter(TestCaseData<int> testData)
-        {
-            RunUnmanagedTests(o => o.Int32CounterSet, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt32TestValues))]
         public void RealmSet_WhenUnmanaged_NullableInt32(TestCaseData<int?> testData)
         {
             RunUnmanagedTests(o => o.NullableInt32Set, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt32TestValues))]
-        public void RealmSet_WhenUnmanaged_NullableInt32Counter(TestCaseData<int?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableInt32CounterSet, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(Int32TestValues))]
@@ -349,22 +289,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.Int32Set, o => o.Int32List, o => o.Int32Dict, testData);
         }
 
-        [TestCaseSource(nameof(Int32TestValues))]
-        public void RealmSet_WhenManaged_Int32Counter(TestCaseData<int> testData)
-        {
-            RunManagedTests(o => o.Int32CounterSet, o => o.Int32CounterList, o => o.Int32CounterDict, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt32TestValues))]
         public void RealmSet_WhenManaged_NullableInt32(TestCaseData<int?> testData)
         {
             RunManagedTests(o => o.NullableInt32Set, o => o.NullableInt32List, o => o.NullableInt32Dict, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt32TestValues))]
-        public void RealmSet_WhenManaged_NullableInt32Counter(TestCaseData<int?> testData)
-        {
-            RunManagedTests(o => o.NullableInt32CounterSet, o => o.NullableInt32CounterList, o => o.NullableInt32CounterDict, ToInteger(testData));
         }
 
         [Test]
@@ -420,22 +348,10 @@ namespace Realms.Tests.Database
             RunUnmanagedTests(o => o.Int64Set, testData);
         }
 
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void RealmSet_WhenUnmanaged_Int64Counter(TestCaseData<long> testData)
-        {
-            RunUnmanagedTests(o => o.Int64CounterSet, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt64TestValues))]
         public void RealmSet_WhenUnmanaged_NullableInt64(TestCaseData<long?> testData)
         {
             RunUnmanagedTests(o => o.NullableInt64Set, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void RealmSet_WhenUnmanaged_NullableInt64Counter(TestCaseData<long?> testData)
-        {
-            RunUnmanagedTests(o => o.NullableInt64CounterSet, ToInteger(testData));
         }
 
         [TestCaseSource(nameof(Int64TestValues))]
@@ -444,22 +360,10 @@ namespace Realms.Tests.Database
             RunManagedTests(o => o.Int64Set, o => o.Int64List, o => o.Int64Dict, testData);
         }
 
-        [TestCaseSource(nameof(Int64TestValues))]
-        public void RealmSet_WhenManaged_Int64Counter(TestCaseData<long> testData)
-        {
-            RunManagedTests(o => o.Int64CounterSet, o => o.Int64CounterList, o => o.Int64CounterDict, ToInteger(testData));
-        }
-
         [TestCaseSource(nameof(NullableInt64TestValues))]
         public void RealmSet_WhenManaged_NullableInt64(TestCaseData<long?> testData)
         {
             RunManagedTests(o => o.NullableInt64Set, o => o.NullableInt64List, o => o.NullableInt64Dict, testData);
-        }
-
-        [TestCaseSource(nameof(NullableInt64TestValues))]
-        public void RealmSet_WhenManaged_NullableInt64Counter(TestCaseData<long?> testData)
-        {
-            RunManagedTests(o => o.NullableInt64CounterSet, o => o.NullableInt64CounterList, o => o.NullableInt64CounterDict, ToInteger(testData));
         }
 
         [Test]

--- a/Tests/Realm.Tests/Database/TestObjects.cs
+++ b/Tests/Realm.Tests/Database/TestObjects.cs
@@ -162,22 +162,6 @@ namespace Realms.Tests
 
         public IList<Guid?> NullableGuidList { get; }
 
-        public IList<RealmInteger<byte>> ByteCounterList { get; }
-
-        public IList<RealmInteger<short>> Int16CounterList { get; }
-
-        public IList<RealmInteger<int>> Int32CounterList { get; }
-
-        public IList<RealmInteger<long>> Int64CounterList { get; }
-
-        public IList<RealmInteger<byte>?> NullableByteCounterList { get; }
-
-        public IList<RealmInteger<short>?> NullableInt16CounterList { get; }
-
-        public IList<RealmInteger<int>?> NullableInt32CounterList { get; }
-
-        public IList<RealmInteger<long>?> NullableInt64CounterList { get; }
-
         public IList<RealmValue> RealmValueList { get; }
     }
 
@@ -241,22 +225,6 @@ namespace Realms.Tests
 
         public ISet<ObjectId?> NullableObjectIdSet { get; }
 
-        public ISet<RealmInteger<byte>> ByteCounterSet { get; }
-
-        public ISet<RealmInteger<short>> Int16CounterSet { get; }
-
-        public ISet<RealmInteger<int>> Int32CounterSet { get; }
-
-        public ISet<RealmInteger<long>> Int64CounterSet { get; }
-
-        public ISet<RealmInteger<byte>?> NullableByteCounterSet { get; }
-
-        public ISet<RealmInteger<short>?> NullableInt16CounterSet { get; }
-
-        public ISet<RealmInteger<int>?> NullableInt32CounterSet { get; }
-
-        public ISet<RealmInteger<long>?> NullableInt64CounterSet { get; }
-
         public ISet<IntPropertyObject> ObjectSet { get; }
 
         public ISet<RealmValue> RealmValueSet { get; }
@@ -319,22 +287,6 @@ namespace Realms.Tests
 
         public IList<ObjectId?> NullableObjectIdList { get; }
 
-        public IList<RealmInteger<byte>> ByteCounterList { get; }
-
-        public IList<RealmInteger<short>> Int16CounterList { get; }
-
-        public IList<RealmInteger<int>> Int32CounterList { get; }
-
-        public IList<RealmInteger<long>> Int64CounterList { get; }
-
-        public IList<RealmInteger<byte>?> NullableByteCounterList { get; }
-
-        public IList<RealmInteger<short>?> NullableInt16CounterList { get; }
-
-        public IList<RealmInteger<int>?> NullableInt32CounterList { get; }
-
-        public IList<RealmInteger<long>?> NullableInt64CounterList { get; }
-
         public IList<IntPropertyObject> ObjectList { get; }
 
         public IList<RealmValue> RealmValueList { get; }
@@ -396,22 +348,6 @@ namespace Realms.Tests
         public IDictionary<string, Decimal128?> NullableDecimal128Dict { get; }
 
         public IDictionary<string, ObjectId?> NullableObjectIdDict { get; }
-
-        public IDictionary<string, RealmInteger<byte>> ByteCounterDict { get; }
-
-        public IDictionary<string, RealmInteger<short>> Int16CounterDict { get; }
-
-        public IDictionary<string, RealmInteger<int>> Int32CounterDict { get; }
-
-        public IDictionary<string, RealmInteger<long>> Int64CounterDict { get; }
-
-        public IDictionary<string, RealmInteger<byte>?> NullableByteCounterDict { get; }
-
-        public IDictionary<string, RealmInteger<short>?> NullableInt16CounterDict { get; }
-
-        public IDictionary<string, RealmInteger<int>?> NullableInt32CounterDict { get; }
-
-        public IDictionary<string, RealmInteger<long>?> NullableInt64CounterDict { get; }
 
         public IDictionary<string, IntPropertyObject> ObjectDict { get; }
 
@@ -588,22 +524,6 @@ namespace Realms.Tests
         public IDictionary<string, Decimal128?> NullableDecimal128Dictionary { get; }
 
         public IDictionary<string, ObjectId?> NullableObjectIdDictionary { get; }
-
-        public IDictionary<string, RealmInteger<byte>> ByteCounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<short>> Int16CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<int>> Int32CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<long>> Int64CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<byte>?> NullableByteCounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<short>?> NullableInt16CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<int>?> NullableInt32CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<long>?> NullableInt64CounterDictionary { get; }
 
         public IDictionary<string, byte[]> NullableBinaryDictionary { get; }
 

--- a/Tests/Weaver/AssemblyToProcess/FaultyClasses.cs
+++ b/Tests/Weaver/AssemblyToProcess/FaultyClasses.cs
@@ -23,6 +23,18 @@ using Realms;
 
 namespace AssemblyToProcess
 {
+    public class RealmCollectionsWithCounter : RealmObject
+    {
+        public int Id { get; set; }
+
+        public IList<RealmInteger<int>> CounterList { get; set; }
+
+        public ISet<RealmInteger<int>> CounterSet { get; set; }
+
+        public IDictionary<string, RealmInteger<int>> CounterDict { get; set; }
+
+    }
+
     public class RealmListWithSetter : RealmObject
     {
         public IList<Person> People { get; set; }

--- a/Tests/Weaver/AssemblyToProcess/TestObjects.cs
+++ b/Tests/Weaver/AssemblyToProcess/TestObjects.cs
@@ -151,22 +151,6 @@ namespace AssemblyToProcess
         public IList<ObjectId?> NullableObjectIdList { get; }
 
         public IList<Guid?> NullableGuidList { get; }
-
-        public IList<RealmInteger<byte>> ByteCounterList { get; }
-
-        public IList<RealmInteger<short>> Int16CounterList { get; }
-
-        public IList<RealmInteger<int>> Int32CounterList { get; }
-
-        public IList<RealmInteger<long>> Int64CounterList { get; }
-
-        public IList<RealmInteger<byte>?> NullableByteCounterList { get; }
-
-        public IList<RealmInteger<short>?> NullableInt16CounterList { get; }
-
-        public IList<RealmInteger<int>?> NullableInt32CounterList { get; }
-
-        public IList<RealmInteger<long>?> NullableInt64CounterList { get; }
     }
 
     public class SetsObject : RealmObject
@@ -220,22 +204,6 @@ namespace AssemblyToProcess
         public ISet<Decimal128?> NullableDecimal128Set { get; }
 
         public ISet<ObjectId?> NullableObjectIdSet { get; }
-
-        public ISet<RealmInteger<byte>> ByteCounterSet { get; }
-
-        public ISet<RealmInteger<short>> Int16CounterSet { get; }
-
-        public ISet<RealmInteger<int>> Int32CounterSet { get; }
-
-        public ISet<RealmInteger<long>> Int64CounterSet { get; }
-
-        public ISet<RealmInteger<byte>?> NullableByteCounterSet { get; }
-
-        public ISet<RealmInteger<short>?> NullableInt16CounterSet { get; }
-
-        public ISet<RealmInteger<int>?> NullableInt32CounterSet { get; }
-
-        public ISet<RealmInteger<long>?> NullableInt64CounterSet { get; }
     }
 
     public class DictionariesObject : RealmObject
@@ -292,22 +260,6 @@ namespace AssemblyToProcess
         public IDictionary<string, Decimal128?> NullableDecimal128Dictionary { get; }
 
         public IDictionary<string, ObjectId?> NullableObjectIdDictionary { get; }
-
-        public IDictionary<string, RealmInteger<byte>> ByteCounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<short>> Int16CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<int>> Int32CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<long>> Int64CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<byte>?> NullableByteCounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<short>?> NullableInt16CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<int>?> NullableInt32CounterDictionary { get; }
-
-        public IDictionary<string, RealmInteger<long>?> NullableInt64CounterDictionary { get; }
     }
 
     public class MixOfCollectionsObject : RealmObject

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -83,7 +83,7 @@ namespace RealmWeaver
                 Config = config
             };
 
-            return weaver.ExecuteTestRun(assemblyPath, runPeVerify: false, ignoreCodes: new[] { "80131869" }); ;
+            return weaver.ExecuteTestRun(assemblyPath, runPeVerify: false, ignoreCodes: new[] { "80131869" });
         }
 
         #endregion helpers

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -83,7 +83,7 @@ namespace RealmWeaver
                 Config = config
             };
 
-            return weaver.ExecuteTestRun(assemblyPath, ignoreCodes: new[] { "80131869" });
+            return weaver.ExecuteTestRun(assemblyPath, runPeVerify: false, ignoreCodes: new[] { "80131869" }); ;
         }
 
         #endregion helpers
@@ -490,6 +490,9 @@ namespace RealmWeaver
 
             var expectedErrors = new[]
             {
+                "RealmCollectionsWithCounter.CounterList is an IList<RealmInteger> which is not supported.",
+                "RealmCollectionsWithCounter.CounterSet is an ISet<RealmInteger> which is not supported.",
+                "RealmCollectionsWithCounter.CounterDict is an IDictionary<RealmInteger> which is not supported.",
                 "RealmListWithSetter.People has a setter but its type is a IList which only supports getters.",
                 "Class EmbeddedWithPrimaryKey is an EmbeddedObject but has a primary key NotAllowed defined.",
                 "IndexedProperties.SingleProperty is marked as [Indexed] which is only allowed on integral types as well as string, bool and DateTimeOffset, not on System.Single.",


### PR DESCRIPTION
This PR adds an error in the weaver when declaring collections of `RealmInteger`.

Fixes #2308
