### PR TITLE
Handle weaver errors in Unity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## vNext (TBD)
+
+### Fixed
+* \[Unity] Fixed an issue where failing to weave an assembly due to modeling errors, would only show an error in the logs once and then fail opening a Realm with `No RealmObjects. Has linker stripped them?`. Now, the weaving errors will show up on every code change/weave attempt and the runtime error will explicitly suggest manually re-running the weaver. (Issue [#2310](https://github.com/realm/realm-dotnet/issues/2310))
+
+### Enhancements
+* None
+
+### Compatibility
+* Realm Studio: 11.0.0-alpha.0 or later.
+
+### Internal
+* Using Core 11.0.3.
+
 ## 10.2.0 (2021-06-15)
 
 ### Fixed

--- a/Realm/AssemblyInfo.props
+++ b/Realm/AssemblyInfo.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Realm .NET</Product>
-    <VersionPrefix>10.2.0</VersionPrefix>
+    <VersionPrefix>10.2.1</VersionPrefix>
     <Description Condition="'$(Description)' == ''">Realm is a mobile database: a replacement for SQLite</Description>
     <Company>Realm Inc.</Company>
     <Copyright>Copyright © $([System.DateTime]::Now.ToString(yyyy)) Realm Inc.</Copyright>

--- a/Realm/Realm.UnityWeaver/UnityWeaver.cs
+++ b/Realm/Realm.UnityWeaver/UnityWeaver.cs
@@ -216,6 +216,12 @@ namespace RealmWeaver
 
                     var results = weaver.Execute(analyticsConfig);
 
+                    if (results.ErrorMessage != null)
+                    {
+                        UnityLogger.Instance.Error($"[{name}] Weaving failed: {results}");
+                        return false;
+                    }
+
                     // Unity creates an entry in the build console for each item, so let's not pollute it.
                     if (results.SkipReason == null)
                     {
@@ -227,7 +233,7 @@ namespace RealmWeaver
             }
             catch (Exception ex)
             {
-                UnityLogger.Instance.Warning($"[{name}] Weaving failed: {ex}");
+                UnityLogger.Instance.Error($"[{name}] Weaving failed: {ex}");
             }
 
             return false;

--- a/Realm/Realm.UnityWeaver/UnityWeaver.cs
+++ b/Realm/Realm.UnityWeaver/UnityWeaver.cs
@@ -171,7 +171,7 @@ namespace RealmWeaver
             }
             catch (Exception ex)
             {
-                UnityLogger.Instance.Error($"Failed to weave assemblies: {ex}");
+                UnityLogger.Instance.Error($"[Realm] Failed to weave assemblies. If the error persists, please report it to https://github.com/realm/realm-dotnet/issues: {ex}");
             }
             finally
             {
@@ -233,7 +233,7 @@ namespace RealmWeaver
             }
             catch (Exception ex)
             {
-                UnityLogger.Instance.Error($"[{name}] Weaving failed: {ex}");
+                UnityLogger.Instance.Error($"[{name}] Failed to weave assembly. If the error persists, please report it to https://github.com/realm/realm-dotnet/issues: {ex}");
             }
 
             return false;

--- a/Realm/Realm.Weaver/Extensions/TypeReferenceExtensions.cs
+++ b/Realm/Realm.Weaver/Extensions/TypeReferenceExtensions.cs
@@ -34,8 +34,8 @@ internal static class TypeReferenceExtensions
         {
             return @this.GetConstructors()
                 .OrderBy(c => c.Parameters.Count)
-                .Select(c => c.DebugInformation.SequencePoints.FirstOrDefault())
-                .FirstOrDefault(sp => sp != null);
+                .SelectMany(c => c.DebugInformation.SequencePoints)
+                .FirstOrDefault();
         }
 
         SequencePoint GetPropSequencePoint()

--- a/Realm/Realm.Weaver/Extensions/TypeReferenceExtensions.cs
+++ b/Realm/Realm.Weaver/Extensions/TypeReferenceExtensions.cs
@@ -17,12 +17,35 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System.ComponentModel;
+using System.Linq;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 using RealmWeaver;
 
 [EditorBrowsable(EditorBrowsableState.Never)]
 internal static class TypeReferenceExtensions
 {
+    public static SequencePoint GetSequencePoint(this TypeDefinition @this)
+    {
+        return GetCtorSequencePoint() ?? GetPropSequencePoint();
+
+        SequencePoint GetCtorSequencePoint()
+        {
+            return @this.GetConstructors()
+                .OrderBy(c => c.Parameters.Count)
+                .Select(c => c.DebugInformation.SequencePoints.FirstOrDefault())
+                .FirstOrDefault(sp => sp != null);
+        }
+
+        SequencePoint GetPropSequencePoint()
+        {
+            return @this.Properties
+                .Select(p => p.GetMethod?.DebugInformation.SequencePoints.FirstOrDefault() ?? p.SetMethod?.DebugInformation.SequencePoints.FirstOrDefault())
+                .FirstOrDefault(sp => sp != null);
+        }
+    }
+
     public static bool IsRealmObjectDescendant(this TypeReference @this, ImportedReferences references)
     {
         try

--- a/Realm/Realm.Weaver/RealmWeaver.cs
+++ b/Realm/Realm.Weaver/RealmWeaver.cs
@@ -265,10 +265,10 @@ Analytics payload
                             }
 
                             var realmAttributeNames = prop.CustomAttributes
-                                                            .Select(a => a.AttributeType.Name)
-                                                            .Intersect(RealmPropertyAttributes)
-                                                            .OrderBy(a => a)
-                                                            .Select(a => $"[{a.Replace("Attribute", string.Empty)}]");
+                                                          .Select(a => a.AttributeType.Name)
+                                                          .Intersect(RealmPropertyAttributes)
+                                                          .OrderBy(a => a)
+                                                          .Select(a => $"[{a.Replace("Attribute", string.Empty)}]");
 
                             if (realmAttributeNames.Any())
                             {

--- a/Realm/Realm.Weaver/RealmWeaver.cs
+++ b/Realm/Realm.Weaver/RealmWeaver.cs
@@ -215,18 +215,18 @@ Analytics payload
                 }
             }).ToArray();
 
-            var failedResults = weaveResults.Where(r => !r.IsSuccessful);
-            if (failedResults.Any())
-            {
-                return WeaveModuleResult.Error($"The following types had errors when woven: {string.Join(", ", failedResults.Select(f => f.Type))}");
-            }
-
             WeaveSchema(matchingTypes);
 
             var wovenAssemblyAttribute = new CustomAttribute(_references.WovenAssemblyAttribute_Constructor);
             _moduleDefinition.Assembly.CustomAttributes.Add(wovenAssemblyAttribute);
 
             submitAnalytics.Wait();
+
+            var failedResults = weaveResults.Where(r => !r.IsSuccessful);
+            if (failedResults.Any())
+            {
+                return WeaveModuleResult.Error($"The following types had errors when woven: {string.Join(", ", failedResults.Select(f => f.Type))}");
+            }
 
             return WeaveModuleResult.Success(weaveResults);
         }

--- a/Realm/Realm.Weaver/WeaveResults.cs
+++ b/Realm/Realm.Weaver/WeaveResults.cs
@@ -27,26 +27,39 @@ namespace RealmWeaver
     {
         public static WeaveModuleResult Success(IEnumerable<WeaveTypeResult> types)
         {
-            return new WeaveModuleResult(types.ToArray(), skipReason: null);
+            return new WeaveModuleResult(types.ToArray());
+        }
+
+        public static WeaveModuleResult Error(string message)
+        {
+            return new WeaveModuleResult(errorMessage: message);
         }
 
         public static WeaveModuleResult Skipped(string reason)
         {
-            return new WeaveModuleResult(types: null, skipReason: reason);
+            return new WeaveModuleResult(skipReason: reason);
         }
 
         public WeaveTypeResult[] Types { get; }
 
         public string SkipReason { get; }
 
-        private WeaveModuleResult(WeaveTypeResult[] types, string skipReason)
+        public string ErrorMessage { get; }
+
+        private WeaveModuleResult(WeaveTypeResult[] types = null, string skipReason = null, string errorMessage = null)
         {
             Types = types;
             SkipReason = skipReason;
+            ErrorMessage = errorMessage;
         }
 
         public override string ToString()
         {
+            if (ErrorMessage != null)
+            {
+                return ErrorMessage;
+            }
+
             if (SkipReason != null)
             {
                 return SkipReason;
@@ -71,18 +84,31 @@ namespace RealmWeaver
             return new WeaveTypeResult(type, properties.ToArray());
         }
 
+        public static WeaveTypeResult Error(string type)
+        {
+            return new WeaveTypeResult(type, success: false);
+        }
+
         public string Type { get; }
+
+        public bool IsSuccessful { get; }
 
         public WeavePropertyResult[] Properties { get; }
 
-        private WeaveTypeResult(string type, WeavePropertyResult[] properties)
+        private WeaveTypeResult(string type, WeavePropertyResult[] properties = null, bool success = true)
         {
             Properties = properties;
             Type = type;
+            IsSuccessful = success;
         }
 
         public override string ToString()
         {
+            if (!IsSuccessful)
+            {
+                return $"An error occurred while weaving '{Type}'. Check the logs for more information.";
+            }
+
             var sb = new StringBuilder();
             sb.AppendLine($"<b>{Type}</b>");
             foreach (var prop in Properties)

--- a/Realm/Realm/InteropConfig.cs
+++ b/Realm/Realm/InteropConfig.cs
@@ -32,6 +32,10 @@ namespace Realms
         /// </summary>
         public const string DLL_NAME = "realm-wrappers";
 
+        public const string UnityPlatform = "Realm Unity";
+
+        public const string DotNetPlatform = "Realm .NET";
+
         public static readonly string Platform;
 
         public static readonly Version SDKVersion = typeof(InteropConfig).Assembly.GetName().Version;

--- a/Realm/Realm/Schema/RealmSchema.cs
+++ b/Realm/Realm/Schema/RealmSchema.cs
@@ -20,11 +20,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 using Realms.Helpers;
 
 namespace Realms.Schema
@@ -212,8 +210,14 @@ namespace Realms.Schema
             {
                 if (Count == 0)
                 {
-                    throw new InvalidOperationException(
-                        "No RealmObjects. Has linker stripped them? See https://docs.mongodb.com/realm-legacy/docs/dotnet/latest/#linker-stripped-schema");
+                    var message = InteropConfig.Platform switch
+                    {
+                        InteropConfig.UnityPlatform => "Try weaving assemblies again ('Realm' -> 'Weave Assemblies' from the editor or simply make a code change) and make sure you don't have any Realm-related errors in the logs.",
+                        InteropConfig.DotNetPlatform => "Has linker stripped them? See https://docs.mongodb.com/realm-legacy/docs/dotnet/latest/#linker-stripped-schema",
+                        _ => string.Empty
+                    };
+
+                    throw new InvalidOperationException($"No RealmObjects. {message}");
                 }
 
                 return new RealmSchema(this);

--- a/Realm/Realm/Schema/RealmSchema.cs
+++ b/Realm/Realm/Schema/RealmSchema.cs
@@ -213,7 +213,7 @@ namespace Realms.Schema
                     var message = InteropConfig.Platform switch
                     {
                         InteropConfig.UnityPlatform => "Try weaving assemblies again ('Realm' -> 'Weave Assemblies' from the editor or simply make a code change) and make sure you don't have any Realm-related errors in the logs.",
-                        InteropConfig.DotNetPlatform => "Has linker stripped them? See https://docs.mongodb.com/realm-legacy/docs/dotnet/latest/#linker-stripped-schema",
+                        InteropConfig.DotNetPlatform => "Has linker stripped them? See https://docs.mongodb.com/realm/sdk/dotnet/troubleshooting/",
                         _ => string.Empty
                     };
 


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This PR contains two main changes:
* Stops the weaving process on error. This is necessary because Unity will not treat extension-generated error logs as build failures and will happily run the built assembly. This means that we may end up in a situation where classes are partially woven and things fail silently in runtime.
* Modifies the error message for Unity when a RealmConfiguration is created without schema. This is likely due to a build error and we advise users to re-run the weaver and look for error messages in the logs.

Fixes https://github.com/realm/realm-dotnet/issues/2310

##  TODO

* [x] Changelog entry
