### PR TITLE
Verify that objects do not belong to different realm when added to collection

### DIFF
--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -196,6 +196,12 @@ namespace Realms
             }
 
             var robj = value.AsRealmObject<RealmObject>();
+
+            if (robj.IsManaged && robj.Realm != Realm)
+            {
+                throw new RealmException("Can't add to the collection an object that is already in another realm.");
+            }
+
             if (!robj.IsManaged)
             {
                 Realm.Add(robj);

--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -197,7 +197,7 @@ namespace Realms
 
             var robj = value.AsRealmObject<RealmObject>();
 
-            if (robj.IsManaged && robj.Realm != Realm)
+            if (robj.IsManaged && !robj.Realm.IsSameInstance(Realm))
             {
                 throw new RealmException("Can't add to the collection an object that is already in another realm.");
             }

--- a/Realm/Realm/DatabaseTypes/RealmSet.cs
+++ b/Realm/Realm/DatabaseTypes/RealmSet.cs
@@ -67,15 +67,7 @@ namespace Realms
         {
             var realmValue = Operator.Convert<T, RealmValue>(value);
 
-            if (realmValue.Type == RealmValueType.Object)
-            {
-                var robj = realmValue.AsRealmObject<RealmObject>();
-                if (!robj.IsManaged)
-                {
-                    Realm.Add(robj);
-                }
-            }
-
+            AddToRealmIfNecessary(realmValue);
             return _setHandle.Add(realmValue);
         }
 

--- a/Tests/Realm.Tests/Database/RealmSetTests.cs
+++ b/Tests/Realm.Tests/Database/RealmSetTests.cs
@@ -1162,6 +1162,31 @@ namespace Realms.Tests.Database
 
         #endregion
 
+        [Test]
+        public void ObjectFromAnotherRealm_ThrowsRealmException()
+        {
+            var realm2 = GetRealm(CreateConfiguration(Guid.NewGuid().ToString()));
+
+            var item = new IntPropertyObject { Int = 5 };
+
+            var obj1 = _realm.Write(() =>
+            {
+                return _realm.Add(new CollectionsObject());
+            });
+
+            var obj2 = realm2.Write(() =>
+            {
+                return realm2.Add(new CollectionsObject());
+            });
+
+            _realm.Write(() =>
+            {
+                obj1.ObjectSet.Add(item);
+            });
+
+            Assert.That(() => realm2.Write(() => obj2.ObjectSet.Add(item)), Throws.TypeOf<RealmException>().And.Message.Contains("object that is already in another realm"));
+        }
+
         static RealmSetTests()
         {
             ObjectTestValues = GetObjectTestValues().ToArray();

--- a/Tests/Realm.Tests/Database/TestObjects.cs
+++ b/Tests/Realm.Tests/Database/TestObjects.cs
@@ -295,6 +295,8 @@ namespace Realms.Tests
 
         public IList<IntPropertyObject> ObjectList { get; }
 
+        public IList<EmbeddedIntPropertyObject> EmbeddedObjectList { get; }
+
         public IList<RealmValue> RealmValueList { get; }
 
         public IDictionary<string, char> CharDict { get; }


### PR DESCRIPTION
Added to checks to verify that objects do not belong to a different realm when being added to collection

Fixes #2462

