### PR TITLE
Turn off analytics for tests and benchmarks

### DIFF
--- a/Tests/Benchmarks/PerformanceTests/FodyWeavers.xml
+++ b/Tests/Benchmarks/PerformanceTests/FodyWeavers.xml
@@ -1,3 +1,4 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Realm />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Realm DisableAnalytics="true" />
 </Weavers>

--- a/Tests/Realm.Tests/FodyWeavers.xml
+++ b/Tests/Realm.Tests/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Realm />
+  <Realm DisableAnalytics="true"/>
 </Weavers>


### PR DESCRIPTION
## Description
Tests are messing with our analytics hence we need to turn off analytics for tests and benchmarks.
In order to do so the attribute **DisableAnalytics** was added and set to true in **FodyWeavers.xml**-s. Once that's done, `RealmWeaver.Execute` receives `Analytics.Config` with `RunAnalytics` set to false. When the flow arrives to `Analytics.SubmitAnalytics`, such method skips the analytics collection and delivery because `Analytics.Config.RunAnalytics` is set to false.
