### PR TITLE
Delete some artifacts from the workflow after it runs

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -6,7 +6,7 @@
 #@ windowsArchs = [ 'Win32', 'x64' ]
 #@ windowsUWPArchs = [ 'Win32', 'x64', 'ARM' ]
 #@ wrappersCacheCondition = "steps.check-cache.outputs.cache-hit != 'true'"
-#@ nugetPackages = [ 'Realm.Fody', 'Realm', 'Realm.UnityUtils', 'Realm.UnityWeaver']
+#@ nugetPackages = [ 'Realm.Fody', 'Realm', 'Realm.UnityUtils', 'Realm.UnityWeaver' ]
 
 #@ def checkCache(key):
 name: Check cache
@@ -115,34 +115,56 @@ steps:
 #@ end
 #@ end
 
-#@ def fetchPackageArtifacts(pkgs):
-#@ for pkg in pkgs:
-#@ finalPkgName = pkg + ".${{ needs.build-packages.outputs.package_version }}.nupkg"
+#@ def fetchPackageArtifacts():
+#@ for pkg in [ "Realm", "Realm.Fody" ]:
   - name: #@ "Fetch " + pkg
     uses: actions/download-artifact@v2
     with:
-      name: #@ finalPkgName
+      name: #@ pkg + ".${{ needs.build-packages.outputs.package_version }}.nupkg"
       path: ${{ github.workspace }}/Realm/packages/
 #@ end
 #@ end
 
-#@ def fetchWrapperBinaries():
+#@ def deleteTempPackageArtifacts():
+#@ for pkg in [ 'Realm.UnityUtils', 'Realm.UnityWeaver' ]:
+  - name: #@ "Delete " + pkg
+    uses: geekyeggo/delete-artifact@v1
+    with:
+      name: #@ pkg + ".${{ needs.build-packages.outputs.package_version }}.nupkg"
+#@ end
+#@ end
+
+#@ def getWrapperBinaryNames():
 #@ wrapperPlatforms = [ 'macos', 'ios', 'linux' ]
 #@ for androidABI in androidABIs:
-#@ wrapperPlatforms.append("android-" + androidABI)
+#@   wrapperPlatforms.append("android-" + androidABI)
 #@ end
 #@ for windowsArch in windowsArchs:
-#@ wrapperPlatforms.append("windows-" + windowsArch)
+#@   wrapperPlatforms.append("windows-" + windowsArch)
 #@ end
 #@ for uwpArch in windowsUWPArchs:
-#@ wrapperPlatforms.append("windows-uwp-" + uwpArch)
+#@   wrapperPlatforms.append("windows-uwp-" + uwpArch)
 #@ end
-#@ for platform in wrapperPlatforms:
+#@
+#@ return wrapperPlatforms
+#@ end
+
+#@ def fetchWrapperBinaries():
+#@ for platform in getWrapperBinaryNames():
   - name: #@ "Fetch artifacts for " + platform
     uses: actions/download-artifact@v2
     with:
       name: #@ "wrappers-" + platform
       path: wrappers/build
+#@ end
+#@ end
+
+#@ def deleteWrapperBinaries():
+#@ for platform in getWrapperBinaryNames():
+  - name: #@ "Delete artifacts for " + platform
+    uses: geekyeggo/delete-artifact@v1
+    with:
+      name: #@ "wrappers-" + platform
 #@ end
 #@ end
 
@@ -281,7 +303,7 @@ jobs:
     needs: build-packages
     steps:
       - #@ template.replace(checkoutCode())
-      - #@ template.replace(fetchPackageArtifacts( [ "Realm", "Realm.Fody" ] ))
+      - #@ template.replace(fetchPackageArtifacts())
       - #@ template.replace(msbuildOnWin("Tests/Realm.Tests", TargetFramework="net461"))
       - name: Run the tests
         run: #@ "./Tests/Realm.Tests/bin/" + configuration + "/net461/Realm.Tests.exe --result=TestResults.Windows.xml --labels=After"
@@ -292,7 +314,7 @@ jobs:
     needs: build-packages
     steps:
       - #@ template.replace(checkoutCode())
-      - #@ template.replace(fetchPackageArtifacts( [ "Realm", "Realm.Fody" ] ))
+      - #@ template.replace(fetchPackageArtifacts())
       - name: Import test certificate
         run: |
           $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
@@ -337,21 +359,21 @@ jobs:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
         targetFramework: [ netcoreapp3.1, net5.0 ]
     steps:
-    - #@ template.replace(checkoutCode())
-    - #@ template.replace(fetchPackageArtifacts( [ "Realm", "Realm.Fody" ] ))
-    - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After", "${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}"))
-    - #@ publishTestsResults("TestResults.xml", "${{ matrix.os }} ${{ matrix.targetFramework }} tests results")
+      - #@ template.replace(checkoutCode())
+      - #@ template.replace(fetchPackageArtifacts())
+      - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After", "${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}"))
+      - #@ publishTestsResults("TestResults.xml", "${{ matrix.os }} ${{ matrix.targetFramework }} tests results")
   run-tests-xamarin-macos:
     runs-on: macos-latest
     name: Test Xamarin.macOS
     needs: build-packages
     steps:
       - #@ template.replace(checkoutCode())
-      - #@ template.replace(fetchPackageArtifacts( [ "Realm", "Realm.Fody" ] ))
+      - #@ template.replace(fetchPackageArtifacts())
       - #@ msbuild("Tests/Tests.XamarinMac", TargetFrameworkVersion="v2.0", RestoreConfigFile="Tests/Test.NuGet.Config", UseRealmNupkgsWithVersion="${{ needs.build-packages.outputs.package_version }}")
       - name: Run the tests
         run: #@ "Tests/Tests.XamarinMac/bin/" + configuration + "/Tests.XamarinMac.app/Contents/MacOS/Tests.XamarinMac --headless --labels=All --result=${{ github.workspace }}/TestResults.macOS.xml"
-      - #@ publishTestsResults("TestResults.macOS.xml", "Xamarin MacOs tests results")
+      - #@ publishTestsResults("TestResults.macOS.xml", "Xamarin macOS tests results")
   run-tests-weaver:
     runs-on: windows-latest
     name: Test weaver
@@ -359,3 +381,11 @@ jobs:
       - #@ template.replace(checkoutCode())
       - #@ template.replace(dotnetPublishAndRun("Tests/Weaver/Realm.Fody.Tests", "netcoreapp3.1", "Realm.Fody.Tests --result=TestResults.Weaver.xml --labels=After"))
       - #@ publishTestsResults("TestResults.Weaver.xml", "Weaver tests results")
+  run-cleanup:
+    runs-on: ubuntu-latest
+    name: Workflow cleanup
+    needs: [ run-tests-net-framework, run-tests-uwp, run-tests-netcore-net5, run-tests-xamarin-macos, run-tests-weaver ]
+    if: always()
+    steps:
+      - #@ template.replace(deleteWrapperBinaries())
+      - #@ template.replace(deleteTempPackageArtifacts())

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -384,7 +384,7 @@ jobs:
   run-cleanup:
     runs-on: ubuntu-latest
     name: Workflow cleanup
-    needs: [ run-tests-net-framework, run-tests-uwp, run-tests-netcore-net5, run-tests-xamarin-macos, run-tests-weaver ]
+    needs: [ run-tests-net-framework, run-tests-uwp, run-tests-netcore-net5, run-tests-xamarin-macos, run-tests-weaver, build-packages ]
     if: always()
     steps:
       - #@ template.replace(deleteWrapperBinaries())

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -580,6 +580,7 @@ jobs:
     - run-tests-netcore-net5
     - run-tests-xamarin-macos
     - run-tests-weaver
+    - build-packages
     if: always()
     steps:
     - name: Delete artifacts for macos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -545,7 +545,7 @@ jobs:
       with:
         files: TestResults.macOS.xml
         comment_mode: "off"
-        check_name: Xamarin MacOs tests results
+        check_name: Xamarin macOS tests results
   run-tests-weaver:
     runs-on: windows-latest
     name: Test weaver
@@ -571,3 +571,70 @@ jobs:
         files: TestResults.Weaver.xml
         comment_mode: "off"
         check_name: Weaver tests results
+  run-cleanup:
+    runs-on: ubuntu-latest
+    name: Workflow cleanup
+    needs:
+    - run-tests-net-framework
+    - run-tests-uwp
+    - run-tests-netcore-net5
+    - run-tests-xamarin-macos
+    - run-tests-weaver
+    if: always()
+    steps:
+    - name: Delete artifacts for macos
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-macos
+    - name: Delete artifacts for ios
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-ios
+    - name: Delete artifacts for linux
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-linux
+    - name: Delete artifacts for android-armeabi-v7a
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-android-armeabi-v7a
+    - name: Delete artifacts for android-arm64-v8a
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-android-arm64-v8a
+    - name: Delete artifacts for android-x86
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-android-x86
+    - name: Delete artifacts for android-x86_64
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-android-x86_64
+    - name: Delete artifacts for windows-Win32
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-windows-Win32
+    - name: Delete artifacts for windows-x64
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-windows-x64
+    - name: Delete artifacts for windows-uwp-Win32
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-windows-uwp-Win32
+    - name: Delete artifacts for windows-uwp-x64
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-windows-uwp-x64
+    - name: Delete artifacts for windows-uwp-ARM
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: wrappers-windows-uwp-ARM
+    - name: Delete Realm.UnityUtils
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: Realm.UnityUtils.${{ needs.build-packages.outputs.package_version }}.nupkg
+    - name: Delete Realm.UnityWeaver
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: Realm.UnityWeaver.${{ needs.build-packages.outputs.package_version }}.nupkg


### PR DESCRIPTION
This deletes the wrappers and the extra packages that only the Unity build uses. Apart from saving space, I'm just annoyed when I have to scroll through a bunch of artifacts to find what I'm looking for 😄

I decided to put it in a separate step even though it can technically be done after packaging because I was thinking we may eventually want to do other things with the artifacts - for example get all the debug symbols and zip them together in a debug package or something similar.