### PR TITLE
Fix a few GA nits

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -108,7 +108,7 @@ steps:
 #@   propsArg += " -p:" + prop + "=" + properties[prop]
 #@ end
 #@
-#@ runtime = "${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }}"
+#@ runtime = "${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}"
   - name: #@ "Publish " + projectPath
     run: #@ "dotnet publish " + projectPath + " -c " + configuration + " -f " + framework + " -r " + runtime + propsArg
     shell: bash

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -102,8 +102,19 @@ steps:
 #@ end
 #@ end
 
-#@ def dotnetPublishAndRun(projectPath, framework, executeCommand, **properties):
-#@ propsArg = " -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}"
+#@ def dotnetPublishAndRunTests(projectPath, framework, executeCommand, addNet5):
+#@ properties = {
+#@   "AddNet5Framework": addNet5,
+#@   "RestoreConfigFile": "Tests/Test.NuGet.Config",
+#@   "UseRealmNupkgsWithVersion": "${{ needs.build-packages.outputs.package_version }}"
+#@ }
+#@
+#@ return dotnetPublishAndRun(projectPath, framework, executeCommand, properties)
+#@
+#@ end
+
+#@ def dotnetPublishAndRun(projectPath, framework, executeCommand, properties = {}):
+#@ propsArg = ""
 #@ for prop in properties.keys():
 #@   propsArg += " -p:" + prop + "=" + properties[prop]
 #@ end
@@ -303,8 +314,8 @@ jobs:
     steps:
     - #@ checkoutCode()
     - #@ template.replace(fetchPackageArtifacts( [ "Realm", "Realm.Fody" ] ))
-    - #@ template.replace(dotnetPublishAndRun("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.NetCore.xml --labels=After", AddNet5Framework="${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}"))
-    - #@ publishTestsResults("TestResults.NetCore.xml", "${{ matrix.os }} ${{ matrix.targetFramework }} tests results")
+    - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After", "${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}"))
+    - #@ publishTestsResults("TestResults.xml", "${{ matrix.os }} ${{ matrix.targetFramework }} tests results")
   run-tests-xamarin-macos:
     runs-on: macos-latest
     name: Run tests for Xamarin on MacOS

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -74,12 +74,9 @@ steps:
 #@ end
 
 #@ def buildPackages():
-#@ finalList = []
 #@ for pkgName in nugetPackages:
-#@  finalList.append(msbuild("Realm/" + pkgName, target="Pack", PackageOutputPath="${{ github.workspace }}/Realm/packages", VersionSuffix="${{ steps.set-version-suffix.outputs.build_suffix }}"))
+  - #@ msbuild("Realm/" + pkgName, target="Pack", PackageOutputPath="${{ github.workspace }}/Realm/packages", VersionSuffix="${{ steps.set-version-suffix.outputs.build_suffix }}")
 #@ end
-#@
-#@ return finalList
 #@ end
 
 #@ def uploadPackageArtifacts():
@@ -103,6 +100,21 @@ steps:
       name: #@ finalPkgName
       path: ${{ github.workspace }}/Realm/packages/
 #@ end
+#@ end
+
+#@ def dotnetPublishAndRun(projectPath, framework, executeCommand, **properties):
+#@ propsArg = " -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}"
+#@ for prop in properties.keys():
+#@   propsArg += " -p:" + prop + "=" + properties[prop]
+#@ end
+#@
+#@ runtime = "${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }}"
+  - name: #@ "Publish " + projectPath
+    run: #@ "dotnet publish " + projectPath + " -c " + configuration + " -f " + framework + " -r " + runtime + propsArg
+    shell: bash
+  - name: Run the tests
+    run: #@ "./" + projectPath + "/bin/" + configuration + "/" + framework + "/" + runtime + "/" + executeCommand
+    shell: bash
 #@ end
 
 #@ def publishTestsResults(files, test_title):
@@ -139,47 +151,6 @@ shell: bash
 #@
 name: #@ "Build " + projectPath
 run: #@ "msbuild " + projectPath + target + " -p:Configuration=" + configuration + " -restore" + parsedProps
-#@ end
-
-#@ def dotnetPublish(projectPath, **properties):
-#@ parsedProps = ""
-#@ targetFramework = ""
-#@ runtime = ""
-#@ commonProps = " -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}"
-#@ for prop in properties.keys():
-#@  if prop == "TargetFramework":
-#@    targetFramework = " -f " + properties[prop]
-#@  elif prop == "Runtime":
-#@    runtime = " -r " + properties[prop]
-#@  else:
-#@    parsedProps += " -p:" + prop + "=" + properties[prop]
-#@  end
-#@ end
-#@
-name: #@ "Build " + projectPath
-run: #@ "dotnet publish " + projectPath + " -c " + configuration + runtime + targetFramework + commonProps + parsedProps
-shell: bash
-#@ end
-
-#@ def dotnetRun(projectPath, **properties):
-#@ parsedProps = ""
-#@ targetFramework = ""
-#@ resultsPath = ""
-#@ labels = ""
-#@ for prop in properties.keys():
-#@  if prop == "TargetFramework":
-#@    targetFramework = " -f " + properties[prop]
-#@  elif prop == "ResultsFile":
-#@    resultsPath = " --result=" + properties[prop]
-#@  elif prop == "Labels":
-#@    labels = " --labels=" + properties[prop]
-#@  else:
-#@    parsedProps += " -p:" + prop + "=" + properties[prop]
-#@  end
-#@ end
-#@
-name: #@ "Run " + projectPath
-run: #@ "dotnet run -p " + projectPath + " -c " + configuration + targetFramework + resultsPath + labels + parsedProps
 #@ end
 
 ---
@@ -332,17 +303,7 @@ jobs:
     steps:
     - #@ checkoutCode()
     - #@ template.replace(fetchPackageArtifacts( [ "Realm", "Realm.Fody" ] ))
-    - if: ${{ matrix.os == 'macos-latest' }}
-      run: echo "runtime=osx-x64" >> $GITHUB_ENV
-    - if: ${{ matrix.os == 'windows-latest' }}
-      run: echo "runtime=win-x64" >> $GITHUB_ENV
-      shell: bash
-    - if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: echo "runtime=linux-x64" >> $GITHUB_ENV
-    - #@ dotnetPublish("Tests/Realm.Tests", Runtime="${{ env.runtime }}", TargetFramework="${{ matrix.targetFramework }}", AddNet5Framework="${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}")
-    - name: Run the tests
-      run: #@ "./Tests/Realm.Tests/bin/" + configuration + "/${{ matrix.targetFramework }}/${{ env.runtime }}/Realm.Tests --result=TestResults.NetCore.xml --labels=After"
-      shell: bash
+    - #@ template.replace(dotnetPublishAndRun("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.NetCore.xml --labels=After", AddNet5Framework="${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}"))
     - #@ publishTestsResults("TestResults.NetCore.xml", "${{ matrix.os }} ${{ matrix.targetFramework }} tests results")
   run-tests-xamarin-macos:
     runs-on: macos-latest
@@ -360,5 +321,5 @@ jobs:
     name: Run tests for the weaver
     steps:
       - #@ checkoutCode()
-      - #@ dotnetRun("Tests/Weaver/Realm.Fody.Tests", TargetFramework="netcoreapp3.1", ResultsFile="TestResults.Weaver.xml", Labels="After")
+      - #@ template.replace(dotnetPublishAndRun("Tests/Weaver/Realm.Fody.Tests", "netcoreapp3.1", "Realm.Fody.Tests --result=TestResults.Weaver.xml --labels=After"))
       - #@ publishTestsResults("TestResults.Weaver.xml", "Weaver tests results")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,10 +378,10 @@ jobs:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}.nupkg
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:AddNet5Framework=${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}
+      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:AddNet5Framework=${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}
       shell: bash
     - name: Run the tests
-      run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.NetCore.xml --labels=After
+      run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.NetCore.xml --labels=After
       shell: bash
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
@@ -429,10 +429,10 @@ jobs:
       with:
         submodules: recursive
     - name: Publish Tests/Weaver/Realm.Fody.Tests
-      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
       shell: bash
     - name: Run the tests
-      run: ./Tests/Weaver/Realm.Fody.Tests/bin/Release/netcoreapp3.1/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Fody.Tests --result=TestResults.Weaver.xml --labels=After
+      run: ./Tests/Weaver/Realm.Fody.Tests/bin/Release/netcoreapp3.1/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Fody.Tests --result=TestResults.Weaver.xml --labels=After
       shell: bash
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -377,18 +377,11 @@ jobs:
       with:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}.nupkg
         path: ${{ github.workspace }}/Realm/packages/
-    - if: ${{ matrix.os == 'macos-latest' }}
-      run: echo "runtime=osx-x64" >> $GITHUB_ENV
-    - if: ${{ matrix.os == 'windows-latest' }}
-      run: echo "runtime=win-x64" >> $GITHUB_ENV
-      shell: bash
-    - if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: echo "runtime=linux-x64" >> $GITHUB_ENV
-    - name: Build Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -r ${{ env.runtime }} -f ${{ matrix.targetFramework }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:AddNet5Framework=${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}
+    - name: Publish Tests/Realm.Tests
+      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:AddNet5Framework=${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}
       shell: bash
     - name: Run the tests
-      run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ env.runtime }}/Realm.Tests --result=TestResults.NetCore.xml --labels=After
+      run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.NetCore.xml --labels=After
       shell: bash
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
@@ -435,8 +428,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Run Tests/Weaver/Realm.Fody.Tests
-      run: dotnet run -p Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 --result=TestResults.Weaver.xml --labels=After
+    - name: Publish Tests/Weaver/Realm.Fody.Tests
+      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      shell: bash
+    - name: Run the tests
+      run: ./Tests/Weaver/Realm.Fody.Tests/bin/Release/netcoreapp3.1/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runmner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Fody.Tests --result=TestResults.Weaver.xml --labels=After
+      shell: bash
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
       if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,16 +378,16 @@ jobs:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}.nupkg
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:AddNet5Framework=${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}
+      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AddNet5Framework=${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
       shell: bash
     - name: Run the tests
-      run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.NetCore.xml --labels=After
+      run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.xml --labels=After
       shell: bash
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
       if: always()
       with:
-        files: TestResults.NetCore.xml
+        files: TestResults.xml
         comment_mode: update last
         check_name: ${{ matrix.os }} ${{ matrix.targetFramework }} tests results
   run-tests-xamarin-macos:
@@ -429,7 +429,7 @@ jobs:
       with:
         submodules: recursive
     - name: Publish Tests/Weaver/Realm.Fody.Tests
-      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}
       shell: bash
     - name: Run the tests
       run: ./Tests/Weaver/Realm.Fody.Tests/bin/Release/netcoreapp3.1/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Fody.Tests --result=TestResults.Weaver.xml --labels=After

--- a/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
+++ b/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
@@ -5,6 +5,7 @@
     <DisableFody>true</DisableFody>
     <IsTestProject>true</IsTestProject>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Fixes a few nits that I noticed when reviewing https://github.com/realm/realm-dotnet/pull/2354, notably:
- `buildPackages` yield returns array nodes while iterating.
- `dotnetPublish` is replaced with `dotnetPublishAndRun` which publishes an executable then runs it.
- `dotnetPublishAndRunTests` is added as a convenience wrapper around `dotnetPublish` for when we need to setup some of the build properties
- Modified the weaver tests to use `dotnetPublish` - there was no fundamental issue with `dotnetRun` but since it was the only job that used it, figured might as well unify things.
- Modified the weaver test project to output executable