### PR TITLE
Handle conversions of enums in queries

### DIFF
--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -472,9 +472,9 @@ namespace Realms.Helpers
                 return ((IGenericConverter<TResult>)converter).Convert(value);
             }
 
-            if (value is TResult res)
+            if (value is IConvertible)
             {
-                return res;
+                return (TResult)System.Convert.ChangeType(value, targetType);
             }
 
             throw new InvalidCastException($"No conversion exists from {sourceType.FullName} to {targetType.FullName}");
@@ -510,6 +510,10 @@ namespace Realms.Helpers
                 else if (targetType.IsAssignableFrom(sourceType) || sourceType == typeof(object))
                 {
                     _converter = new InheritanceConverter<TSource, TTarget>();
+                }
+                else if (typeof(IConvertible).IsAssignableFrom(sourceType))
+                {
+                    _converter = new ConvertChangeTypeConverter<TSource, TTarget>();
                 }
                 else
                 {
@@ -594,6 +598,11 @@ namespace Realms.Helpers
             public override TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
 
             public override TTarget Convert(object source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {source?.GetType().FullName} to {typeof(TTarget).FullName}");
+        }
+
+        private class ConvertChangeTypeConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
+        {
+            public override TTarget Convert(TSource source) => (TTarget)System.Convert.ChangeType(source, typeof(TTarget));
         }
 
         #region ToRealmValue Converters

--- a/Realm/Realm/Helpers/Operator.cs
+++ b/Realm/Realm/Helpers/Operator.cs
@@ -511,10 +511,6 @@ namespace Realms.Helpers
                 {
                     _converter = new InheritanceConverter<TSource, TTarget>();
                 }
-                else if (typeof(IConvertible).IsAssignableFrom(sourceType))
-                {
-                    _converter = new ConvertChangeTypeConverter<TSource, TTarget>();
-                }
                 else
                 {
                     _converter = new ThrowingConverter<TSource, TTarget>();
@@ -598,11 +594,6 @@ namespace Realms.Helpers
             public override TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
 
             public override TTarget Convert(object source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {source?.GetType().FullName} to {typeof(TTarget).FullName}");
-        }
-
-        private class ConvertChangeTypeConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
-        {
-            public override TTarget Convert(TSource source) => (TTarget)System.Convert.ChangeType(source, typeof(TTarget));
         }
 
         #region ToRealmValue Converters

--- a/Realm/Realm/Helpers/Operator.tt
+++ b/Realm/Realm/Helpers/Operator.tt
@@ -185,9 +185,9 @@ namespace Realms.Helpers
                 return ((IGenericConverter<TResult>)converter).Convert(value);
             }
 
-            if (value is TResult res)
+            if (value is IConvertible)
             {
-                return res;
+                return (TResult)System.Convert.ChangeType(value, targetType);
             }
 
             throw new InvalidCastException($"No conversion exists from {sourceType.FullName} to {targetType.FullName}");
@@ -223,6 +223,10 @@ namespace Realms.Helpers
                 else if (targetType.IsAssignableFrom(sourceType) || sourceType == typeof(object))
                 {
                     _converter = new InheritanceConverter<TSource, TTarget>();
+                }
+                else if (typeof(IConvertible).IsAssignableFrom(sourceType))
+                {
+                    _converter = new ConvertChangeTypeConverter<TSource, TTarget>();
                 }
                 else
                 {
@@ -307,6 +311,11 @@ namespace Realms.Helpers
             public override TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
 
             public override TTarget Convert(object source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {source?.GetType().FullName} to {typeof(TTarget).FullName}");
+        }
+
+        private class ConvertChangeTypeConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
+        {
+            public override TTarget Convert(TSource source) => (TTarget)System.Convert.ChangeType(source, typeof(TTarget));
         }
 
         #region ToRealmValue Converters

--- a/Realm/Realm/Helpers/Operator.tt
+++ b/Realm/Realm/Helpers/Operator.tt
@@ -224,10 +224,6 @@ namespace Realms.Helpers
                 {
                     _converter = new InheritanceConverter<TSource, TTarget>();
                 }
-                else if (typeof(IConvertible).IsAssignableFrom(sourceType))
-                {
-                    _converter = new ConvertChangeTypeConverter<TSource, TTarget>();
-                }
                 else
                 {
                     _converter = new ThrowingConverter<TSource, TTarget>();
@@ -311,11 +307,6 @@ namespace Realms.Helpers
             public override TTarget Convert(TSource source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {typeof(TSource).FullName} to {typeof(TTarget).FullName}");
 
             public override TTarget Convert(object source) => source is TTarget obj ? obj : throw new InvalidCastException($"No conversion exists from {source?.GetType().FullName} to {typeof(TTarget).FullName}");
-        }
-
-        private class ConvertChangeTypeConverter<TSource, TTarget> : SpecializedConverterBase<TSource, TTarget>
-        {
-            public override TTarget Convert(TSource source) => (TTarget)System.Convert.ChangeType(source, typeof(TTarget));
         }
 
         #region ToRealmValue Converters

--- a/Tests/Realm.Tests/Database/RealmResults/ConvertTests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/ConvertTests.cs
@@ -533,9 +533,26 @@ namespace Realms.Tests.Database
         [Test]
         public void Equal_WhenVariableIsEnum()
         {
+            var one = MyEnum.One;
+            var enumQuery = _realm.All<AllTypesObject>().Where(o => o.Int32Property == (int)one).ToArray();
+            Assert.That(enumQuery.Length, Is.EqualTo(1));
+            Assert.That(enumQuery[0].Int32Property, Is.EqualTo(1));
+
+            var reverseCastEnumQuery = _realm.All<AllTypesObject>().Where(o => (MyEnum)o.Int32Property == one).ToArray();
+            Assert.That(reverseCastEnumQuery.Length, Is.EqualTo(1));
+            Assert.That(reverseCastEnumQuery[0].Int32Property, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Equal_WhenVariableIsInlineEnum()
+        {
             var enumQuery = _realm.All<AllTypesObject>().Where(o => o.Int32Property == (int)MyEnum.One).ToArray();
             Assert.That(enumQuery.Length, Is.EqualTo(1));
             Assert.That(enumQuery[0].Int32Property, Is.EqualTo(1));
+
+            var reverseCastEnumQuery = _realm.All<AllTypesObject>().Where(o => (MyEnum)o.Int32Property == MyEnum.One).ToArray();
+            Assert.That(reverseCastEnumQuery.Length, Is.EqualTo(1));
+            Assert.That(reverseCastEnumQuery[0].Int32Property, Is.EqualTo(1));
         }
 
         [Test]


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This adds a fallback when converting `IConvertible` types to go ahead and try to use `Convert.ChangeType` - while it's slower than our built-in convertors, it's still better than throwing. The most common case this will handle is using enums in queries.

Fixes https://github.com/realm/realm-dotnet/issues/2392

##  TODO

* [ ] Changelog entry
* [x] Tests (if applicable)
