### PR TITLE
Added test for property acess after delete rollback

### DIFF
--- a/Tests/Realm.Tests/Database/ObjectIntegrationTests.cs
+++ b/Tests/Realm.Tests/Database/ObjectIntegrationTests.cs
@@ -44,6 +44,21 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void AccessObjectAfterDeleteRollback()
+        {
+            var person = new Person { FirstName = "Mike" };
+            _realm.Write(() => _realm.Add(person));
+
+            using (var transaction = _realm.BeginWrite())
+            {
+                _realm.Remove(person);
+                transaction.Rollback();
+            }
+
+            Assert.That(person.FirstName, Is.EqualTo("Mike"));
+        }
+
+        [Test]
         public void ReadAndWriteEqualityTest()
         {
             // Arrange


### PR DESCRIPTION
This PR adds a test to be sure we don't introduce any regressions with deletion and rollbacks. 

Fixes #1332

