### PR TITLE
Remove Lambda.Compile from results visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 
 ### Internal
 * Using Core 11.x.y. (it's in flux)
+* Removed Lambda compilation in ResultsVisitor when we encounter a conversion operator. This
+  is needed because IL2CPP cannot comiple lambdas dynamically. Instead, we're now using
+  `Operator.Convert<TTarget>(object)` which is slightly less efficient than `Operator.Convert<TSource, TTarget>`
+  but still quite a bit faster than `Convert.ChangeType` and also doesn't suffer from the
+  deficiencies around `Decimal128` conversion. The main downside is that we'll no longer
+  support queries with an argument that is a custom user type with an implicit conversion
+  operator defined.
 
 ## 10.2.0-beta.1 (2021-04-12)
 

--- a/Realm/Realm/GlobalSuppressions.cs
+++ b/Realm/Realm/GlobalSuppressions.cs
@@ -23,3 +23,5 @@
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is the private event", Scope = "member", Target = "~E:Realms.Realm._realmChanged")]
 [assembly: SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "The values of the enum represent types.", Scope = "type", Target = "~T:Realms.RealmValueType")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Doesn't need docs", Scope = "type", Target = "~T:Realms.Helpers.Operator.ISpecializedConverter`2")]
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Doesn't need docs", Scope = "member", Target = "~P:Realms.Helpers.Operator.IGenericConverter`1.SourceType")]
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Doesn't need docs", Scope = "member", Target = "~M:Realms.Helpers.Operator.IGenericConverter`1.Convert(System.Object)~`0")]

--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -367,10 +367,9 @@ namespace Realms.Helpers
         /// know the exact type, but we know that a conversion exists.
         /// </summary>
         /// <remarks>
-        /// In synthetic benchmarks it performs about
-        /// two orders of magnitude faster than Convert.ChangeType. It is about 4 times slower than a direct cast
-        /// when the types are known, but about an order of magnitude faster than a cast that involves boxing to
-        /// object.
+        /// In synthetic benchmarks it performs about two orders of magnitude faster than Convert.ChangeType.
+        /// It is about 4 times slower than a direct cast when the types are known, but about an order of
+        /// magnitude faster than a cast that involves boxing to object.
         /// <br/>
         /// It makes use of implicit and explicit conversion operators defined on types to convert between
         /// numeric types, which means that we can use it both for downcasting and upcasting numeric types.
@@ -410,6 +409,65 @@ namespace Realms.Helpers
             }
 
             return GenericOperator<TFrom, TResult>.Convert(value);
+        }
+
+        /// <summary>
+        /// Converts an object to <typeparamref name="TResult"/>. It is intended to be used instead of Convert.ChangeType
+        /// for database types. It is less efficient than <see cref="Convert{TFrom, TResult}(TFrom)"/> so if both the source
+        /// and the target types are known, use the concrete conversion.
+        /// </summary>
+        /// <typeparam name="TResult">The type to which <paramref name="value"/> will be converted.</typeparam>
+        /// <param name="value">The value to convert to <typeparamref name="TResult"/>.</param>
+        /// <returns>The value of <paramref name="value"/> represented as <typeparamref name="TResult"/>.</returns>
+        public static TResult Convert<TResult>(object value)
+        {
+            var targetType = typeof(TResult);
+            if (targetType == typeof(RealmValue))
+            {
+                /* This is special cased due to a bug in the Xamarin.iOS interpreter. When value
+                 * is null, we end up with a NRE with the following stacktrace:
+                 *
+                 * <System.NullReferenceException: Object reference not set to an instance of an object
+                 * at System.Linq.Expressions.Interpreter.LightLambda.Run1[T0,TRet] (T0 arg0) [0x00038] in <ee28ffe65f2e47a98ea97b07327fb8f4>:0
+                 * at (wrapper delegate-invoke) System.Func`2[System.String,Realms.RealmValue].invoke_TResult_T(string)
+                 * at Realms.Helpers.Operator.Convert[TFrom,TResult] (TFrom value) [0x00005] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 * at Realms.RealmList`1[T].<.ctor>b__5_1 (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 * at Realms.RealmList`1[T].Add (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 *
+                 * May or may not be related to https://github.com/mono/mono/issues/15852.
+                 */
+                if (value is null)
+                {
+                    return Convert<RealmValue, TResult>(RealmValue.Null);
+                }
+
+                /* This is another special case where `value` is inheritable from RealmObjectBase. There's
+                 * no direct conversion from T to RealmValue, but there's conversion if we go through RealmObjectBase.
+                 */
+                if (value is RealmObjectBase robj)
+                {
+                    return Convert<RealmValue, TResult>(robj);
+                }
+            }
+
+            if (value is null)
+            {
+                return default(TResult) == null ? default(TResult) : throw new NotSupportedException($"Can't convert from null to {targetType.FullName} because the target type is not nullable.");
+            }
+
+            var sourceType = value.GetType();
+
+            if (_valueConverters.TryGetValue((sourceType, targetType), out var converter))
+            {
+                return ((IGenericConverter<TResult>)converter).Convert(value);
+            }
+
+            if (value is TResult res)
+            {
+                return res;
+            }
+
+            throw new NotSupportedException($"No conversion exists from {sourceType.FullName} to {targetType.FullName}");
         }
 
         /// <summary>
@@ -459,6 +517,18 @@ namespace Realms.Helpers
         }
 
         /// <summary>
+        /// An interface representing converter that can convert from <see cref="SourceType"/> to
+        /// <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TTarget">The type to which <see cref="SourceType"/> will be converted.</typeparam>
+        private interface IGenericConverter<TTarget> : IConverter
+        {
+            Type SourceType { get; }
+
+            TTarget Convert(object obj);
+        }
+
+        /// <summary>
         /// Interface representing a concrete converter from <typeparamref name="TSource"/>
         /// to <typeparamref name="TTarget"/>. For most types there will be exactly one concrete
         /// implementation, but there may be cases, such as <see cref="InheritanceConverter{TSource, TTarget}"/>
@@ -466,9 +536,18 @@ namespace Realms.Helpers
         /// </summary>
         /// <typeparam name="TSource">The type from which to convert.</typeparam>
         /// <typeparam name="TTarget">The type to which <typeparamref name="TSource"/> will be converted.</typeparam>
-        private interface ISpecializedConverter<TSource, TTarget> : IConverter
+        private interface ISpecializedConverter<TSource, TTarget> : IGenericConverter<TTarget>
         {
             TTarget Convert(TSource source);
+        }
+
+        private abstract class SpecializedConverterBase<TSource, TTarget> : ISpecializedConverter<TSource, TTarget>
+        {
+            public Type SourceType { get; } = typeof(TSource);
+
+            public abstract TTarget Convert(TSource source);
+
+            public virtual TTarget Convert(object obj) => Convert((TSource)obj);
         }
 
         /// <summary>
@@ -478,9 +557,9 @@ namespace Realms.Helpers
         /// </summary>
         /// <typeparam name="TSource">The type from which to convert.</typeparam>
         /// <typeparam name="TTarget">The type to which <typeparamref name="TSource"/> will be converted.</typeparam>
-        private class ThrowingConverter<TSource, TTarget> : ISpecializedConverter<TSource, TTarget>
+        private class ThrowingConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
         {
-            public TTarget Convert(TSource source) => throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
+            public override TTarget Convert(TSource source) => throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
         }
 
         /// <summary>
@@ -488,9 +567,9 @@ namespace Realms.Helpers
         /// the target type is, so we need to convert, just in case.
         /// </summary>
         /// <typeparam name="T">The type of both the source and the target.</typeparam>
-        private class UnaryConverter<T> : ISpecializedConverter<T, T>
+        private class UnaryConverter<T> : SpecializedConverterBase<T, T>
         {
-            public T Convert(T source) => source;
+            public override T Convert(T source) => source;
         }
 
         /// <summary>
@@ -500,1656 +579,1658 @@ namespace Realms.Helpers
         /// </summary>
         /// <typeparam name="TSource">The type from which to convert.</typeparam>
         /// <typeparam name="TTarget">The type to which <typeparamref name="TSource"/> will be converted.</typeparam>
-        private class InheritanceConverter<TSource, TTarget> : ISpecializedConverter<TSource, TTarget>
+        private class InheritanceConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
         {
-            public TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
+            public override TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
+
+            public override TTarget Convert(object source) => source is TTarget obj ? obj : throw new NotSupportedException($"No conversion exists from {source?.GetType().FullName} to {typeof(TTarget).FullName}");
         }
 
         #region ToRealmValue Converters
 
-        public class CharRealmValueConverter : ISpecializedConverter<char, RealmValue>
+        private class CharRealmValueConverter : SpecializedConverterBase<char, RealmValue>
         {
-            public RealmValue Convert(char value) => value;
+            public override RealmValue Convert(char value) => value;
         }
 
-        public class ByteRealmValueConverter : ISpecializedConverter<byte, RealmValue>
+        private class ByteRealmValueConverter : SpecializedConverterBase<byte, RealmValue>
         {
-            public RealmValue Convert(byte value) => value;
+            public override RealmValue Convert(byte value) => value;
         }
 
-        public class ShortRealmValueConverter : ISpecializedConverter<short, RealmValue>
+        private class ShortRealmValueConverter : SpecializedConverterBase<short, RealmValue>
         {
-            public RealmValue Convert(short value) => value;
+            public override RealmValue Convert(short value) => value;
         }
 
-        public class IntRealmValueConverter : ISpecializedConverter<int, RealmValue>
+        private class IntRealmValueConverter : SpecializedConverterBase<int, RealmValue>
         {
-            public RealmValue Convert(int value) => value;
+            public override RealmValue Convert(int value) => value;
         }
 
-        public class LongRealmValueConverter : ISpecializedConverter<long, RealmValue>
+        private class LongRealmValueConverter : SpecializedConverterBase<long, RealmValue>
         {
-            public RealmValue Convert(long value) => value;
+            public override RealmValue Convert(long value) => value;
         }
 
-        public class FloatRealmValueConverter : ISpecializedConverter<float, RealmValue>
+        private class FloatRealmValueConverter : SpecializedConverterBase<float, RealmValue>
         {
-            public RealmValue Convert(float value) => value;
+            public override RealmValue Convert(float value) => value;
         }
 
-        public class DoubleRealmValueConverter : ISpecializedConverter<double, RealmValue>
+        private class DoubleRealmValueConverter : SpecializedConverterBase<double, RealmValue>
         {
-            public RealmValue Convert(double value) => value;
+            public override RealmValue Convert(double value) => value;
         }
 
-        public class BoolRealmValueConverter : ISpecializedConverter<bool, RealmValue>
+        private class BoolRealmValueConverter : SpecializedConverterBase<bool, RealmValue>
         {
-            public RealmValue Convert(bool value) => value;
+            public override RealmValue Convert(bool value) => value;
         }
 
-        public class DateTimeOffsetRealmValueConverter : ISpecializedConverter<DateTimeOffset, RealmValue>
+        private class DateTimeOffsetRealmValueConverter : SpecializedConverterBase<DateTimeOffset, RealmValue>
         {
-            public RealmValue Convert(DateTimeOffset value) => value;
+            public override RealmValue Convert(DateTimeOffset value) => value;
         }
 
-        public class DecimalRealmValueConverter : ISpecializedConverter<decimal, RealmValue>
+        private class DecimalRealmValueConverter : SpecializedConverterBase<decimal, RealmValue>
         {
-            public RealmValue Convert(decimal value) => value;
+            public override RealmValue Convert(decimal value) => value;
         }
 
-        public class Decimal128RealmValueConverter : ISpecializedConverter<Decimal128, RealmValue>
+        private class Decimal128RealmValueConverter : SpecializedConverterBase<Decimal128, RealmValue>
         {
-            public RealmValue Convert(Decimal128 value) => value;
+            public override RealmValue Convert(Decimal128 value) => value;
         }
 
-        public class ObjectIdRealmValueConverter : ISpecializedConverter<ObjectId, RealmValue>
+        private class ObjectIdRealmValueConverter : SpecializedConverterBase<ObjectId, RealmValue>
         {
-            public RealmValue Convert(ObjectId value) => value;
+            public override RealmValue Convert(ObjectId value) => value;
         }
 
-        public class GuidRealmValueConverter : ISpecializedConverter<Guid, RealmValue>
+        private class GuidRealmValueConverter : SpecializedConverterBase<Guid, RealmValue>
         {
-            public RealmValue Convert(Guid value) => value;
+            public override RealmValue Convert(Guid value) => value;
         }
 
-        public class NullableCharRealmValueConverter : ISpecializedConverter<char?, RealmValue>
+        private class NullableCharRealmValueConverter : SpecializedConverterBase<char?, RealmValue>
         {
-            public RealmValue Convert(char? value) => value;
+            public override RealmValue Convert(char? value) => value;
         }
 
-        public class NullableByteRealmValueConverter : ISpecializedConverter<byte?, RealmValue>
+        private class NullableByteRealmValueConverter : SpecializedConverterBase<byte?, RealmValue>
         {
-            public RealmValue Convert(byte? value) => value;
+            public override RealmValue Convert(byte? value) => value;
         }
 
-        public class NullableShortRealmValueConverter : ISpecializedConverter<short?, RealmValue>
+        private class NullableShortRealmValueConverter : SpecializedConverterBase<short?, RealmValue>
         {
-            public RealmValue Convert(short? value) => value;
+            public override RealmValue Convert(short? value) => value;
         }
 
-        public class NullableIntRealmValueConverter : ISpecializedConverter<int?, RealmValue>
+        private class NullableIntRealmValueConverter : SpecializedConverterBase<int?, RealmValue>
         {
-            public RealmValue Convert(int? value) => value;
+            public override RealmValue Convert(int? value) => value;
         }
 
-        public class NullableLongRealmValueConverter : ISpecializedConverter<long?, RealmValue>
+        private class NullableLongRealmValueConverter : SpecializedConverterBase<long?, RealmValue>
         {
-            public RealmValue Convert(long? value) => value;
+            public override RealmValue Convert(long? value) => value;
         }
 
-        public class NullableFloatRealmValueConverter : ISpecializedConverter<float?, RealmValue>
+        private class NullableFloatRealmValueConverter : SpecializedConverterBase<float?, RealmValue>
         {
-            public RealmValue Convert(float? value) => value;
+            public override RealmValue Convert(float? value) => value;
         }
 
-        public class NullableDoubleRealmValueConverter : ISpecializedConverter<double?, RealmValue>
+        private class NullableDoubleRealmValueConverter : SpecializedConverterBase<double?, RealmValue>
         {
-            public RealmValue Convert(double? value) => value;
+            public override RealmValue Convert(double? value) => value;
         }
 
-        public class NullableBoolRealmValueConverter : ISpecializedConverter<bool?, RealmValue>
+        private class NullableBoolRealmValueConverter : SpecializedConverterBase<bool?, RealmValue>
         {
-            public RealmValue Convert(bool? value) => value;
+            public override RealmValue Convert(bool? value) => value;
         }
 
-        public class NullableDateTimeOffsetRealmValueConverter : ISpecializedConverter<DateTimeOffset?, RealmValue>
+        private class NullableDateTimeOffsetRealmValueConverter : SpecializedConverterBase<DateTimeOffset?, RealmValue>
         {
-            public RealmValue Convert(DateTimeOffset? value) => value;
+            public override RealmValue Convert(DateTimeOffset? value) => value;
         }
 
-        public class NullableDecimalRealmValueConverter : ISpecializedConverter<decimal?, RealmValue>
+        private class NullableDecimalRealmValueConverter : SpecializedConverterBase<decimal?, RealmValue>
         {
-            public RealmValue Convert(decimal? value) => value;
+            public override RealmValue Convert(decimal? value) => value;
         }
 
-        public class NullableDecimal128RealmValueConverter : ISpecializedConverter<Decimal128?, RealmValue>
+        private class NullableDecimal128RealmValueConverter : SpecializedConverterBase<Decimal128?, RealmValue>
         {
-            public RealmValue Convert(Decimal128? value) => value;
+            public override RealmValue Convert(Decimal128? value) => value;
         }
 
-        public class NullableObjectIdRealmValueConverter : ISpecializedConverter<ObjectId?, RealmValue>
+        private class NullableObjectIdRealmValueConverter : SpecializedConverterBase<ObjectId?, RealmValue>
         {
-            public RealmValue Convert(ObjectId? value) => value;
+            public override RealmValue Convert(ObjectId? value) => value;
         }
 
-        public class NullableGuidRealmValueConverter : ISpecializedConverter<Guid?, RealmValue>
+        private class NullableGuidRealmValueConverter : SpecializedConverterBase<Guid?, RealmValue>
         {
-            public RealmValue Convert(Guid? value) => value;
+            public override RealmValue Convert(Guid? value) => value;
         }
 
-        public class RealmIntegerByteRealmValueConverter : ISpecializedConverter<RealmInteger<byte>, RealmValue>
+        private class RealmIntegerByteRealmValueConverter : SpecializedConverterBase<RealmInteger<byte>, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<byte> value) => value;
+            public override RealmValue Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerShortRealmValueConverter : ISpecializedConverter<RealmInteger<short>, RealmValue>
+        private class RealmIntegerShortRealmValueConverter : SpecializedConverterBase<RealmInteger<short>, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<short> value) => value;
+            public override RealmValue Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerIntRealmValueConverter : ISpecializedConverter<RealmInteger<int>, RealmValue>
+        private class RealmIntegerIntRealmValueConverter : SpecializedConverterBase<RealmInteger<int>, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<int> value) => value;
+            public override RealmValue Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerLongRealmValueConverter : ISpecializedConverter<RealmInteger<long>, RealmValue>
+        private class RealmIntegerLongRealmValueConverter : SpecializedConverterBase<RealmInteger<long>, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<long> value) => value;
+            public override RealmValue Convert(RealmInteger<long> value) => value;
         }
 
-        public class NullableRealmIntegerByteRealmValueConverter : ISpecializedConverter<RealmInteger<byte>?, RealmValue>
+        private class NullableRealmIntegerByteRealmValueConverter : SpecializedConverterBase<RealmInteger<byte>?, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<byte>? value) => value;
+            public override RealmValue Convert(RealmInteger<byte>? value) => value;
         }
 
-        public class NullableRealmIntegerShortRealmValueConverter : ISpecializedConverter<RealmInteger<short>?, RealmValue>
+        private class NullableRealmIntegerShortRealmValueConverter : SpecializedConverterBase<RealmInteger<short>?, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<short>? value) => value;
+            public override RealmValue Convert(RealmInteger<short>? value) => value;
         }
 
-        public class NullableRealmIntegerIntRealmValueConverter : ISpecializedConverter<RealmInteger<int>?, RealmValue>
+        private class NullableRealmIntegerIntRealmValueConverter : SpecializedConverterBase<RealmInteger<int>?, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<int>? value) => value;
+            public override RealmValue Convert(RealmInteger<int>? value) => value;
         }
 
-        public class NullableRealmIntegerLongRealmValueConverter : ISpecializedConverter<RealmInteger<long>?, RealmValue>
+        private class NullableRealmIntegerLongRealmValueConverter : SpecializedConverterBase<RealmInteger<long>?, RealmValue>
         {
-            public RealmValue Convert(RealmInteger<long>? value) => value;
+            public override RealmValue Convert(RealmInteger<long>? value) => value;
         }
 
-        public class ByteArrayRealmValueConverter : ISpecializedConverter<byte[], RealmValue>
+        private class ByteArrayRealmValueConverter : SpecializedConverterBase<byte[], RealmValue>
         {
-            public RealmValue Convert(byte[] value) => value;
+            public override RealmValue Convert(byte[] value) => value;
         }
 
-        public class StringRealmValueConverter : ISpecializedConverter<string, RealmValue>
+        private class StringRealmValueConverter : SpecializedConverterBase<string, RealmValue>
         {
-            public RealmValue Convert(string value) => value;
+            public override RealmValue Convert(string value) => value;
         }
 
-        public class RealmObjectBaseRealmValueConverter : ISpecializedConverter<RealmObjectBase, RealmValue>
+        private class RealmObjectBaseRealmValueConverter : SpecializedConverterBase<RealmObjectBase, RealmValue>
         {
-            public RealmValue Convert(RealmObjectBase value) => value;
+            public override RealmValue Convert(RealmObjectBase value) => value;
         }
         #endregion ToRealmValue Converters
 
         #region FromRealmValue Converters
 
-        public class RealmValueCharConverter : ISpecializedConverter<RealmValue, char>
+        private class RealmValueCharConverter : SpecializedConverterBase<RealmValue, char>
         {
-            public char Convert(RealmValue value) => (char)value;
+            public override char Convert(RealmValue value) => (char)value;
         }
 
-        public class RealmValueByteConverter : ISpecializedConverter<RealmValue, byte>
+        private class RealmValueByteConverter : SpecializedConverterBase<RealmValue, byte>
         {
-            public byte Convert(RealmValue value) => (byte)value;
+            public override byte Convert(RealmValue value) => (byte)value;
         }
 
-        public class RealmValueShortConverter : ISpecializedConverter<RealmValue, short>
+        private class RealmValueShortConverter : SpecializedConverterBase<RealmValue, short>
         {
-            public short Convert(RealmValue value) => (short)value;
+            public override short Convert(RealmValue value) => (short)value;
         }
 
-        public class RealmValueIntConverter : ISpecializedConverter<RealmValue, int>
+        private class RealmValueIntConverter : SpecializedConverterBase<RealmValue, int>
         {
-            public int Convert(RealmValue value) => (int)value;
+            public override int Convert(RealmValue value) => (int)value;
         }
 
-        public class RealmValueLongConverter : ISpecializedConverter<RealmValue, long>
+        private class RealmValueLongConverter : SpecializedConverterBase<RealmValue, long>
         {
-            public long Convert(RealmValue value) => (long)value;
+            public override long Convert(RealmValue value) => (long)value;
         }
 
-        public class RealmValueFloatConverter : ISpecializedConverter<RealmValue, float>
+        private class RealmValueFloatConverter : SpecializedConverterBase<RealmValue, float>
         {
-            public float Convert(RealmValue value) => (float)value;
+            public override float Convert(RealmValue value) => (float)value;
         }
 
-        public class RealmValueDoubleConverter : ISpecializedConverter<RealmValue, double>
+        private class RealmValueDoubleConverter : SpecializedConverterBase<RealmValue, double>
         {
-            public double Convert(RealmValue value) => (double)value;
+            public override double Convert(RealmValue value) => (double)value;
         }
 
-        public class RealmValueBoolConverter : ISpecializedConverter<RealmValue, bool>
+        private class RealmValueBoolConverter : SpecializedConverterBase<RealmValue, bool>
         {
-            public bool Convert(RealmValue value) => (bool)value;
+            public override bool Convert(RealmValue value) => (bool)value;
         }
 
-        public class RealmValueDateTimeOffsetConverter : ISpecializedConverter<RealmValue, DateTimeOffset>
+        private class RealmValueDateTimeOffsetConverter : SpecializedConverterBase<RealmValue, DateTimeOffset>
         {
-            public DateTimeOffset Convert(RealmValue value) => (DateTimeOffset)value;
+            public override DateTimeOffset Convert(RealmValue value) => (DateTimeOffset)value;
         }
 
-        public class RealmValueDecimalConverter : ISpecializedConverter<RealmValue, decimal>
+        private class RealmValueDecimalConverter : SpecializedConverterBase<RealmValue, decimal>
         {
-            public decimal Convert(RealmValue value) => (decimal)value;
+            public override decimal Convert(RealmValue value) => (decimal)value;
         }
 
-        public class RealmValueDecimal128Converter : ISpecializedConverter<RealmValue, Decimal128>
+        private class RealmValueDecimal128Converter : SpecializedConverterBase<RealmValue, Decimal128>
         {
-            public Decimal128 Convert(RealmValue value) => (Decimal128)value;
+            public override Decimal128 Convert(RealmValue value) => (Decimal128)value;
         }
 
-        public class RealmValueObjectIdConverter : ISpecializedConverter<RealmValue, ObjectId>
+        private class RealmValueObjectIdConverter : SpecializedConverterBase<RealmValue, ObjectId>
         {
-            public ObjectId Convert(RealmValue value) => (ObjectId)value;
+            public override ObjectId Convert(RealmValue value) => (ObjectId)value;
         }
 
-        public class RealmValueGuidConverter : ISpecializedConverter<RealmValue, Guid>
+        private class RealmValueGuidConverter : SpecializedConverterBase<RealmValue, Guid>
         {
-            public Guid Convert(RealmValue value) => (Guid)value;
+            public override Guid Convert(RealmValue value) => (Guid)value;
         }
 
-        public class RealmValueNullableCharConverter : ISpecializedConverter<RealmValue, char?>
+        private class RealmValueNullableCharConverter : SpecializedConverterBase<RealmValue, char?>
         {
-            public char? Convert(RealmValue value) => (char?)value;
+            public override char? Convert(RealmValue value) => (char?)value;
         }
 
-        public class RealmValueNullableByteConverter : ISpecializedConverter<RealmValue, byte?>
+        private class RealmValueNullableByteConverter : SpecializedConverterBase<RealmValue, byte?>
         {
-            public byte? Convert(RealmValue value) => (byte?)value;
+            public override byte? Convert(RealmValue value) => (byte?)value;
         }
 
-        public class RealmValueNullableShortConverter : ISpecializedConverter<RealmValue, short?>
+        private class RealmValueNullableShortConverter : SpecializedConverterBase<RealmValue, short?>
         {
-            public short? Convert(RealmValue value) => (short?)value;
+            public override short? Convert(RealmValue value) => (short?)value;
         }
 
-        public class RealmValueNullableIntConverter : ISpecializedConverter<RealmValue, int?>
+        private class RealmValueNullableIntConverter : SpecializedConverterBase<RealmValue, int?>
         {
-            public int? Convert(RealmValue value) => (int?)value;
+            public override int? Convert(RealmValue value) => (int?)value;
         }
 
-        public class RealmValueNullableLongConverter : ISpecializedConverter<RealmValue, long?>
+        private class RealmValueNullableLongConverter : SpecializedConverterBase<RealmValue, long?>
         {
-            public long? Convert(RealmValue value) => (long?)value;
+            public override long? Convert(RealmValue value) => (long?)value;
         }
 
-        public class RealmValueNullableFloatConverter : ISpecializedConverter<RealmValue, float?>
+        private class RealmValueNullableFloatConverter : SpecializedConverterBase<RealmValue, float?>
         {
-            public float? Convert(RealmValue value) => (float?)value;
+            public override float? Convert(RealmValue value) => (float?)value;
         }
 
-        public class RealmValueNullableDoubleConverter : ISpecializedConverter<RealmValue, double?>
+        private class RealmValueNullableDoubleConverter : SpecializedConverterBase<RealmValue, double?>
         {
-            public double? Convert(RealmValue value) => (double?)value;
+            public override double? Convert(RealmValue value) => (double?)value;
         }
 
-        public class RealmValueNullableBoolConverter : ISpecializedConverter<RealmValue, bool?>
+        private class RealmValueNullableBoolConverter : SpecializedConverterBase<RealmValue, bool?>
         {
-            public bool? Convert(RealmValue value) => (bool?)value;
+            public override bool? Convert(RealmValue value) => (bool?)value;
         }
 
-        public class RealmValueNullableDateTimeOffsetConverter : ISpecializedConverter<RealmValue, DateTimeOffset?>
+        private class RealmValueNullableDateTimeOffsetConverter : SpecializedConverterBase<RealmValue, DateTimeOffset?>
         {
-            public DateTimeOffset? Convert(RealmValue value) => (DateTimeOffset?)value;
+            public override DateTimeOffset? Convert(RealmValue value) => (DateTimeOffset?)value;
         }
 
-        public class RealmValueNullableDecimalConverter : ISpecializedConverter<RealmValue, decimal?>
+        private class RealmValueNullableDecimalConverter : SpecializedConverterBase<RealmValue, decimal?>
         {
-            public decimal? Convert(RealmValue value) => (decimal?)value;
+            public override decimal? Convert(RealmValue value) => (decimal?)value;
         }
 
-        public class RealmValueNullableDecimal128Converter : ISpecializedConverter<RealmValue, Decimal128?>
+        private class RealmValueNullableDecimal128Converter : SpecializedConverterBase<RealmValue, Decimal128?>
         {
-            public Decimal128? Convert(RealmValue value) => (Decimal128?)value;
+            public override Decimal128? Convert(RealmValue value) => (Decimal128?)value;
         }
 
-        public class RealmValueNullableObjectIdConverter : ISpecializedConverter<RealmValue, ObjectId?>
+        private class RealmValueNullableObjectIdConverter : SpecializedConverterBase<RealmValue, ObjectId?>
         {
-            public ObjectId? Convert(RealmValue value) => (ObjectId?)value;
+            public override ObjectId? Convert(RealmValue value) => (ObjectId?)value;
         }
 
-        public class RealmValueNullableGuidConverter : ISpecializedConverter<RealmValue, Guid?>
+        private class RealmValueNullableGuidConverter : SpecializedConverterBase<RealmValue, Guid?>
         {
-            public Guid? Convert(RealmValue value) => (Guid?)value;
+            public override Guid? Convert(RealmValue value) => (Guid?)value;
         }
 
-        public class RealmValueRealmIntegerByteConverter : ISpecializedConverter<RealmValue, RealmInteger<byte>>
+        private class RealmValueRealmIntegerByteConverter : SpecializedConverterBase<RealmValue, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(RealmValue value) => (RealmInteger<byte>)value;
+            public override RealmInteger<byte> Convert(RealmValue value) => (RealmInteger<byte>)value;
         }
 
-        public class RealmValueRealmIntegerShortConverter : ISpecializedConverter<RealmValue, RealmInteger<short>>
+        private class RealmValueRealmIntegerShortConverter : SpecializedConverterBase<RealmValue, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(RealmValue value) => (RealmInteger<short>)value;
+            public override RealmInteger<short> Convert(RealmValue value) => (RealmInteger<short>)value;
         }
 
-        public class RealmValueRealmIntegerIntConverter : ISpecializedConverter<RealmValue, RealmInteger<int>>
+        private class RealmValueRealmIntegerIntConverter : SpecializedConverterBase<RealmValue, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(RealmValue value) => (RealmInteger<int>)value;
+            public override RealmInteger<int> Convert(RealmValue value) => (RealmInteger<int>)value;
         }
 
-        public class RealmValueRealmIntegerLongConverter : ISpecializedConverter<RealmValue, RealmInteger<long>>
+        private class RealmValueRealmIntegerLongConverter : SpecializedConverterBase<RealmValue, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(RealmValue value) => (RealmInteger<long>)value;
+            public override RealmInteger<long> Convert(RealmValue value) => (RealmInteger<long>)value;
         }
 
-        public class RealmValueNullableRealmIntegerByteConverter : ISpecializedConverter<RealmValue, RealmInteger<byte>?>
+        private class RealmValueNullableRealmIntegerByteConverter : SpecializedConverterBase<RealmValue, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(RealmValue value) => (RealmInteger<byte>?)value;
+            public override RealmInteger<byte>? Convert(RealmValue value) => (RealmInteger<byte>?)value;
         }
 
-        public class RealmValueNullableRealmIntegerShortConverter : ISpecializedConverter<RealmValue, RealmInteger<short>?>
+        private class RealmValueNullableRealmIntegerShortConverter : SpecializedConverterBase<RealmValue, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(RealmValue value) => (RealmInteger<short>?)value;
+            public override RealmInteger<short>? Convert(RealmValue value) => (RealmInteger<short>?)value;
         }
 
-        public class RealmValueNullableRealmIntegerIntConverter : ISpecializedConverter<RealmValue, RealmInteger<int>?>
+        private class RealmValueNullableRealmIntegerIntConverter : SpecializedConverterBase<RealmValue, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(RealmValue value) => (RealmInteger<int>?)value;
+            public override RealmInteger<int>? Convert(RealmValue value) => (RealmInteger<int>?)value;
         }
 
-        public class RealmValueNullableRealmIntegerLongConverter : ISpecializedConverter<RealmValue, RealmInteger<long>?>
+        private class RealmValueNullableRealmIntegerLongConverter : SpecializedConverterBase<RealmValue, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(RealmValue value) => (RealmInteger<long>?)value;
+            public override RealmInteger<long>? Convert(RealmValue value) => (RealmInteger<long>?)value;
         }
 
-        public class RealmValueByteArrayConverter : ISpecializedConverter<RealmValue, byte[]>
+        private class RealmValueByteArrayConverter : SpecializedConverterBase<RealmValue, byte[]>
         {
-            public byte[] Convert(RealmValue value) => (byte[])value;
+            public override byte[] Convert(RealmValue value) => (byte[])value;
         }
 
-        public class RealmValueStringConverter : ISpecializedConverter<RealmValue, string>
+        private class RealmValueStringConverter : SpecializedConverterBase<RealmValue, string>
         {
-            public string Convert(RealmValue value) => (string)value;
+            public override string Convert(RealmValue value) => (string)value;
         }
 
-        public class RealmValueRealmObjectBaseConverter : ISpecializedConverter<RealmValue, RealmObjectBase>
+        private class RealmValueRealmObjectBaseConverter : SpecializedConverterBase<RealmValue, RealmObjectBase>
         {
-            public RealmObjectBase Convert(RealmValue value) => (RealmObjectBase)value;
+            public override RealmObjectBase Convert(RealmValue value) => (RealmObjectBase)value;
         }
         #endregion FromRealmValue Converters
 
         #region Integral Converters
 
-        public class CharNullableCharConverter : ISpecializedConverter<char, char?>
+        private class CharNullableCharConverter : SpecializedConverterBase<char, char?>
         {
-            public char? Convert(char value) => (char)value;
+            public override char? Convert(char value) => (char)value;
         }
 
-        public class CharNullableByteConverter : ISpecializedConverter<char, byte?>
+        private class CharNullableByteConverter : SpecializedConverterBase<char, byte?>
         {
-            public byte? Convert(char value) => (byte)value;
+            public override byte? Convert(char value) => (byte)value;
         }
 
-        public class CharNullableShortConverter : ISpecializedConverter<char, short?>
+        private class CharNullableShortConverter : SpecializedConverterBase<char, short?>
         {
-            public short? Convert(char value) => (short)value;
+            public override short? Convert(char value) => (short)value;
         }
 
-        public class CharNullableIntConverter : ISpecializedConverter<char, int?>
+        private class CharNullableIntConverter : SpecializedConverterBase<char, int?>
         {
-            public int? Convert(char value) => value;
+            public override int? Convert(char value) => value;
         }
 
-        public class CharNullableLongConverter : ISpecializedConverter<char, long?>
+        private class CharNullableLongConverter : SpecializedConverterBase<char, long?>
         {
-            public long? Convert(char value) => value;
+            public override long? Convert(char value) => value;
         }
 
-        public class CharNullableRealmIntegerByteConverter : ISpecializedConverter<char, RealmInteger<byte>?>
+        private class CharNullableRealmIntegerByteConverter : SpecializedConverterBase<char, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(char value) => (byte)value;
+            public override RealmInteger<byte>? Convert(char value) => (byte)value;
         }
 
-        public class CharNullableRealmIntegerShortConverter : ISpecializedConverter<char, RealmInteger<short>?>
+        private class CharNullableRealmIntegerShortConverter : SpecializedConverterBase<char, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(char value) => (short)value;
+            public override RealmInteger<short>? Convert(char value) => (short)value;
         }
 
-        public class CharNullableRealmIntegerIntConverter : ISpecializedConverter<char, RealmInteger<int>?>
+        private class CharNullableRealmIntegerIntConverter : SpecializedConverterBase<char, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(char value) => value;
+            public override RealmInteger<int>? Convert(char value) => value;
         }
 
-        public class CharNullableRealmIntegerLongConverter : ISpecializedConverter<char, RealmInteger<long>?>
+        private class CharNullableRealmIntegerLongConverter : SpecializedConverterBase<char, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(char value) => value;
+            public override RealmInteger<long>? Convert(char value) => value;
         }
 
-        public class CharNullableFloatConverter : ISpecializedConverter<char, float?>
+        private class CharNullableFloatConverter : SpecializedConverterBase<char, float?>
         {
-            public float? Convert(char value) => value;
+            public override float? Convert(char value) => value;
         }
 
-        public class CharNullableDoubleConverter : ISpecializedConverter<char, double?>
+        private class CharNullableDoubleConverter : SpecializedConverterBase<char, double?>
         {
-            public double? Convert(char value) => value;
+            public override double? Convert(char value) => value;
         }
 
-        public class CharNullableDecimalConverter : ISpecializedConverter<char, decimal?>
+        private class CharNullableDecimalConverter : SpecializedConverterBase<char, decimal?>
         {
-            public decimal? Convert(char value) => value;
+            public override decimal? Convert(char value) => value;
         }
 
-        public class CharNullableDecimal128Converter : ISpecializedConverter<char, Decimal128?>
+        private class CharNullableDecimal128Converter : SpecializedConverterBase<char, Decimal128?>
         {
-            public Decimal128? Convert(char value) => value;
+            public override Decimal128? Convert(char value) => value;
         }
 
-        public class ByteNullableCharConverter : ISpecializedConverter<byte, char?>
+        private class ByteNullableCharConverter : SpecializedConverterBase<byte, char?>
         {
-            public char? Convert(byte value) => (char)value;
+            public override char? Convert(byte value) => (char)value;
         }
 
-        public class ByteNullableByteConverter : ISpecializedConverter<byte, byte?>
+        private class ByteNullableByteConverter : SpecializedConverterBase<byte, byte?>
         {
-            public byte? Convert(byte value) => value;
+            public override byte? Convert(byte value) => value;
         }
 
-        public class ByteNullableShortConverter : ISpecializedConverter<byte, short?>
+        private class ByteNullableShortConverter : SpecializedConverterBase<byte, short?>
         {
-            public short? Convert(byte value) => value;
+            public override short? Convert(byte value) => value;
         }
 
-        public class ByteNullableIntConverter : ISpecializedConverter<byte, int?>
+        private class ByteNullableIntConverter : SpecializedConverterBase<byte, int?>
         {
-            public int? Convert(byte value) => value;
+            public override int? Convert(byte value) => value;
         }
 
-        public class ByteNullableLongConverter : ISpecializedConverter<byte, long?>
+        private class ByteNullableLongConverter : SpecializedConverterBase<byte, long?>
         {
-            public long? Convert(byte value) => value;
+            public override long? Convert(byte value) => value;
         }
 
-        public class ByteNullableRealmIntegerByteConverter : ISpecializedConverter<byte, RealmInteger<byte>?>
+        private class ByteNullableRealmIntegerByteConverter : SpecializedConverterBase<byte, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(byte value) => value;
+            public override RealmInteger<byte>? Convert(byte value) => value;
         }
 
-        public class ByteNullableRealmIntegerShortConverter : ISpecializedConverter<byte, RealmInteger<short>?>
+        private class ByteNullableRealmIntegerShortConverter : SpecializedConverterBase<byte, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(byte value) => value;
+            public override RealmInteger<short>? Convert(byte value) => value;
         }
 
-        public class ByteNullableRealmIntegerIntConverter : ISpecializedConverter<byte, RealmInteger<int>?>
+        private class ByteNullableRealmIntegerIntConverter : SpecializedConverterBase<byte, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(byte value) => value;
+            public override RealmInteger<int>? Convert(byte value) => value;
         }
 
-        public class ByteNullableRealmIntegerLongConverter : ISpecializedConverter<byte, RealmInteger<long>?>
+        private class ByteNullableRealmIntegerLongConverter : SpecializedConverterBase<byte, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(byte value) => value;
+            public override RealmInteger<long>? Convert(byte value) => value;
         }
 
-        public class ByteNullableFloatConverter : ISpecializedConverter<byte, float?>
+        private class ByteNullableFloatConverter : SpecializedConverterBase<byte, float?>
         {
-            public float? Convert(byte value) => value;
+            public override float? Convert(byte value) => value;
         }
 
-        public class ByteNullableDoubleConverter : ISpecializedConverter<byte, double?>
+        private class ByteNullableDoubleConverter : SpecializedConverterBase<byte, double?>
         {
-            public double? Convert(byte value) => value;
+            public override double? Convert(byte value) => value;
         }
 
-        public class ByteNullableDecimalConverter : ISpecializedConverter<byte, decimal?>
+        private class ByteNullableDecimalConverter : SpecializedConverterBase<byte, decimal?>
         {
-            public decimal? Convert(byte value) => value;
+            public override decimal? Convert(byte value) => value;
         }
 
-        public class ByteNullableDecimal128Converter : ISpecializedConverter<byte, Decimal128?>
+        private class ByteNullableDecimal128Converter : SpecializedConverterBase<byte, Decimal128?>
         {
-            public Decimal128? Convert(byte value) => value;
+            public override Decimal128? Convert(byte value) => value;
         }
 
-        public class ShortNullableCharConverter : ISpecializedConverter<short, char?>
+        private class ShortNullableCharConverter : SpecializedConverterBase<short, char?>
         {
-            public char? Convert(short value) => (char)value;
+            public override char? Convert(short value) => (char)value;
         }
 
-        public class ShortNullableByteConverter : ISpecializedConverter<short, byte?>
+        private class ShortNullableByteConverter : SpecializedConverterBase<short, byte?>
         {
-            public byte? Convert(short value) => (byte)value;
+            public override byte? Convert(short value) => (byte)value;
         }
 
-        public class ShortNullableShortConverter : ISpecializedConverter<short, short?>
+        private class ShortNullableShortConverter : SpecializedConverterBase<short, short?>
         {
-            public short? Convert(short value) => value;
+            public override short? Convert(short value) => value;
         }
 
-        public class ShortNullableIntConverter : ISpecializedConverter<short, int?>
+        private class ShortNullableIntConverter : SpecializedConverterBase<short, int?>
         {
-            public int? Convert(short value) => value;
+            public override int? Convert(short value) => value;
         }
 
-        public class ShortNullableLongConverter : ISpecializedConverter<short, long?>
+        private class ShortNullableLongConverter : SpecializedConverterBase<short, long?>
         {
-            public long? Convert(short value) => value;
+            public override long? Convert(short value) => value;
         }
 
-        public class ShortNullableRealmIntegerByteConverter : ISpecializedConverter<short, RealmInteger<byte>?>
+        private class ShortNullableRealmIntegerByteConverter : SpecializedConverterBase<short, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(short value) => (byte)value;
+            public override RealmInteger<byte>? Convert(short value) => (byte)value;
         }
 
-        public class ShortNullableRealmIntegerShortConverter : ISpecializedConverter<short, RealmInteger<short>?>
+        private class ShortNullableRealmIntegerShortConverter : SpecializedConverterBase<short, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(short value) => value;
+            public override RealmInteger<short>? Convert(short value) => value;
         }
 
-        public class ShortNullableRealmIntegerIntConverter : ISpecializedConverter<short, RealmInteger<int>?>
+        private class ShortNullableRealmIntegerIntConverter : SpecializedConverterBase<short, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(short value) => value;
+            public override RealmInteger<int>? Convert(short value) => value;
         }
 
-        public class ShortNullableRealmIntegerLongConverter : ISpecializedConverter<short, RealmInteger<long>?>
+        private class ShortNullableRealmIntegerLongConverter : SpecializedConverterBase<short, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(short value) => value;
+            public override RealmInteger<long>? Convert(short value) => value;
         }
 
-        public class ShortNullableFloatConverter : ISpecializedConverter<short, float?>
+        private class ShortNullableFloatConverter : SpecializedConverterBase<short, float?>
         {
-            public float? Convert(short value) => value;
+            public override float? Convert(short value) => value;
         }
 
-        public class ShortNullableDoubleConverter : ISpecializedConverter<short, double?>
+        private class ShortNullableDoubleConverter : SpecializedConverterBase<short, double?>
         {
-            public double? Convert(short value) => value;
+            public override double? Convert(short value) => value;
         }
 
-        public class ShortNullableDecimalConverter : ISpecializedConverter<short, decimal?>
+        private class ShortNullableDecimalConverter : SpecializedConverterBase<short, decimal?>
         {
-            public decimal? Convert(short value) => value;
+            public override decimal? Convert(short value) => value;
         }
 
-        public class ShortNullableDecimal128Converter : ISpecializedConverter<short, Decimal128?>
+        private class ShortNullableDecimal128Converter : SpecializedConverterBase<short, Decimal128?>
         {
-            public Decimal128? Convert(short value) => value;
+            public override Decimal128? Convert(short value) => value;
         }
 
-        public class IntNullableCharConverter : ISpecializedConverter<int, char?>
+        private class IntNullableCharConverter : SpecializedConverterBase<int, char?>
         {
-            public char? Convert(int value) => (char)value;
+            public override char? Convert(int value) => (char)value;
         }
 
-        public class IntNullableByteConverter : ISpecializedConverter<int, byte?>
+        private class IntNullableByteConverter : SpecializedConverterBase<int, byte?>
         {
-            public byte? Convert(int value) => (byte)value;
+            public override byte? Convert(int value) => (byte)value;
         }
 
-        public class IntNullableShortConverter : ISpecializedConverter<int, short?>
+        private class IntNullableShortConverter : SpecializedConverterBase<int, short?>
         {
-            public short? Convert(int value) => (short)value;
+            public override short? Convert(int value) => (short)value;
         }
 
-        public class IntNullableIntConverter : ISpecializedConverter<int, int?>
+        private class IntNullableIntConverter : SpecializedConverterBase<int, int?>
         {
-            public int? Convert(int value) => value;
+            public override int? Convert(int value) => value;
         }
 
-        public class IntNullableLongConverter : ISpecializedConverter<int, long?>
+        private class IntNullableLongConverter : SpecializedConverterBase<int, long?>
         {
-            public long? Convert(int value) => value;
+            public override long? Convert(int value) => value;
         }
 
-        public class IntNullableRealmIntegerByteConverter : ISpecializedConverter<int, RealmInteger<byte>?>
+        private class IntNullableRealmIntegerByteConverter : SpecializedConverterBase<int, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(int value) => (byte)value;
+            public override RealmInteger<byte>? Convert(int value) => (byte)value;
         }
 
-        public class IntNullableRealmIntegerShortConverter : ISpecializedConverter<int, RealmInteger<short>?>
+        private class IntNullableRealmIntegerShortConverter : SpecializedConverterBase<int, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(int value) => (short)value;
+            public override RealmInteger<short>? Convert(int value) => (short)value;
         }
 
-        public class IntNullableRealmIntegerIntConverter : ISpecializedConverter<int, RealmInteger<int>?>
+        private class IntNullableRealmIntegerIntConverter : SpecializedConverterBase<int, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(int value) => value;
+            public override RealmInteger<int>? Convert(int value) => value;
         }
 
-        public class IntNullableRealmIntegerLongConverter : ISpecializedConverter<int, RealmInteger<long>?>
+        private class IntNullableRealmIntegerLongConverter : SpecializedConverterBase<int, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(int value) => value;
+            public override RealmInteger<long>? Convert(int value) => value;
         }
 
-        public class IntNullableFloatConverter : ISpecializedConverter<int, float?>
+        private class IntNullableFloatConverter : SpecializedConverterBase<int, float?>
         {
-            public float? Convert(int value) => value;
+            public override float? Convert(int value) => value;
         }
 
-        public class IntNullableDoubleConverter : ISpecializedConverter<int, double?>
+        private class IntNullableDoubleConverter : SpecializedConverterBase<int, double?>
         {
-            public double? Convert(int value) => value;
+            public override double? Convert(int value) => value;
         }
 
-        public class IntNullableDecimalConverter : ISpecializedConverter<int, decimal?>
+        private class IntNullableDecimalConverter : SpecializedConverterBase<int, decimal?>
         {
-            public decimal? Convert(int value) => value;
+            public override decimal? Convert(int value) => value;
         }
 
-        public class IntNullableDecimal128Converter : ISpecializedConverter<int, Decimal128?>
+        private class IntNullableDecimal128Converter : SpecializedConverterBase<int, Decimal128?>
         {
-            public Decimal128? Convert(int value) => value;
+            public override Decimal128? Convert(int value) => value;
         }
 
-        public class LongNullableCharConverter : ISpecializedConverter<long, char?>
+        private class LongNullableCharConverter : SpecializedConverterBase<long, char?>
         {
-            public char? Convert(long value) => (char)value;
+            public override char? Convert(long value) => (char)value;
         }
 
-        public class LongNullableByteConverter : ISpecializedConverter<long, byte?>
+        private class LongNullableByteConverter : SpecializedConverterBase<long, byte?>
         {
-            public byte? Convert(long value) => (byte)value;
+            public override byte? Convert(long value) => (byte)value;
         }
 
-        public class LongNullableShortConverter : ISpecializedConverter<long, short?>
+        private class LongNullableShortConverter : SpecializedConverterBase<long, short?>
         {
-            public short? Convert(long value) => (short)value;
+            public override short? Convert(long value) => (short)value;
         }
 
-        public class LongNullableIntConverter : ISpecializedConverter<long, int?>
+        private class LongNullableIntConverter : SpecializedConverterBase<long, int?>
         {
-            public int? Convert(long value) => (int)value;
+            public override int? Convert(long value) => (int)value;
         }
 
-        public class LongNullableLongConverter : ISpecializedConverter<long, long?>
+        private class LongNullableLongConverter : SpecializedConverterBase<long, long?>
         {
-            public long? Convert(long value) => value;
+            public override long? Convert(long value) => value;
         }
 
-        public class LongNullableRealmIntegerByteConverter : ISpecializedConverter<long, RealmInteger<byte>?>
+        private class LongNullableRealmIntegerByteConverter : SpecializedConverterBase<long, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(long value) => (byte)value;
+            public override RealmInteger<byte>? Convert(long value) => (byte)value;
         }
 
-        public class LongNullableRealmIntegerShortConverter : ISpecializedConverter<long, RealmInteger<short>?>
+        private class LongNullableRealmIntegerShortConverter : SpecializedConverterBase<long, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(long value) => (short)value;
+            public override RealmInteger<short>? Convert(long value) => (short)value;
         }
 
-        public class LongNullableRealmIntegerIntConverter : ISpecializedConverter<long, RealmInteger<int>?>
+        private class LongNullableRealmIntegerIntConverter : SpecializedConverterBase<long, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(long value) => (int)value;
+            public override RealmInteger<int>? Convert(long value) => (int)value;
         }
 
-        public class LongNullableRealmIntegerLongConverter : ISpecializedConverter<long, RealmInteger<long>?>
+        private class LongNullableRealmIntegerLongConverter : SpecializedConverterBase<long, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(long value) => value;
+            public override RealmInteger<long>? Convert(long value) => value;
         }
 
-        public class LongNullableFloatConverter : ISpecializedConverter<long, float?>
+        private class LongNullableFloatConverter : SpecializedConverterBase<long, float?>
         {
-            public float? Convert(long value) => value;
+            public override float? Convert(long value) => value;
         }
 
-        public class LongNullableDoubleConverter : ISpecializedConverter<long, double?>
+        private class LongNullableDoubleConverter : SpecializedConverterBase<long, double?>
         {
-            public double? Convert(long value) => value;
+            public override double? Convert(long value) => value;
         }
 
-        public class LongNullableDecimalConverter : ISpecializedConverter<long, decimal?>
+        private class LongNullableDecimalConverter : SpecializedConverterBase<long, decimal?>
         {
-            public decimal? Convert(long value) => value;
+            public override decimal? Convert(long value) => value;
         }
 
-        public class LongNullableDecimal128Converter : ISpecializedConverter<long, Decimal128?>
+        private class LongNullableDecimal128Converter : SpecializedConverterBase<long, Decimal128?>
         {
-            public Decimal128? Convert(long value) => value;
+            public override Decimal128? Convert(long value) => value;
         }
 
-        public class RealmIntegerByteNullableCharConverter : ISpecializedConverter<RealmInteger<byte>, char?>
+        private class RealmIntegerByteNullableCharConverter : SpecializedConverterBase<RealmInteger<byte>, char?>
         {
-            public char? Convert(RealmInteger<byte> value) => (char)(byte)value;
+            public override char? Convert(RealmInteger<byte> value) => (char)(byte)value;
         }
 
-        public class RealmIntegerByteNullableByteConverter : ISpecializedConverter<RealmInteger<byte>, byte?>
+        private class RealmIntegerByteNullableByteConverter : SpecializedConverterBase<RealmInteger<byte>, byte?>
         {
-            public byte? Convert(RealmInteger<byte> value) => value;
+            public override byte? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableShortConverter : ISpecializedConverter<RealmInteger<byte>, short?>
+        private class RealmIntegerByteNullableShortConverter : SpecializedConverterBase<RealmInteger<byte>, short?>
         {
-            public short? Convert(RealmInteger<byte> value) => value;
+            public override short? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableIntConverter : ISpecializedConverter<RealmInteger<byte>, int?>
+        private class RealmIntegerByteNullableIntConverter : SpecializedConverterBase<RealmInteger<byte>, int?>
         {
-            public int? Convert(RealmInteger<byte> value) => value;
+            public override int? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableLongConverter : ISpecializedConverter<RealmInteger<byte>, long?>
+        private class RealmIntegerByteNullableLongConverter : SpecializedConverterBase<RealmInteger<byte>, long?>
         {
-            public long? Convert(RealmInteger<byte> value) => value;
+            public override long? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableRealmIntegerByteConverter : ISpecializedConverter<RealmInteger<byte>, RealmInteger<byte>?>
+        private class RealmIntegerByteNullableRealmIntegerByteConverter : SpecializedConverterBase<RealmInteger<byte>, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(RealmInteger<byte> value) => value;
+            public override RealmInteger<byte>? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableRealmIntegerShortConverter : ISpecializedConverter<RealmInteger<byte>, RealmInteger<short>?>
+        private class RealmIntegerByteNullableRealmIntegerShortConverter : SpecializedConverterBase<RealmInteger<byte>, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(RealmInteger<byte> value) => (short)value;
+            public override RealmInteger<short>? Convert(RealmInteger<byte> value) => (short)value;
         }
 
-        public class RealmIntegerByteNullableRealmIntegerIntConverter : ISpecializedConverter<RealmInteger<byte>, RealmInteger<int>?>
+        private class RealmIntegerByteNullableRealmIntegerIntConverter : SpecializedConverterBase<RealmInteger<byte>, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(RealmInteger<byte> value) => (int)value;
+            public override RealmInteger<int>? Convert(RealmInteger<byte> value) => (int)value;
         }
 
-        public class RealmIntegerByteNullableRealmIntegerLongConverter : ISpecializedConverter<RealmInteger<byte>, RealmInteger<long>?>
+        private class RealmIntegerByteNullableRealmIntegerLongConverter : SpecializedConverterBase<RealmInteger<byte>, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(RealmInteger<byte> value) => (long)value;
+            public override RealmInteger<long>? Convert(RealmInteger<byte> value) => (long)value;
         }
 
-        public class RealmIntegerByteNullableFloatConverter : ISpecializedConverter<RealmInteger<byte>, float?>
+        private class RealmIntegerByteNullableFloatConverter : SpecializedConverterBase<RealmInteger<byte>, float?>
         {
-            public float? Convert(RealmInteger<byte> value) => value;
+            public override float? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableDoubleConverter : ISpecializedConverter<RealmInteger<byte>, double?>
+        private class RealmIntegerByteNullableDoubleConverter : SpecializedConverterBase<RealmInteger<byte>, double?>
         {
-            public double? Convert(RealmInteger<byte> value) => value;
+            public override double? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableDecimalConverter : ISpecializedConverter<RealmInteger<byte>, decimal?>
+        private class RealmIntegerByteNullableDecimalConverter : SpecializedConverterBase<RealmInteger<byte>, decimal?>
         {
-            public decimal? Convert(RealmInteger<byte> value) => value;
+            public override decimal? Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteNullableDecimal128Converter : ISpecializedConverter<RealmInteger<byte>, Decimal128?>
+        private class RealmIntegerByteNullableDecimal128Converter : SpecializedConverterBase<RealmInteger<byte>, Decimal128?>
         {
-            public Decimal128? Convert(RealmInteger<byte> value) => (byte)value;
+            public override Decimal128? Convert(RealmInteger<byte> value) => (byte)value;
         }
 
-        public class RealmIntegerShortNullableCharConverter : ISpecializedConverter<RealmInteger<short>, char?>
+        private class RealmIntegerShortNullableCharConverter : SpecializedConverterBase<RealmInteger<short>, char?>
         {
-            public char? Convert(RealmInteger<short> value) => (char)(short)value;
+            public override char? Convert(RealmInteger<short> value) => (char)(short)value;
         }
 
-        public class RealmIntegerShortNullableByteConverter : ISpecializedConverter<RealmInteger<short>, byte?>
+        private class RealmIntegerShortNullableByteConverter : SpecializedConverterBase<RealmInteger<short>, byte?>
         {
-            public byte? Convert(RealmInteger<short> value) => (byte)value;
+            public override byte? Convert(RealmInteger<short> value) => (byte)value;
         }
 
-        public class RealmIntegerShortNullableShortConverter : ISpecializedConverter<RealmInteger<short>, short?>
+        private class RealmIntegerShortNullableShortConverter : SpecializedConverterBase<RealmInteger<short>, short?>
         {
-            public short? Convert(RealmInteger<short> value) => value;
+            public override short? Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortNullableIntConverter : ISpecializedConverter<RealmInteger<short>, int?>
+        private class RealmIntegerShortNullableIntConverter : SpecializedConverterBase<RealmInteger<short>, int?>
         {
-            public int? Convert(RealmInteger<short> value) => value;
+            public override int? Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortNullableLongConverter : ISpecializedConverter<RealmInteger<short>, long?>
+        private class RealmIntegerShortNullableLongConverter : SpecializedConverterBase<RealmInteger<short>, long?>
         {
-            public long? Convert(RealmInteger<short> value) => value;
+            public override long? Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortNullableRealmIntegerByteConverter : ISpecializedConverter<RealmInteger<short>, RealmInteger<byte>?>
+        private class RealmIntegerShortNullableRealmIntegerByteConverter : SpecializedConverterBase<RealmInteger<short>, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(RealmInteger<short> value) => (byte)value;
+            public override RealmInteger<byte>? Convert(RealmInteger<short> value) => (byte)value;
         }
 
-        public class RealmIntegerShortNullableRealmIntegerShortConverter : ISpecializedConverter<RealmInteger<short>, RealmInteger<short>?>
+        private class RealmIntegerShortNullableRealmIntegerShortConverter : SpecializedConverterBase<RealmInteger<short>, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(RealmInteger<short> value) => value;
+            public override RealmInteger<short>? Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortNullableRealmIntegerIntConverter : ISpecializedConverter<RealmInteger<short>, RealmInteger<int>?>
+        private class RealmIntegerShortNullableRealmIntegerIntConverter : SpecializedConverterBase<RealmInteger<short>, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(RealmInteger<short> value) => (int)value;
+            public override RealmInteger<int>? Convert(RealmInteger<short> value) => (int)value;
         }
 
-        public class RealmIntegerShortNullableRealmIntegerLongConverter : ISpecializedConverter<RealmInteger<short>, RealmInteger<long>?>
+        private class RealmIntegerShortNullableRealmIntegerLongConverter : SpecializedConverterBase<RealmInteger<short>, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(RealmInteger<short> value) => (long)value;
+            public override RealmInteger<long>? Convert(RealmInteger<short> value) => (long)value;
         }
 
-        public class RealmIntegerShortNullableFloatConverter : ISpecializedConverter<RealmInteger<short>, float?>
+        private class RealmIntegerShortNullableFloatConverter : SpecializedConverterBase<RealmInteger<short>, float?>
         {
-            public float? Convert(RealmInteger<short> value) => value;
+            public override float? Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortNullableDoubleConverter : ISpecializedConverter<RealmInteger<short>, double?>
+        private class RealmIntegerShortNullableDoubleConverter : SpecializedConverterBase<RealmInteger<short>, double?>
         {
-            public double? Convert(RealmInteger<short> value) => value;
+            public override double? Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortNullableDecimalConverter : ISpecializedConverter<RealmInteger<short>, decimal?>
+        private class RealmIntegerShortNullableDecimalConverter : SpecializedConverterBase<RealmInteger<short>, decimal?>
         {
-            public decimal? Convert(RealmInteger<short> value) => value;
+            public override decimal? Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortNullableDecimal128Converter : ISpecializedConverter<RealmInteger<short>, Decimal128?>
+        private class RealmIntegerShortNullableDecimal128Converter : SpecializedConverterBase<RealmInteger<short>, Decimal128?>
         {
-            public Decimal128? Convert(RealmInteger<short> value) => (short)value;
+            public override Decimal128? Convert(RealmInteger<short> value) => (short)value;
         }
 
-        public class RealmIntegerIntNullableCharConverter : ISpecializedConverter<RealmInteger<int>, char?>
+        private class RealmIntegerIntNullableCharConverter : SpecializedConverterBase<RealmInteger<int>, char?>
         {
-            public char? Convert(RealmInteger<int> value) => (char)value;
+            public override char? Convert(RealmInteger<int> value) => (char)value;
         }
 
-        public class RealmIntegerIntNullableByteConverter : ISpecializedConverter<RealmInteger<int>, byte?>
+        private class RealmIntegerIntNullableByteConverter : SpecializedConverterBase<RealmInteger<int>, byte?>
         {
-            public byte? Convert(RealmInteger<int> value) => (byte)value;
+            public override byte? Convert(RealmInteger<int> value) => (byte)value;
         }
 
-        public class RealmIntegerIntNullableShortConverter : ISpecializedConverter<RealmInteger<int>, short?>
+        private class RealmIntegerIntNullableShortConverter : SpecializedConverterBase<RealmInteger<int>, short?>
         {
-            public short? Convert(RealmInteger<int> value) => (short)value;
+            public override short? Convert(RealmInteger<int> value) => (short)value;
         }
 
-        public class RealmIntegerIntNullableIntConverter : ISpecializedConverter<RealmInteger<int>, int?>
+        private class RealmIntegerIntNullableIntConverter : SpecializedConverterBase<RealmInteger<int>, int?>
         {
-            public int? Convert(RealmInteger<int> value) => value;
+            public override int? Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntNullableLongConverter : ISpecializedConverter<RealmInteger<int>, long?>
+        private class RealmIntegerIntNullableLongConverter : SpecializedConverterBase<RealmInteger<int>, long?>
         {
-            public long? Convert(RealmInteger<int> value) => value;
+            public override long? Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntNullableRealmIntegerByteConverter : ISpecializedConverter<RealmInteger<int>, RealmInteger<byte>?>
+        private class RealmIntegerIntNullableRealmIntegerByteConverter : SpecializedConverterBase<RealmInteger<int>, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(RealmInteger<int> value) => (byte)value;
+            public override RealmInteger<byte>? Convert(RealmInteger<int> value) => (byte)value;
         }
 
-        public class RealmIntegerIntNullableRealmIntegerShortConverter : ISpecializedConverter<RealmInteger<int>, RealmInteger<short>?>
+        private class RealmIntegerIntNullableRealmIntegerShortConverter : SpecializedConverterBase<RealmInteger<int>, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(RealmInteger<int> value) => (short)value;
+            public override RealmInteger<short>? Convert(RealmInteger<int> value) => (short)value;
         }
 
-        public class RealmIntegerIntNullableRealmIntegerIntConverter : ISpecializedConverter<RealmInteger<int>, RealmInteger<int>?>
+        private class RealmIntegerIntNullableRealmIntegerIntConverter : SpecializedConverterBase<RealmInteger<int>, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(RealmInteger<int> value) => value;
+            public override RealmInteger<int>? Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntNullableRealmIntegerLongConverter : ISpecializedConverter<RealmInteger<int>, RealmInteger<long>?>
+        private class RealmIntegerIntNullableRealmIntegerLongConverter : SpecializedConverterBase<RealmInteger<int>, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(RealmInteger<int> value) => (long)value;
+            public override RealmInteger<long>? Convert(RealmInteger<int> value) => (long)value;
         }
 
-        public class RealmIntegerIntNullableFloatConverter : ISpecializedConverter<RealmInteger<int>, float?>
+        private class RealmIntegerIntNullableFloatConverter : SpecializedConverterBase<RealmInteger<int>, float?>
         {
-            public float? Convert(RealmInteger<int> value) => value;
+            public override float? Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntNullableDoubleConverter : ISpecializedConverter<RealmInteger<int>, double?>
+        private class RealmIntegerIntNullableDoubleConverter : SpecializedConverterBase<RealmInteger<int>, double?>
         {
-            public double? Convert(RealmInteger<int> value) => value;
+            public override double? Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntNullableDecimalConverter : ISpecializedConverter<RealmInteger<int>, decimal?>
+        private class RealmIntegerIntNullableDecimalConverter : SpecializedConverterBase<RealmInteger<int>, decimal?>
         {
-            public decimal? Convert(RealmInteger<int> value) => value;
+            public override decimal? Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntNullableDecimal128Converter : ISpecializedConverter<RealmInteger<int>, Decimal128?>
+        private class RealmIntegerIntNullableDecimal128Converter : SpecializedConverterBase<RealmInteger<int>, Decimal128?>
         {
-            public Decimal128? Convert(RealmInteger<int> value) => (int)value;
+            public override Decimal128? Convert(RealmInteger<int> value) => (int)value;
         }
 
-        public class RealmIntegerLongNullableCharConverter : ISpecializedConverter<RealmInteger<long>, char?>
+        private class RealmIntegerLongNullableCharConverter : SpecializedConverterBase<RealmInteger<long>, char?>
         {
-            public char? Convert(RealmInteger<long> value) => (char)value;
+            public override char? Convert(RealmInteger<long> value) => (char)value;
         }
 
-        public class RealmIntegerLongNullableByteConverter : ISpecializedConverter<RealmInteger<long>, byte?>
+        private class RealmIntegerLongNullableByteConverter : SpecializedConverterBase<RealmInteger<long>, byte?>
         {
-            public byte? Convert(RealmInteger<long> value) => (byte)value;
+            public override byte? Convert(RealmInteger<long> value) => (byte)value;
         }
 
-        public class RealmIntegerLongNullableShortConverter : ISpecializedConverter<RealmInteger<long>, short?>
+        private class RealmIntegerLongNullableShortConverter : SpecializedConverterBase<RealmInteger<long>, short?>
         {
-            public short? Convert(RealmInteger<long> value) => (short)value;
+            public override short? Convert(RealmInteger<long> value) => (short)value;
         }
 
-        public class RealmIntegerLongNullableIntConverter : ISpecializedConverter<RealmInteger<long>, int?>
+        private class RealmIntegerLongNullableIntConverter : SpecializedConverterBase<RealmInteger<long>, int?>
         {
-            public int? Convert(RealmInteger<long> value) => (int)value;
+            public override int? Convert(RealmInteger<long> value) => (int)value;
         }
 
-        public class RealmIntegerLongNullableLongConverter : ISpecializedConverter<RealmInteger<long>, long?>
+        private class RealmIntegerLongNullableLongConverter : SpecializedConverterBase<RealmInteger<long>, long?>
         {
-            public long? Convert(RealmInteger<long> value) => value;
+            public override long? Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongNullableRealmIntegerByteConverter : ISpecializedConverter<RealmInteger<long>, RealmInteger<byte>?>
+        private class RealmIntegerLongNullableRealmIntegerByteConverter : SpecializedConverterBase<RealmInteger<long>, RealmInteger<byte>?>
         {
-            public RealmInteger<byte>? Convert(RealmInteger<long> value) => (byte)value;
+            public override RealmInteger<byte>? Convert(RealmInteger<long> value) => (byte)value;
         }
 
-        public class RealmIntegerLongNullableRealmIntegerShortConverter : ISpecializedConverter<RealmInteger<long>, RealmInteger<short>?>
+        private class RealmIntegerLongNullableRealmIntegerShortConverter : SpecializedConverterBase<RealmInteger<long>, RealmInteger<short>?>
         {
-            public RealmInteger<short>? Convert(RealmInteger<long> value) => (short)value;
+            public override RealmInteger<short>? Convert(RealmInteger<long> value) => (short)value;
         }
 
-        public class RealmIntegerLongNullableRealmIntegerIntConverter : ISpecializedConverter<RealmInteger<long>, RealmInteger<int>?>
+        private class RealmIntegerLongNullableRealmIntegerIntConverter : SpecializedConverterBase<RealmInteger<long>, RealmInteger<int>?>
         {
-            public RealmInteger<int>? Convert(RealmInteger<long> value) => (int)value;
+            public override RealmInteger<int>? Convert(RealmInteger<long> value) => (int)value;
         }
 
-        public class RealmIntegerLongNullableRealmIntegerLongConverter : ISpecializedConverter<RealmInteger<long>, RealmInteger<long>?>
+        private class RealmIntegerLongNullableRealmIntegerLongConverter : SpecializedConverterBase<RealmInteger<long>, RealmInteger<long>?>
         {
-            public RealmInteger<long>? Convert(RealmInteger<long> value) => value;
+            public override RealmInteger<long>? Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongNullableFloatConverter : ISpecializedConverter<RealmInteger<long>, float?>
+        private class RealmIntegerLongNullableFloatConverter : SpecializedConverterBase<RealmInteger<long>, float?>
         {
-            public float? Convert(RealmInteger<long> value) => value;
+            public override float? Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongNullableDoubleConverter : ISpecializedConverter<RealmInteger<long>, double?>
+        private class RealmIntegerLongNullableDoubleConverter : SpecializedConverterBase<RealmInteger<long>, double?>
         {
-            public double? Convert(RealmInteger<long> value) => value;
+            public override double? Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongNullableDecimalConverter : ISpecializedConverter<RealmInteger<long>, decimal?>
+        private class RealmIntegerLongNullableDecimalConverter : SpecializedConverterBase<RealmInteger<long>, decimal?>
         {
-            public decimal? Convert(RealmInteger<long> value) => value;
+            public override decimal? Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongNullableDecimal128Converter : ISpecializedConverter<RealmInteger<long>, Decimal128?>
+        private class RealmIntegerLongNullableDecimal128Converter : SpecializedConverterBase<RealmInteger<long>, Decimal128?>
         {
-            public Decimal128? Convert(RealmInteger<long> value) => (long)value;
+            public override Decimal128? Convert(RealmInteger<long> value) => (long)value;
         }
 
-        public class CharByteConverter : ISpecializedConverter<char, byte>
+        private class CharByteConverter : SpecializedConverterBase<char, byte>
         {
-            public byte Convert(char value) => (byte)value;
+            public override byte Convert(char value) => (byte)value;
         }
 
-        public class CharShortConverter : ISpecializedConverter<char, short>
+        private class CharShortConverter : SpecializedConverterBase<char, short>
         {
-            public short Convert(char value) => (short)value;
+            public override short Convert(char value) => (short)value;
         }
 
-        public class CharIntConverter : ISpecializedConverter<char, int>
+        private class CharIntConverter : SpecializedConverterBase<char, int>
         {
-            public int Convert(char value) => value;
+            public override int Convert(char value) => value;
         }
 
-        public class CharLongConverter : ISpecializedConverter<char, long>
+        private class CharLongConverter : SpecializedConverterBase<char, long>
         {
-            public long Convert(char value) => value;
+            public override long Convert(char value) => value;
         }
 
-        public class CharRealmIntegerByteConverter : ISpecializedConverter<char, RealmInteger<byte>>
+        private class CharRealmIntegerByteConverter : SpecializedConverterBase<char, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(char value) => (byte)value;
+            public override RealmInteger<byte> Convert(char value) => (byte)value;
         }
 
-        public class CharRealmIntegerShortConverter : ISpecializedConverter<char, RealmInteger<short>>
+        private class CharRealmIntegerShortConverter : SpecializedConverterBase<char, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(char value) => (short)value;
+            public override RealmInteger<short> Convert(char value) => (short)value;
         }
 
-        public class CharRealmIntegerIntConverter : ISpecializedConverter<char, RealmInteger<int>>
+        private class CharRealmIntegerIntConverter : SpecializedConverterBase<char, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(char value) => value;
+            public override RealmInteger<int> Convert(char value) => value;
         }
 
-        public class CharRealmIntegerLongConverter : ISpecializedConverter<char, RealmInteger<long>>
+        private class CharRealmIntegerLongConverter : SpecializedConverterBase<char, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(char value) => value;
+            public override RealmInteger<long> Convert(char value) => value;
         }
 
-        public class CharFloatConverter : ISpecializedConverter<char, float>
+        private class CharFloatConverter : SpecializedConverterBase<char, float>
         {
-            public float Convert(char value) => value;
+            public override float Convert(char value) => value;
         }
 
-        public class CharDoubleConverter : ISpecializedConverter<char, double>
+        private class CharDoubleConverter : SpecializedConverterBase<char, double>
         {
-            public double Convert(char value) => value;
+            public override double Convert(char value) => value;
         }
 
-        public class CharDecimalConverter : ISpecializedConverter<char, decimal>
+        private class CharDecimalConverter : SpecializedConverterBase<char, decimal>
         {
-            public decimal Convert(char value) => value;
+            public override decimal Convert(char value) => value;
         }
 
-        public class CharDecimal128Converter : ISpecializedConverter<char, Decimal128>
+        private class CharDecimal128Converter : SpecializedConverterBase<char, Decimal128>
         {
-            public Decimal128 Convert(char value) => value;
+            public override Decimal128 Convert(char value) => value;
         }
 
-        public class ByteCharConverter : ISpecializedConverter<byte, char>
+        private class ByteCharConverter : SpecializedConverterBase<byte, char>
         {
-            public char Convert(byte value) => (char)value;
+            public override char Convert(byte value) => (char)value;
         }
 
-        public class ByteShortConverter : ISpecializedConverter<byte, short>
+        private class ByteShortConverter : SpecializedConverterBase<byte, short>
         {
-            public short Convert(byte value) => value;
+            public override short Convert(byte value) => value;
         }
 
-        public class ByteIntConverter : ISpecializedConverter<byte, int>
+        private class ByteIntConverter : SpecializedConverterBase<byte, int>
         {
-            public int Convert(byte value) => value;
+            public override int Convert(byte value) => value;
         }
 
-        public class ByteLongConverter : ISpecializedConverter<byte, long>
+        private class ByteLongConverter : SpecializedConverterBase<byte, long>
         {
-            public long Convert(byte value) => value;
+            public override long Convert(byte value) => value;
         }
 
-        public class ByteRealmIntegerByteConverter : ISpecializedConverter<byte, RealmInteger<byte>>
+        private class ByteRealmIntegerByteConverter : SpecializedConverterBase<byte, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(byte value) => value;
+            public override RealmInteger<byte> Convert(byte value) => value;
         }
 
-        public class ByteRealmIntegerShortConverter : ISpecializedConverter<byte, RealmInteger<short>>
+        private class ByteRealmIntegerShortConverter : SpecializedConverterBase<byte, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(byte value) => value;
+            public override RealmInteger<short> Convert(byte value) => value;
         }
 
-        public class ByteRealmIntegerIntConverter : ISpecializedConverter<byte, RealmInteger<int>>
+        private class ByteRealmIntegerIntConverter : SpecializedConverterBase<byte, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(byte value) => value;
+            public override RealmInteger<int> Convert(byte value) => value;
         }
 
-        public class ByteRealmIntegerLongConverter : ISpecializedConverter<byte, RealmInteger<long>>
+        private class ByteRealmIntegerLongConverter : SpecializedConverterBase<byte, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(byte value) => value;
+            public override RealmInteger<long> Convert(byte value) => value;
         }
 
-        public class ByteFloatConverter : ISpecializedConverter<byte, float>
+        private class ByteFloatConverter : SpecializedConverterBase<byte, float>
         {
-            public float Convert(byte value) => value;
+            public override float Convert(byte value) => value;
         }
 
-        public class ByteDoubleConverter : ISpecializedConverter<byte, double>
+        private class ByteDoubleConverter : SpecializedConverterBase<byte, double>
         {
-            public double Convert(byte value) => value;
+            public override double Convert(byte value) => value;
         }
 
-        public class ByteDecimalConverter : ISpecializedConverter<byte, decimal>
+        private class ByteDecimalConverter : SpecializedConverterBase<byte, decimal>
         {
-            public decimal Convert(byte value) => value;
+            public override decimal Convert(byte value) => value;
         }
 
-        public class ByteDecimal128Converter : ISpecializedConverter<byte, Decimal128>
+        private class ByteDecimal128Converter : SpecializedConverterBase<byte, Decimal128>
         {
-            public Decimal128 Convert(byte value) => value;
+            public override Decimal128 Convert(byte value) => value;
         }
 
-        public class ShortCharConverter : ISpecializedConverter<short, char>
+        private class ShortCharConverter : SpecializedConverterBase<short, char>
         {
-            public char Convert(short value) => (char)value;
+            public override char Convert(short value) => (char)value;
         }
 
-        public class ShortByteConverter : ISpecializedConverter<short, byte>
+        private class ShortByteConverter : SpecializedConverterBase<short, byte>
         {
-            public byte Convert(short value) => (byte)value;
+            public override byte Convert(short value) => (byte)value;
         }
 
-        public class ShortIntConverter : ISpecializedConverter<short, int>
+        private class ShortIntConverter : SpecializedConverterBase<short, int>
         {
-            public int Convert(short value) => value;
+            public override int Convert(short value) => value;
         }
 
-        public class ShortLongConverter : ISpecializedConverter<short, long>
+        private class ShortLongConverter : SpecializedConverterBase<short, long>
         {
-            public long Convert(short value) => value;
+            public override long Convert(short value) => value;
         }
 
-        public class ShortRealmIntegerByteConverter : ISpecializedConverter<short, RealmInteger<byte>>
+        private class ShortRealmIntegerByteConverter : SpecializedConverterBase<short, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(short value) => (byte)value;
+            public override RealmInteger<byte> Convert(short value) => (byte)value;
         }
 
-        public class ShortRealmIntegerShortConverter : ISpecializedConverter<short, RealmInteger<short>>
+        private class ShortRealmIntegerShortConverter : SpecializedConverterBase<short, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(short value) => value;
+            public override RealmInteger<short> Convert(short value) => value;
         }
 
-        public class ShortRealmIntegerIntConverter : ISpecializedConverter<short, RealmInteger<int>>
+        private class ShortRealmIntegerIntConverter : SpecializedConverterBase<short, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(short value) => value;
+            public override RealmInteger<int> Convert(short value) => value;
         }
 
-        public class ShortRealmIntegerLongConverter : ISpecializedConverter<short, RealmInteger<long>>
+        private class ShortRealmIntegerLongConverter : SpecializedConverterBase<short, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(short value) => value;
+            public override RealmInteger<long> Convert(short value) => value;
         }
 
-        public class ShortFloatConverter : ISpecializedConverter<short, float>
+        private class ShortFloatConverter : SpecializedConverterBase<short, float>
         {
-            public float Convert(short value) => value;
+            public override float Convert(short value) => value;
         }
 
-        public class ShortDoubleConverter : ISpecializedConverter<short, double>
+        private class ShortDoubleConverter : SpecializedConverterBase<short, double>
         {
-            public double Convert(short value) => value;
+            public override double Convert(short value) => value;
         }
 
-        public class ShortDecimalConverter : ISpecializedConverter<short, decimal>
+        private class ShortDecimalConverter : SpecializedConverterBase<short, decimal>
         {
-            public decimal Convert(short value) => value;
+            public override decimal Convert(short value) => value;
         }
 
-        public class ShortDecimal128Converter : ISpecializedConverter<short, Decimal128>
+        private class ShortDecimal128Converter : SpecializedConverterBase<short, Decimal128>
         {
-            public Decimal128 Convert(short value) => value;
+            public override Decimal128 Convert(short value) => value;
         }
 
-        public class IntCharConverter : ISpecializedConverter<int, char>
+        private class IntCharConverter : SpecializedConverterBase<int, char>
         {
-            public char Convert(int value) => (char)value;
+            public override char Convert(int value) => (char)value;
         }
 
-        public class IntByteConverter : ISpecializedConverter<int, byte>
+        private class IntByteConverter : SpecializedConverterBase<int, byte>
         {
-            public byte Convert(int value) => (byte)value;
+            public override byte Convert(int value) => (byte)value;
         }
 
-        public class IntShortConverter : ISpecializedConverter<int, short>
+        private class IntShortConverter : SpecializedConverterBase<int, short>
         {
-            public short Convert(int value) => (short)value;
+            public override short Convert(int value) => (short)value;
         }
 
-        public class IntLongConverter : ISpecializedConverter<int, long>
+        private class IntLongConverter : SpecializedConverterBase<int, long>
         {
-            public long Convert(int value) => value;
+            public override long Convert(int value) => value;
         }
 
-        public class IntRealmIntegerByteConverter : ISpecializedConverter<int, RealmInteger<byte>>
+        private class IntRealmIntegerByteConverter : SpecializedConverterBase<int, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(int value) => (byte)value;
+            public override RealmInteger<byte> Convert(int value) => (byte)value;
         }
 
-        public class IntRealmIntegerShortConverter : ISpecializedConverter<int, RealmInteger<short>>
+        private class IntRealmIntegerShortConverter : SpecializedConverterBase<int, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(int value) => (short)value;
+            public override RealmInteger<short> Convert(int value) => (short)value;
         }
 
-        public class IntRealmIntegerIntConverter : ISpecializedConverter<int, RealmInteger<int>>
+        private class IntRealmIntegerIntConverter : SpecializedConverterBase<int, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(int value) => value;
+            public override RealmInteger<int> Convert(int value) => value;
         }
 
-        public class IntRealmIntegerLongConverter : ISpecializedConverter<int, RealmInteger<long>>
+        private class IntRealmIntegerLongConverter : SpecializedConverterBase<int, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(int value) => value;
+            public override RealmInteger<long> Convert(int value) => value;
         }
 
-        public class IntFloatConverter : ISpecializedConverter<int, float>
+        private class IntFloatConverter : SpecializedConverterBase<int, float>
         {
-            public float Convert(int value) => value;
+            public override float Convert(int value) => value;
         }
 
-        public class IntDoubleConverter : ISpecializedConverter<int, double>
+        private class IntDoubleConverter : SpecializedConverterBase<int, double>
         {
-            public double Convert(int value) => value;
+            public override double Convert(int value) => value;
         }
 
-        public class IntDecimalConverter : ISpecializedConverter<int, decimal>
+        private class IntDecimalConverter : SpecializedConverterBase<int, decimal>
         {
-            public decimal Convert(int value) => value;
+            public override decimal Convert(int value) => value;
         }
 
-        public class IntDecimal128Converter : ISpecializedConverter<int, Decimal128>
+        private class IntDecimal128Converter : SpecializedConverterBase<int, Decimal128>
         {
-            public Decimal128 Convert(int value) => value;
+            public override Decimal128 Convert(int value) => value;
         }
 
-        public class LongCharConverter : ISpecializedConverter<long, char>
+        private class LongCharConverter : SpecializedConverterBase<long, char>
         {
-            public char Convert(long value) => (char)value;
+            public override char Convert(long value) => (char)value;
         }
 
-        public class LongByteConverter : ISpecializedConverter<long, byte>
+        private class LongByteConverter : SpecializedConverterBase<long, byte>
         {
-            public byte Convert(long value) => (byte)value;
+            public override byte Convert(long value) => (byte)value;
         }
 
-        public class LongShortConverter : ISpecializedConverter<long, short>
+        private class LongShortConverter : SpecializedConverterBase<long, short>
         {
-            public short Convert(long value) => (short)value;
+            public override short Convert(long value) => (short)value;
         }
 
-        public class LongIntConverter : ISpecializedConverter<long, int>
+        private class LongIntConverter : SpecializedConverterBase<long, int>
         {
-            public int Convert(long value) => (int)value;
+            public override int Convert(long value) => (int)value;
         }
 
-        public class LongRealmIntegerByteConverter : ISpecializedConverter<long, RealmInteger<byte>>
+        private class LongRealmIntegerByteConverter : SpecializedConverterBase<long, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(long value) => (byte)value;
+            public override RealmInteger<byte> Convert(long value) => (byte)value;
         }
 
-        public class LongRealmIntegerShortConverter : ISpecializedConverter<long, RealmInteger<short>>
+        private class LongRealmIntegerShortConverter : SpecializedConverterBase<long, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(long value) => (short)value;
+            public override RealmInteger<short> Convert(long value) => (short)value;
         }
 
-        public class LongRealmIntegerIntConverter : ISpecializedConverter<long, RealmInteger<int>>
+        private class LongRealmIntegerIntConverter : SpecializedConverterBase<long, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(long value) => (int)value;
+            public override RealmInteger<int> Convert(long value) => (int)value;
         }
 
-        public class LongRealmIntegerLongConverter : ISpecializedConverter<long, RealmInteger<long>>
+        private class LongRealmIntegerLongConverter : SpecializedConverterBase<long, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(long value) => value;
+            public override RealmInteger<long> Convert(long value) => value;
         }
 
-        public class LongFloatConverter : ISpecializedConverter<long, float>
+        private class LongFloatConverter : SpecializedConverterBase<long, float>
         {
-            public float Convert(long value) => value;
+            public override float Convert(long value) => value;
         }
 
-        public class LongDoubleConverter : ISpecializedConverter<long, double>
+        private class LongDoubleConverter : SpecializedConverterBase<long, double>
         {
-            public double Convert(long value) => value;
+            public override double Convert(long value) => value;
         }
 
-        public class LongDecimalConverter : ISpecializedConverter<long, decimal>
+        private class LongDecimalConverter : SpecializedConverterBase<long, decimal>
         {
-            public decimal Convert(long value) => value;
+            public override decimal Convert(long value) => value;
         }
 
-        public class LongDecimal128Converter : ISpecializedConverter<long, Decimal128>
+        private class LongDecimal128Converter : SpecializedConverterBase<long, Decimal128>
         {
-            public Decimal128 Convert(long value) => value;
+            public override Decimal128 Convert(long value) => value;
         }
 
-        public class RealmIntegerByteCharConverter : ISpecializedConverter<RealmInteger<byte>, char>
+        private class RealmIntegerByteCharConverter : SpecializedConverterBase<RealmInteger<byte>, char>
         {
-            public char Convert(RealmInteger<byte> value) => (char)(byte)value;
+            public override char Convert(RealmInteger<byte> value) => (char)(byte)value;
         }
 
-        public class RealmIntegerByteByteConverter : ISpecializedConverter<RealmInteger<byte>, byte>
+        private class RealmIntegerByteByteConverter : SpecializedConverterBase<RealmInteger<byte>, byte>
         {
-            public byte Convert(RealmInteger<byte> value) => value;
+            public override byte Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteShortConverter : ISpecializedConverter<RealmInteger<byte>, short>
+        private class RealmIntegerByteShortConverter : SpecializedConverterBase<RealmInteger<byte>, short>
         {
-            public short Convert(RealmInteger<byte> value) => value;
+            public override short Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteIntConverter : ISpecializedConverter<RealmInteger<byte>, int>
+        private class RealmIntegerByteIntConverter : SpecializedConverterBase<RealmInteger<byte>, int>
         {
-            public int Convert(RealmInteger<byte> value) => value;
+            public override int Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteLongConverter : ISpecializedConverter<RealmInteger<byte>, long>
+        private class RealmIntegerByteLongConverter : SpecializedConverterBase<RealmInteger<byte>, long>
         {
-            public long Convert(RealmInteger<byte> value) => value;
+            public override long Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteRealmIntegerShortConverter : ISpecializedConverter<RealmInteger<byte>, RealmInteger<short>>
+        private class RealmIntegerByteRealmIntegerShortConverter : SpecializedConverterBase<RealmInteger<byte>, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(RealmInteger<byte> value) => (short)value;
+            public override RealmInteger<short> Convert(RealmInteger<byte> value) => (short)value;
         }
 
-        public class RealmIntegerByteRealmIntegerIntConverter : ISpecializedConverter<RealmInteger<byte>, RealmInteger<int>>
+        private class RealmIntegerByteRealmIntegerIntConverter : SpecializedConverterBase<RealmInteger<byte>, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(RealmInteger<byte> value) => (int)value;
+            public override RealmInteger<int> Convert(RealmInteger<byte> value) => (int)value;
         }
 
-        public class RealmIntegerByteRealmIntegerLongConverter : ISpecializedConverter<RealmInteger<byte>, RealmInteger<long>>
+        private class RealmIntegerByteRealmIntegerLongConverter : SpecializedConverterBase<RealmInteger<byte>, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(RealmInteger<byte> value) => (long)value;
+            public override RealmInteger<long> Convert(RealmInteger<byte> value) => (long)value;
         }
 
-        public class RealmIntegerByteFloatConverter : ISpecializedConverter<RealmInteger<byte>, float>
+        private class RealmIntegerByteFloatConverter : SpecializedConverterBase<RealmInteger<byte>, float>
         {
-            public float Convert(RealmInteger<byte> value) => value;
+            public override float Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteDoubleConverter : ISpecializedConverter<RealmInteger<byte>, double>
+        private class RealmIntegerByteDoubleConverter : SpecializedConverterBase<RealmInteger<byte>, double>
         {
-            public double Convert(RealmInteger<byte> value) => value;
+            public override double Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteDecimalConverter : ISpecializedConverter<RealmInteger<byte>, decimal>
+        private class RealmIntegerByteDecimalConverter : SpecializedConverterBase<RealmInteger<byte>, decimal>
         {
-            public decimal Convert(RealmInteger<byte> value) => value;
+            public override decimal Convert(RealmInteger<byte> value) => value;
         }
 
-        public class RealmIntegerByteDecimal128Converter : ISpecializedConverter<RealmInteger<byte>, Decimal128>
+        private class RealmIntegerByteDecimal128Converter : SpecializedConverterBase<RealmInteger<byte>, Decimal128>
         {
-            public Decimal128 Convert(RealmInteger<byte> value) => (byte)value;
+            public override Decimal128 Convert(RealmInteger<byte> value) => (byte)value;
         }
 
-        public class RealmIntegerShortCharConverter : ISpecializedConverter<RealmInteger<short>, char>
+        private class RealmIntegerShortCharConverter : SpecializedConverterBase<RealmInteger<short>, char>
         {
-            public char Convert(RealmInteger<short> value) => (char)(short)value;
+            public override char Convert(RealmInteger<short> value) => (char)(short)value;
         }
 
-        public class RealmIntegerShortByteConverter : ISpecializedConverter<RealmInteger<short>, byte>
+        private class RealmIntegerShortByteConverter : SpecializedConverterBase<RealmInteger<short>, byte>
         {
-            public byte Convert(RealmInteger<short> value) => (byte)value;
+            public override byte Convert(RealmInteger<short> value) => (byte)value;
         }
 
-        public class RealmIntegerShortShortConverter : ISpecializedConverter<RealmInteger<short>, short>
+        private class RealmIntegerShortShortConverter : SpecializedConverterBase<RealmInteger<short>, short>
         {
-            public short Convert(RealmInteger<short> value) => value;
+            public override short Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortIntConverter : ISpecializedConverter<RealmInteger<short>, int>
+        private class RealmIntegerShortIntConverter : SpecializedConverterBase<RealmInteger<short>, int>
         {
-            public int Convert(RealmInteger<short> value) => value;
+            public override int Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortLongConverter : ISpecializedConverter<RealmInteger<short>, long>
+        private class RealmIntegerShortLongConverter : SpecializedConverterBase<RealmInteger<short>, long>
         {
-            public long Convert(RealmInteger<short> value) => value;
+            public override long Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortRealmIntegerByteConverter : ISpecializedConverter<RealmInteger<short>, RealmInteger<byte>>
+        private class RealmIntegerShortRealmIntegerByteConverter : SpecializedConverterBase<RealmInteger<short>, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(RealmInteger<short> value) => (byte)value;
+            public override RealmInteger<byte> Convert(RealmInteger<short> value) => (byte)value;
         }
 
-        public class RealmIntegerShortRealmIntegerIntConverter : ISpecializedConverter<RealmInteger<short>, RealmInteger<int>>
+        private class RealmIntegerShortRealmIntegerIntConverter : SpecializedConverterBase<RealmInteger<short>, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(RealmInteger<short> value) => (int)value;
+            public override RealmInteger<int> Convert(RealmInteger<short> value) => (int)value;
         }
 
-        public class RealmIntegerShortRealmIntegerLongConverter : ISpecializedConverter<RealmInteger<short>, RealmInteger<long>>
+        private class RealmIntegerShortRealmIntegerLongConverter : SpecializedConverterBase<RealmInteger<short>, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(RealmInteger<short> value) => (long)value;
+            public override RealmInteger<long> Convert(RealmInteger<short> value) => (long)value;
         }
 
-        public class RealmIntegerShortFloatConverter : ISpecializedConverter<RealmInteger<short>, float>
+        private class RealmIntegerShortFloatConverter : SpecializedConverterBase<RealmInteger<short>, float>
         {
-            public float Convert(RealmInteger<short> value) => value;
+            public override float Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortDoubleConverter : ISpecializedConverter<RealmInteger<short>, double>
+        private class RealmIntegerShortDoubleConverter : SpecializedConverterBase<RealmInteger<short>, double>
         {
-            public double Convert(RealmInteger<short> value) => value;
+            public override double Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortDecimalConverter : ISpecializedConverter<RealmInteger<short>, decimal>
+        private class RealmIntegerShortDecimalConverter : SpecializedConverterBase<RealmInteger<short>, decimal>
         {
-            public decimal Convert(RealmInteger<short> value) => value;
+            public override decimal Convert(RealmInteger<short> value) => value;
         }
 
-        public class RealmIntegerShortDecimal128Converter : ISpecializedConverter<RealmInteger<short>, Decimal128>
+        private class RealmIntegerShortDecimal128Converter : SpecializedConverterBase<RealmInteger<short>, Decimal128>
         {
-            public Decimal128 Convert(RealmInteger<short> value) => (short)value;
+            public override Decimal128 Convert(RealmInteger<short> value) => (short)value;
         }
 
-        public class RealmIntegerIntCharConverter : ISpecializedConverter<RealmInteger<int>, char>
+        private class RealmIntegerIntCharConverter : SpecializedConverterBase<RealmInteger<int>, char>
         {
-            public char Convert(RealmInteger<int> value) => (char)value;
+            public override char Convert(RealmInteger<int> value) => (char)value;
         }
 
-        public class RealmIntegerIntByteConverter : ISpecializedConverter<RealmInteger<int>, byte>
+        private class RealmIntegerIntByteConverter : SpecializedConverterBase<RealmInteger<int>, byte>
         {
-            public byte Convert(RealmInteger<int> value) => (byte)value;
+            public override byte Convert(RealmInteger<int> value) => (byte)value;
         }
 
-        public class RealmIntegerIntShortConverter : ISpecializedConverter<RealmInteger<int>, short>
+        private class RealmIntegerIntShortConverter : SpecializedConverterBase<RealmInteger<int>, short>
         {
-            public short Convert(RealmInteger<int> value) => (short)value;
+            public override short Convert(RealmInteger<int> value) => (short)value;
         }
 
-        public class RealmIntegerIntIntConverter : ISpecializedConverter<RealmInteger<int>, int>
+        private class RealmIntegerIntIntConverter : SpecializedConverterBase<RealmInteger<int>, int>
         {
-            public int Convert(RealmInteger<int> value) => value;
+            public override int Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntLongConverter : ISpecializedConverter<RealmInteger<int>, long>
+        private class RealmIntegerIntLongConverter : SpecializedConverterBase<RealmInteger<int>, long>
         {
-            public long Convert(RealmInteger<int> value) => value;
+            public override long Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntRealmIntegerByteConverter : ISpecializedConverter<RealmInteger<int>, RealmInteger<byte>>
+        private class RealmIntegerIntRealmIntegerByteConverter : SpecializedConverterBase<RealmInteger<int>, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(RealmInteger<int> value) => (byte)value;
+            public override RealmInteger<byte> Convert(RealmInteger<int> value) => (byte)value;
         }
 
-        public class RealmIntegerIntRealmIntegerShortConverter : ISpecializedConverter<RealmInteger<int>, RealmInteger<short>>
+        private class RealmIntegerIntRealmIntegerShortConverter : SpecializedConverterBase<RealmInteger<int>, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(RealmInteger<int> value) => (short)value;
+            public override RealmInteger<short> Convert(RealmInteger<int> value) => (short)value;
         }
 
-        public class RealmIntegerIntRealmIntegerLongConverter : ISpecializedConverter<RealmInteger<int>, RealmInteger<long>>
+        private class RealmIntegerIntRealmIntegerLongConverter : SpecializedConverterBase<RealmInteger<int>, RealmInteger<long>>
         {
-            public RealmInteger<long> Convert(RealmInteger<int> value) => (long)value;
+            public override RealmInteger<long> Convert(RealmInteger<int> value) => (long)value;
         }
 
-        public class RealmIntegerIntFloatConverter : ISpecializedConverter<RealmInteger<int>, float>
+        private class RealmIntegerIntFloatConverter : SpecializedConverterBase<RealmInteger<int>, float>
         {
-            public float Convert(RealmInteger<int> value) => value;
+            public override float Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntDoubleConverter : ISpecializedConverter<RealmInteger<int>, double>
+        private class RealmIntegerIntDoubleConverter : SpecializedConverterBase<RealmInteger<int>, double>
         {
-            public double Convert(RealmInteger<int> value) => value;
+            public override double Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntDecimalConverter : ISpecializedConverter<RealmInteger<int>, decimal>
+        private class RealmIntegerIntDecimalConverter : SpecializedConverterBase<RealmInteger<int>, decimal>
         {
-            public decimal Convert(RealmInteger<int> value) => value;
+            public override decimal Convert(RealmInteger<int> value) => value;
         }
 
-        public class RealmIntegerIntDecimal128Converter : ISpecializedConverter<RealmInteger<int>, Decimal128>
+        private class RealmIntegerIntDecimal128Converter : SpecializedConverterBase<RealmInteger<int>, Decimal128>
         {
-            public Decimal128 Convert(RealmInteger<int> value) => (int)value;
+            public override Decimal128 Convert(RealmInteger<int> value) => (int)value;
         }
 
-        public class RealmIntegerLongCharConverter : ISpecializedConverter<RealmInteger<long>, char>
+        private class RealmIntegerLongCharConverter : SpecializedConverterBase<RealmInteger<long>, char>
         {
-            public char Convert(RealmInteger<long> value) => (char)value;
+            public override char Convert(RealmInteger<long> value) => (char)value;
         }
 
-        public class RealmIntegerLongByteConverter : ISpecializedConverter<RealmInteger<long>, byte>
+        private class RealmIntegerLongByteConverter : SpecializedConverterBase<RealmInteger<long>, byte>
         {
-            public byte Convert(RealmInteger<long> value) => (byte)value;
+            public override byte Convert(RealmInteger<long> value) => (byte)value;
         }
 
-        public class RealmIntegerLongShortConverter : ISpecializedConverter<RealmInteger<long>, short>
+        private class RealmIntegerLongShortConverter : SpecializedConverterBase<RealmInteger<long>, short>
         {
-            public short Convert(RealmInteger<long> value) => (short)value;
+            public override short Convert(RealmInteger<long> value) => (short)value;
         }
 
-        public class RealmIntegerLongIntConverter : ISpecializedConverter<RealmInteger<long>, int>
+        private class RealmIntegerLongIntConverter : SpecializedConverterBase<RealmInteger<long>, int>
         {
-            public int Convert(RealmInteger<long> value) => (int)value;
+            public override int Convert(RealmInteger<long> value) => (int)value;
         }
 
-        public class RealmIntegerLongLongConverter : ISpecializedConverter<RealmInteger<long>, long>
+        private class RealmIntegerLongLongConverter : SpecializedConverterBase<RealmInteger<long>, long>
         {
-            public long Convert(RealmInteger<long> value) => value;
+            public override long Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongRealmIntegerByteConverter : ISpecializedConverter<RealmInteger<long>, RealmInteger<byte>>
+        private class RealmIntegerLongRealmIntegerByteConverter : SpecializedConverterBase<RealmInteger<long>, RealmInteger<byte>>
         {
-            public RealmInteger<byte> Convert(RealmInteger<long> value) => (byte)value;
+            public override RealmInteger<byte> Convert(RealmInteger<long> value) => (byte)value;
         }
 
-        public class RealmIntegerLongRealmIntegerShortConverter : ISpecializedConverter<RealmInteger<long>, RealmInteger<short>>
+        private class RealmIntegerLongRealmIntegerShortConverter : SpecializedConverterBase<RealmInteger<long>, RealmInteger<short>>
         {
-            public RealmInteger<short> Convert(RealmInteger<long> value) => (short)value;
+            public override RealmInteger<short> Convert(RealmInteger<long> value) => (short)value;
         }
 
-        public class RealmIntegerLongRealmIntegerIntConverter : ISpecializedConverter<RealmInteger<long>, RealmInteger<int>>
+        private class RealmIntegerLongRealmIntegerIntConverter : SpecializedConverterBase<RealmInteger<long>, RealmInteger<int>>
         {
-            public RealmInteger<int> Convert(RealmInteger<long> value) => (int)value;
+            public override RealmInteger<int> Convert(RealmInteger<long> value) => (int)value;
         }
 
-        public class RealmIntegerLongFloatConverter : ISpecializedConverter<RealmInteger<long>, float>
+        private class RealmIntegerLongFloatConverter : SpecializedConverterBase<RealmInteger<long>, float>
         {
-            public float Convert(RealmInteger<long> value) => value;
+            public override float Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongDoubleConverter : ISpecializedConverter<RealmInteger<long>, double>
+        private class RealmIntegerLongDoubleConverter : SpecializedConverterBase<RealmInteger<long>, double>
         {
-            public double Convert(RealmInteger<long> value) => value;
+            public override double Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongDecimalConverter : ISpecializedConverter<RealmInteger<long>, decimal>
+        private class RealmIntegerLongDecimalConverter : SpecializedConverterBase<RealmInteger<long>, decimal>
         {
-            public decimal Convert(RealmInteger<long> value) => value;
+            public override decimal Convert(RealmInteger<long> value) => value;
         }
 
-        public class RealmIntegerLongDecimal128Converter : ISpecializedConverter<RealmInteger<long>, Decimal128>
+        private class RealmIntegerLongDecimal128Converter : SpecializedConverterBase<RealmInteger<long>, Decimal128>
         {
-            public Decimal128 Convert(RealmInteger<long> value) => (long)value;
+            public override Decimal128 Convert(RealmInteger<long> value) => (long)value;
         }
 
         #endregion Integral Converters
 
         #region Floating Point Converters
 
-        public class FloatNullableFloatConverter : ISpecializedConverter<float, float?>
+        private class FloatNullableFloatConverter : SpecializedConverterBase<float, float?>
         {
-            public float? Convert(float value) => value;
+            public override float? Convert(float value) => value;
         }
 
-        public class FloatNullableDoubleConverter : ISpecializedConverter<float, double?>
+        private class FloatNullableDoubleConverter : SpecializedConverterBase<float, double?>
         {
-            public double? Convert(float value) => value;
+            public override double? Convert(float value) => value;
         }
 
-        public class FloatNullableDecimalConverter : ISpecializedConverter<float, decimal?>
+        private class FloatNullableDecimalConverter : SpecializedConverterBase<float, decimal?>
         {
-            public decimal? Convert(float value) => (decimal)value;
+            public override decimal? Convert(float value) => (decimal)value;
         }
 
-        public class FloatNullableDecimal128Converter : ISpecializedConverter<float, Decimal128?>
+        private class FloatNullableDecimal128Converter : SpecializedConverterBase<float, Decimal128?>
         {
-            public Decimal128? Convert(float value) => (Decimal128)value;
+            public override Decimal128? Convert(float value) => (Decimal128)value;
         }
 
-        public class DoubleNullableFloatConverter : ISpecializedConverter<double, float?>
+        private class DoubleNullableFloatConverter : SpecializedConverterBase<double, float?>
         {
-            public float? Convert(double value) => (float)value;
+            public override float? Convert(double value) => (float)value;
         }
 
-        public class DoubleNullableDoubleConverter : ISpecializedConverter<double, double?>
+        private class DoubleNullableDoubleConverter : SpecializedConverterBase<double, double?>
         {
-            public double? Convert(double value) => value;
+            public override double? Convert(double value) => value;
         }
 
-        public class DoubleNullableDecimalConverter : ISpecializedConverter<double, decimal?>
+        private class DoubleNullableDecimalConverter : SpecializedConverterBase<double, decimal?>
         {
-            public decimal? Convert(double value) => (decimal)value;
+            public override decimal? Convert(double value) => (decimal)value;
         }
 
-        public class DoubleNullableDecimal128Converter : ISpecializedConverter<double, Decimal128?>
+        private class DoubleNullableDecimal128Converter : SpecializedConverterBase<double, Decimal128?>
         {
-            public Decimal128? Convert(double value) => (Decimal128)value;
+            public override Decimal128? Convert(double value) => (Decimal128)value;
         }
 
-        public class DecimalNullableFloatConverter : ISpecializedConverter<decimal, float?>
+        private class DecimalNullableFloatConverter : SpecializedConverterBase<decimal, float?>
         {
-            public float? Convert(decimal value) => (float)value;
+            public override float? Convert(decimal value) => (float)value;
         }
 
-        public class DecimalNullableDoubleConverter : ISpecializedConverter<decimal, double?>
+        private class DecimalNullableDoubleConverter : SpecializedConverterBase<decimal, double?>
         {
-            public double? Convert(decimal value) => (double)value;
+            public override double? Convert(decimal value) => (double)value;
         }
 
-        public class DecimalNullableDecimalConverter : ISpecializedConverter<decimal, decimal?>
+        private class DecimalNullableDecimalConverter : SpecializedConverterBase<decimal, decimal?>
         {
-            public decimal? Convert(decimal value) => value;
+            public override decimal? Convert(decimal value) => value;
         }
 
-        public class DecimalNullableDecimal128Converter : ISpecializedConverter<decimal, Decimal128?>
+        private class DecimalNullableDecimal128Converter : SpecializedConverterBase<decimal, Decimal128?>
         {
-            public Decimal128? Convert(decimal value) => value;
+            public override Decimal128? Convert(decimal value) => value;
         }
 
-        public class Decimal128NullableFloatConverter : ISpecializedConverter<Decimal128, float?>
+        private class Decimal128NullableFloatConverter : SpecializedConverterBase<Decimal128, float?>
         {
-            public float? Convert(Decimal128 value) => (float)value;
+            public override float? Convert(Decimal128 value) => (float)value;
         }
 
-        public class Decimal128NullableDoubleConverter : ISpecializedConverter<Decimal128, double?>
+        private class Decimal128NullableDoubleConverter : SpecializedConverterBase<Decimal128, double?>
         {
-            public double? Convert(Decimal128 value) => (double)value;
+            public override double? Convert(Decimal128 value) => (double)value;
         }
 
-        public class Decimal128NullableDecimalConverter : ISpecializedConverter<Decimal128, decimal?>
+        private class Decimal128NullableDecimalConverter : SpecializedConverterBase<Decimal128, decimal?>
         {
-            public decimal? Convert(Decimal128 value) => (decimal)value;
+            public override decimal? Convert(Decimal128 value) => (decimal)value;
         }
 
-        public class Decimal128NullableDecimal128Converter : ISpecializedConverter<Decimal128, Decimal128?>
+        private class Decimal128NullableDecimal128Converter : SpecializedConverterBase<Decimal128, Decimal128?>
         {
-            public Decimal128? Convert(Decimal128 value) => value;
+            public override Decimal128? Convert(Decimal128 value) => value;
         }
 
-        public class FloatDoubleConverter : ISpecializedConverter<float, double>
+        private class FloatDoubleConverter : SpecializedConverterBase<float, double>
         {
-            public double Convert(float value) => value;
+            public override double Convert(float value) => value;
         }
 
-        public class FloatDecimalConverter : ISpecializedConverter<float, decimal>
+        private class FloatDecimalConverter : SpecializedConverterBase<float, decimal>
         {
-            public decimal Convert(float value) => (decimal)value;
+            public override decimal Convert(float value) => (decimal)value;
         }
 
-        public class FloatDecimal128Converter : ISpecializedConverter<float, Decimal128>
+        private class FloatDecimal128Converter : SpecializedConverterBase<float, Decimal128>
         {
-            public Decimal128 Convert(float value) => (Decimal128)value;
+            public override Decimal128 Convert(float value) => (Decimal128)value;
         }
 
-        public class DoubleFloatConverter : ISpecializedConverter<double, float>
+        private class DoubleFloatConverter : SpecializedConverterBase<double, float>
         {
-            public float Convert(double value) => (float)value;
+            public override float Convert(double value) => (float)value;
         }
 
-        public class DoubleDecimalConverter : ISpecializedConverter<double, decimal>
+        private class DoubleDecimalConverter : SpecializedConverterBase<double, decimal>
         {
-            public decimal Convert(double value) => (decimal)value;
+            public override decimal Convert(double value) => (decimal)value;
         }
 
-        public class DoubleDecimal128Converter : ISpecializedConverter<double, Decimal128>
+        private class DoubleDecimal128Converter : SpecializedConverterBase<double, Decimal128>
         {
-            public Decimal128 Convert(double value) => (Decimal128)value;
+            public override Decimal128 Convert(double value) => (Decimal128)value;
         }
 
-        public class DecimalFloatConverter : ISpecializedConverter<decimal, float>
+        private class DecimalFloatConverter : SpecializedConverterBase<decimal, float>
         {
-            public float Convert(decimal value) => (float)value;
+            public override float Convert(decimal value) => (float)value;
         }
 
-        public class DecimalDoubleConverter : ISpecializedConverter<decimal, double>
+        private class DecimalDoubleConverter : SpecializedConverterBase<decimal, double>
         {
-            public double Convert(decimal value) => (double)value;
+            public override double Convert(decimal value) => (double)value;
         }
 
-        public class DecimalDecimal128Converter : ISpecializedConverter<decimal, Decimal128>
+        private class DecimalDecimal128Converter : SpecializedConverterBase<decimal, Decimal128>
         {
-            public Decimal128 Convert(decimal value) => value;
+            public override Decimal128 Convert(decimal value) => value;
         }
 
-        public class Decimal128FloatConverter : ISpecializedConverter<Decimal128, float>
+        private class Decimal128FloatConverter : SpecializedConverterBase<Decimal128, float>
         {
-            public float Convert(Decimal128 value) => (float)value;
+            public override float Convert(Decimal128 value) => (float)value;
         }
 
-        public class Decimal128DoubleConverter : ISpecializedConverter<Decimal128, double>
+        private class Decimal128DoubleConverter : SpecializedConverterBase<Decimal128, double>
         {
-            public double Convert(Decimal128 value) => (double)value;
+            public override double Convert(Decimal128 value) => (double)value;
         }
 
-        public class Decimal128DecimalConverter : ISpecializedConverter<Decimal128, decimal>
+        private class Decimal128DecimalConverter : SpecializedConverterBase<Decimal128, decimal>
         {
-            public decimal Convert(Decimal128 value) => (decimal)value;
+            public override decimal Convert(Decimal128 value) => (decimal)value;
         }
 
         #endregion Floating Point Converters

--- a/Realm/Realm/Helpers/Operator.tt
+++ b/Realm/Realm/Helpers/Operator.tt
@@ -41,7 +41,7 @@ namespace Realms.Helpers
         private static IDictionary<(Type, Type), IConverter> _valueConverters = new Dictionary<(Type, Type), IConverter>
         {
 <#
-            var realmValueContents = GetFileContents("..\\RealmValue.cs");
+            var realmValueContents = GetFileContents("..\\DatabaseTypes\\RealmValue.cs");
             var implicitToRealmValueTypes = GetMatchedGroups(realmValueContents, _implicitTypeToRealmValueRegex, "fromType");
             foreach (var type in implicitToRealmValueTypes)
             {
@@ -80,10 +80,9 @@ namespace Realms.Helpers
         /// know the exact type, but we know that a conversion exists.
         /// </summary>
         /// <remarks>
-        /// In synthetic benchmarks it performs about
-        /// two orders of magnitude faster than Convert.ChangeType. It is about 4 times slower than a direct cast
-        /// when the types are known, but about an order of magnitude faster than a cast that involves boxing to
-        /// object.
+        /// In synthetic benchmarks it performs about two orders of magnitude faster than Convert.ChangeType.
+        /// It is about 4 times slower than a direct cast when the types are known, but about an order of
+        /// magnitude faster than a cast that involves boxing to object.
         /// <br/>
         /// It makes use of implicit and explicit conversion operators defined on types to convert between
         /// numeric types, which means that we can use it both for downcasting and upcasting numeric types.
@@ -123,6 +122,65 @@ namespace Realms.Helpers
             }
 
             return GenericOperator<TFrom, TResult>.Convert(value);
+        }
+
+        /// <summary>
+        /// Converts an object to <typeparamref name="TResult"/>. It is intended to be used instead of Convert.ChangeType
+        /// for database types. It is less efficient than <see cref="Convert{TFrom, TResult}(TFrom)"/> so if both the source
+        /// and the target types are known, use the concrete conversion.
+        /// </summary>
+        /// <typeparam name="TResult">The type to which <paramref name="value"/> will be converted.</typeparam>
+        /// <param name="value">The value to convert to <typeparamref name="TResult"/>.</param>
+        /// <returns>The value of <paramref name="value"/> represented as <typeparamref name="TResult"/>.</returns>
+        public static TResult Convert<TResult>(object value)
+        {
+            var targetType = typeof(TResult);
+            if (targetType == typeof(RealmValue))
+            {
+                /* This is special cased due to a bug in the Xamarin.iOS interpreter. When value
+                 * is null, we end up with a NRE with the following stacktrace:
+                 *
+                 * <System.NullReferenceException: Object reference not set to an instance of an object
+                 * at System.Linq.Expressions.Interpreter.LightLambda.Run1[T0,TRet] (T0 arg0) [0x00038] in <ee28ffe65f2e47a98ea97b07327fb8f4>:0
+                 * at (wrapper delegate-invoke) System.Func`2[System.String,Realms.RealmValue].invoke_TResult_T(string)
+                 * at Realms.Helpers.Operator.Convert[TFrom,TResult] (TFrom value) [0x00005] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 * at Realms.RealmList`1[T].<.ctor>b__5_1 (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 * at Realms.RealmList`1[T].Add (T item) [0x00000] in <675c1cc840764fcb9ab78b319ccfeee3>:0
+                 *
+                 * May or may not be related to https://github.com/mono/mono/issues/15852.
+                 */
+                if (value is null)
+                {
+                    return Convert<RealmValue, TResult>(RealmValue.Null);
+                }
+
+                /* This is another special case where `value` is inheritable from RealmObjectBase. There's
+                 * no direct conversion from T to RealmValue, but there's conversion if we go through RealmObjectBase.
+                 */
+                if (value is RealmObjectBase robj)
+                {
+                    return Convert<RealmValue, TResult>(robj);
+                }
+            }
+
+            if (value is null)
+            {
+                return default(TResult) == null ? default(TResult) : throw new NotSupportedException($"Can't convert from null to {targetType.FullName} because the target type is not nullable.");
+            }
+
+            var sourceType = value.GetType();
+
+            if (_valueConverters.TryGetValue((sourceType, targetType), out var converter))
+            {
+                return ((IGenericConverter<TResult>)converter).Convert(value);
+            }
+
+            if (value is TResult res)
+            {
+                return res;
+            }
+
+            throw new NotSupportedException($"No conversion exists from {sourceType.FullName} to {targetType.FullName}");
         }
 
         /// <summary>
@@ -172,6 +230,18 @@ namespace Realms.Helpers
         }
 
         /// <summary>
+        /// An interface representing converter that can convert from <see cref="SourceType"/> to
+        /// <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TTarget">The type to which <see cref="SourceType"/> will be converted.</typeparam>
+        private interface IGenericConverter<TTarget> : IConverter
+        {
+            Type SourceType { get; }
+
+            TTarget Convert(object obj);
+        }
+
+        /// <summary>
         /// Interface representing a concrete converter from <typeparamref name="TSource"/>
         /// to <typeparamref name="TTarget"/>. For most types there will be exactly one concrete
         /// implementation, but there may be cases, such as <see cref="InheritanceConverter{TSource, TTarget}"/>
@@ -179,9 +249,18 @@ namespace Realms.Helpers
         /// </summary>
         /// <typeparam name="TSource">The type from which to convert.</typeparam>
         /// <typeparam name="TTarget">The type to which <typeparamref name="TSource"/> will be converted.</typeparam>
-        private interface ISpecializedConverter<TSource, TTarget> : IConverter
+        private interface ISpecializedConverter<TSource, TTarget> : IGenericConverter<TTarget>
         {
             TTarget Convert(TSource source);
+        }
+
+        private abstract class SpecializedConverterBase<TSource, TTarget> : ISpecializedConverter<TSource, TTarget>
+        {
+            public Type SourceType { get; } = typeof(TSource);
+
+            public abstract TTarget Convert(TSource source);
+
+            public virtual TTarget Convert(object obj) => Convert((TSource)obj);
         }
 
         /// <summary>
@@ -191,9 +270,9 @@ namespace Realms.Helpers
         /// </summary>
         /// <typeparam name="TSource">The type from which to convert.</typeparam>
         /// <typeparam name="TTarget">The type to which <typeparamref name="TSource"/> will be converted.</typeparam>
-        private class ThrowingConverter<TSource, TTarget> : ISpecializedConverter<TSource, TTarget>
+        private class ThrowingConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
         {
-            public TTarget Convert(TSource source) => throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
+            public override TTarget Convert(TSource source) => throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
         }
 
         /// <summary>
@@ -201,9 +280,9 @@ namespace Realms.Helpers
         /// the target type is, so we need to convert, just in case.
         /// </summary>
         /// <typeparam name="T">The type of both the source and the target.</typeparam>
-        private class UnaryConverter<T> : ISpecializedConverter<T, T>
+        private class UnaryConverter<T> : SpecializedConverterBase<T, T>
         {
-            public T Convert(T source) => source;
+            public override T Convert(T source) => source;
         }
 
         /// <summary>
@@ -213,9 +292,11 @@ namespace Realms.Helpers
         /// </summary>
         /// <typeparam name="TSource">The type from which to convert.</typeparam>
         /// <typeparam name="TTarget">The type to which <typeparamref name="TSource"/> will be converted.</typeparam>
-        private class InheritanceConverter<TSource, TTarget> : ISpecializedConverter<TSource, TTarget>
+        private class InheritanceConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
         {
-            public TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
+            public override TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new NotSupportedException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
+
+            public override TTarget Convert(object source) => source is TTarget obj ? obj : throw new NotSupportedException($"No conversion exists from {source?.GetType().FullName} to {typeof(TTarget).FullName}");
         }
 
         #region ToRealmValue Converters
@@ -224,9 +305,9 @@ namespace Realms.Helpers
             {
 #>
 
-        public class <#= ToFriendlyMethodName(type) #>RealmValueConverter : ISpecializedConverter<<#= type #>, RealmValue>
+        private class <#= ToFriendlyMethodName(type) #>RealmValueConverter : SpecializedConverterBase<<#= type #>, RealmValue>
         {
-            public RealmValue Convert(<#= type #> value) => value;
+            public override RealmValue Convert(<#= type #> value) => value;
         }
 <#
             }
@@ -239,9 +320,9 @@ namespace Realms.Helpers
             {
 #>
 
-        public class RealmValue<#= ToFriendlyMethodName(type) #>Converter : ISpecializedConverter<RealmValue, <#= type #>>
+        private class RealmValue<#= ToFriendlyMethodName(type) #>Converter : SpecializedConverterBase<RealmValue, <#= type #>>
         {
-            public <#= type #> Convert(RealmValue value) => (<#= type #>)value;
+            public override <#= type #> Convert(RealmValue value) => (<#= type #>)value;
         }
 <#
             }
@@ -254,9 +335,9 @@ namespace Realms.Helpers
             {
 #>
 
-        public class <#= ToFriendlyMethodName(tuple.Item1) #><#= ToFriendlyMethodName(tuple.Item2) #>Converter : ISpecializedConverter<<#= tuple.Item1 #>, <#= tuple.Item2#>>
+        private class <#= ToFriendlyMethodName(tuple.Item1) #><#= ToFriendlyMethodName(tuple.Item2) #>Converter : SpecializedConverterBase<<#= tuple.Item1 #>, <#= tuple.Item2#>>
         {
-            public <#= tuple.Item2 #> Convert(<#= tuple.Item1 #> value) => <#= tuple.Item3 #>value;
+            public override <#= tuple.Item2 #> Convert(<#= tuple.Item1 #> value) => <#= tuple.Item3 #>value;
         }
 <#
             }
@@ -270,9 +351,9 @@ namespace Realms.Helpers
             {
 #>
 
-        public class <#= ToFriendlyMethodName(tuple.Item1) #><#= ToFriendlyMethodName(tuple.Item2) #>Converter : ISpecializedConverter<<#= tuple.Item1 #>, <#= tuple.Item2#>>
+        private class <#= ToFriendlyMethodName(tuple.Item1) #><#= ToFriendlyMethodName(tuple.Item2) #>Converter : SpecializedConverterBase<<#= tuple.Item1 #>, <#= tuple.Item2#>>
         {
-            public <#= tuple.Item2 #> Convert(<#= tuple.Item1 #> value) => <#= tuple.Item3 #>value;
+            public override <#= tuple.Item2 #> Convert(<#= tuple.Item1 #> value) => <#= tuple.Item3 #>value;
         }
 <#
             }

--- a/Tests/Realm.Tests/Database/RealmResults/ConvertTests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/ConvertTests.cs
@@ -531,6 +531,30 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void Equal_WhenVariableIsEnum()
+        {
+            var enumQuery = _realm.All<AllTypesObject>().Where(o => o.Int32Property == (int)MyEnum.One).ToArray();
+            Assert.That(enumQuery.Length, Is.EqualTo(1));
+            Assert.That(enumQuery[0].Int32Property, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Equal_WhenVariableIsClassWithImplicitOperator_Fails()
+        {
+            var one = new MyOneClass();
+            Assert.Throws<NotSupportedException>(() => _realm.All<AllTypesObject>().Where(o => o.Int32Property == one).ToArray());
+        }
+
+        [Test]
+        public void Equal_WhenVariableIsClassWithImplicitOperator_WhenCastToCorrectType_Succeeds()
+        {
+            int one = new MyOneClass();
+            var classQuery = _realm.All<AllTypesObject>().Where(o => o.Int32Property == one).ToArray();
+            Assert.That(classQuery.Length, Is.EqualTo(1));
+            Assert.That(classQuery[0].Int32Property, Is.EqualTo(1));
+        }
+
+        [Test]
         public void GreaterThan_WhenPropertyIsNullable()
         {
             var intQuery = _realm.All<AllTypesObject>().Where(o => o.NullableInt32Property > 0).ToArray();
@@ -608,6 +632,17 @@ namespace Realms.Tests.Database
             var intQuery = _realm.All<AllTypesObject>().Where(o => o.Int32Property != NullableZero).ToArray();
             Assert.That(intQuery.Length, Is.EqualTo(1));
             Assert.That(intQuery[0].Int32Property, Is.EqualTo(1));
+        }
+
+        private enum MyEnum
+        {
+            Zero,
+            One
+        }
+
+        private class MyOneClass
+        {
+            public static implicit operator int(MyOneClass _) => 1;
         }
     }
 }

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -4,26 +4,6 @@
     <TargetFrameworks>net461;netcoreapp3.1;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
     <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
-    <LocalDev>true</LocalDev>
-    <UnityBuild>false</UnityBuild>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(UnityBuild)' == 'true'">
-    <PackageId>Realm.Tests</PackageId>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(UnityBuild)' != 'true'">
-    <TargetFrameworks>net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(LocalDev)' != 'true'">$(TargetFrameworks);netcoreapp3.1;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' AND '$(LocalDev)' != 'true'">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
-    <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true' AND '$(LocalDev)' != 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
-  
-    <OutputType Condition="$(TargetFramework.StartsWith('net'))">Exe</OutputType>
-  </PropertyGroup>
-  
-  <PropertyGroup>
     <RootNamespace>Realms.Tests</RootNamespace>
     <IsTestProject>true</IsTestProject>
     <LangVersion>8.0</LangVersion>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -4,6 +4,26 @@
     <TargetFrameworks>net461;netcoreapp3.1;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
     <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <LocalDev>true</LocalDev>
+    <UnityBuild>false</UnityBuild>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(UnityBuild)' == 'true'">
+    <PackageId>Realm.Tests</PackageId>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UnityBuild)' != 'true'">
+    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LocalDev)' != 'true'">$(TargetFrameworks);netcoreapp3.1;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' AND '$(LocalDev)' != 'true'">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
+    <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true' AND '$(LocalDev)' != 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
+  
+    <OutputType Condition="$(TargetFramework.StartsWith('net'))">Exe</OutputType>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <RootNamespace>Realms.Tests</RootNamespace>
     <IsTestProject>true</IsTestProject>
     <LangVersion>8.0</LangVersion>


### PR DESCRIPTION
Replaces `Lambda.Compile` in the query visitor with a newly introduced `Operator.Convert<T>(object)` call. While it's not as versatile as `Lambda.Compile`, it's at least supported in IL2CPP.