### PR TITLE
Make sure we don't accumulate test resources endlessly

### DIFF
--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -29,7 +29,7 @@ namespace Realms.Tests
     [Preserve(AllMembers = true)]
     public abstract class RealmTest
     {
-        private readonly List<Realm> _realms = new List<Realm>();
+        private readonly Queue<Realm> _realms = new Queue<Realm>();
         private Logger _originalLogger;
         private LogLevel _originalLogLevel;
 
@@ -67,7 +67,7 @@ namespace Realms.Tests
 
         protected void CleanupOnTearDown(Realm realm)
         {
-            _realms.Add(realm);
+            _realms.Enqueue(realm);
         }
 
         [TearDown]
@@ -98,12 +98,12 @@ namespace Realms.Tests
                 realm.Dispose();
             }
 
-            foreach (var realm in _realms)
+            _realms.DrainQueue(realm =>
             {
                 // TODO: this should be an assertion but fails on our migration tests due to https://github.com/realm/realm-core/issues/4605.
                 // Assert.That(DeleteRealmWithRetries(realm), Is.True, "Couldn't delete a Realm on teardown.");
                 DeleteRealmWithRetries(realm);
-            }
+            });
         }
 
         private static bool DeleteRealmWithRetries(Realm realm)

--- a/Tests/Realm.Tests/Sync/DataTypeTests.cs
+++ b/Tests/Realm.Tests/Sync/DataTypeTests.cs
@@ -552,7 +552,6 @@ namespace Realms.Tests.Sync
 
                 Assert.That(prop1, Is.EqualTo(prop2).Using<T, T>(equalsOverride));
                 Assert.That(prop2, Is.EqualTo(item2).Using<T, T>(equalsOverride));
-
             }, ensureNoSessionErrors: true);
         }
 

--- a/Tests/Realm.Tests/Sync/FunctionsTests.cs
+++ b/Tests/Realm.Tests/Sync/FunctionsTests.cs
@@ -28,7 +28,7 @@ namespace Realms.Tests.Sync
     [TestFixture, Preserve(AllMembers = true)]
     public class FunctionsTests : SyncTestBase
     {
-        private readonly List<string> _conventionsToRemove = new List<string>();
+        private readonly Queue<string> _conventionsToRemove = new Queue<string>();
 
         [Test]
         public void CallFunction_ReturnsResult()
@@ -275,12 +275,7 @@ namespace Realms.Tests.Sync
         {
             base.CustomTearDown();
 
-            foreach (var convention in _conventionsToRemove)
-            {
-                ConventionRegistry.Remove(convention);
-            }
-
-            _conventionsToRemove.Clear();
+            _conventionsToRemove.DrainQueue(ConventionRegistry.Remove);
         }
 
         private static void AssertDateTimeEquals(DateTime first, DateTime second)
@@ -296,7 +291,7 @@ namespace Realms.Tests.Sync
             pack.Add(new CamelCaseElementNameConvention());
             ConventionRegistry.Register(name, pack, _ => true);
 
-            _conventionsToRemove.Add(name);
+            _conventionsToRemove.Enqueue(name);
         }
 
         private class FunctionArgument

--- a/Tests/Realm.Tests/TestHelpers.cs
+++ b/Tests/Realm.Tests/TestHelpers.cs
@@ -27,6 +27,7 @@ using MongoDB.Bson;
 using Nito.AsyncEx;
 using NUnit.Framework;
 using Realms.Helpers;
+using System.Collections.Generic;
 #if __ANDROID__
 using Application = Android.App.Application;
 #endif
@@ -372,6 +373,14 @@ namespace Realms.Tests
             }
 
             return $"<{byteArr[0]}>";
+        }
+
+        public static void DrainQueue<T>(this Queue<T> queue, Action<T> action)
+        {
+            while (queue.Count > 0)
+            {
+                action(queue.Dequeue());
+            }
         }
 
         public static IDisposable Subscribe<T>(this IObservable<T> observable, Action<T> onNext)

--- a/Tests/Realm.Tests/TestHelpers.cs
+++ b/Tests/Realm.Tests/TestHelpers.cs
@@ -22,12 +22,12 @@ using System.Threading;
 #if NETCOREAPP || NETFRAMEWORK
 using System.Runtime.InteropServices;
 #endif
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using Nito.AsyncEx;
 using NUnit.Framework;
 using Realms.Helpers;
-using System.Collections.Generic;
 #if __ANDROID__
 using Application = Android.App.Application;
 #endif


### PR DESCRIPTION
This converts all cleanup lists in tests into queues and we make sure to drain the queues - previously we'd just push stuff to the lists and never empty them.

It resolves the slowing down of test runs with the new delete functionality.