### PR TITLE
Added test for warning with lambda property for RealmObject

### DIFF
--- a/Tests/Weaver/AssemblyToProcess/FaultyClasses.cs
+++ b/Tests/Weaver/AssemblyToProcess/FaultyClasses.cs
@@ -23,6 +23,15 @@ using Realms;
 
 namespace AssemblyToProcess
 {
+    public class LambdaPropertyObject : RealmObject
+    {
+        public IList<Person> ListProperty { get; }
+
+        public Person FirstPropertyObject => ListProperty.First();
+
+        public int IntProperty => ListProperty.Count();
+    }
+
     public class RealmCollectionsWithCounter : RealmObject
     {
         public int Id { get; set; }

--- a/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
+++ b/Tests/Weaver/Realm.Fody.Tests/WeaverTests.cs
@@ -486,7 +486,10 @@ namespace RealmWeaver
             // All warnings and errors are gathered once, so in order to ensure only the correct ones
             // were produced, we make one assertion on all of them here.
 
-            var expectedWarnings = Array.Empty<string>();
+            var expectedWarnings = new[]
+            {
+                "LambdaPropertyObject.FirstPropertyObject is not an automatic property but its type is a RealmObject/EmbeddedObject which normally indicates a relationship."
+            };
 
             var expectedErrors = new[]
             {


### PR DESCRIPTION
The lambda property described in #1196 is actually not crashing the weaver anymore, so the ticket could just be closed. Given that it produces a warning we may as well test for it. 

Fixes #1196 
