### PR TITLE
Fixes for the sync datatype tests

### DIFF
--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -1810,7 +1810,7 @@ namespace Realms
             public dynamic Find(string className, Guid? primaryKey) => FindCore(className, primaryKey);
 
             [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The RealmObjectBase instance will own its handle.")]
-            private RealmObject FindCore(string className, RealmValue primaryKey)
+            internal RealmObject FindCore(string className, RealmValue primaryKey)
             {
                 _realm.ThrowIfDisposed();
 

--- a/Tests/Realm.Tests/Sync/DataTypeSynchronizationTests.cs
+++ b/Tests/Realm.Tests/Sync/DataTypeSynchronizationTests.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using NUnit.Framework;
 using Realms.Helpers;
-using Realms.Logging;
 
 namespace Realms.Tests.Sync
 {
@@ -351,7 +350,7 @@ namespace Realms.Tests.Sync
                     list1.Clear();
                 });
 
-                await WaitForCollectionChangeAsync(list2.AsRealmCollection());
+                await TestHelpers.WaitForConditionAsync(() => !list2.Any());
 
                 Assert.That(list1, Is.Empty);
                 Assert.That(list2, Is.Empty);
@@ -416,7 +415,7 @@ namespace Realms.Tests.Sync
                     set1.Clear();
                 });
 
-                await WaitForCollectionChangeAsync(set2.AsRealmCollection());
+                await TestHelpers.WaitForConditionAsync(() => !set2.Any());
 
                 Assert.That(set1, Is.Empty);
                 Assert.That(set2, Is.Empty);


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Fixes a few issues that I came across when running the datatype tests on macOS - most notably, we were trying to add an object belonging to a different Realm to a dictionary which was failing in all sorts of weird ways. Additionally, it adds adds equals overrides for the RealmValue tests as `RealmValue.Equals` will return `false` for `RealmObject` instances belonging to different Realms. 