### PR TITLE
Clean up native resources on Unity application exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## vNext (TBD)
 
 ### Fixed
-* \[Unity] Fixed an issue where failing to weave an assembly due to modeling errors, would only show an error in the logs once and then fail opening a Realm with `No RealmObjects. Has linker stripped them?`. Now, the weaving errors will show up on every code change/weave attempt and the runtime error will explicitly suggest manually re-running the weaver. (Issue [#2310](https://github.com/realm/realm-dotnet/issues/2310))
-* \[Unity] Fixed an issue that would cause the app to hang on exit when using Sync. (PR [#2467](https://github.com/realm/realm-dotnet/pull/2467))
+* \[Unity\] Fixed an issue where failing to weave an assembly due to modeling errors, would only show an error in the logs once and then fail opening a Realm with `No RealmObjects. Has linker stripped them?`. Now, the weaving errors will show up on every code change/weave attempt and the runtime error will explicitly suggest manually re-running the weaver. (Issue [#2310](https://github.com/realm/realm-dotnet/issues/2310))
+* \[Unity\] Fixed an issue that would cause the app to hang on exit when using Sync. (PR [#2467](https://github.com/realm/realm-dotnet/pull/2467))
+* \[Unity\] Fixed an issue that would cause the Unity editor on macOS to hang after assembly reload if the app uses Sync. (Issue [#2482](https://github.com/realm/realm-dotnet/issues/2482))
 
 ### Enhancements
 * None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * \[Unity] Fixed an issue where failing to weave an assembly due to modeling errors, would only show an error in the logs once and then fail opening a Realm with `No RealmObjects. Has linker stripped them?`. Now, the weaving errors will show up on every code change/weave attempt and the runtime error will explicitly suggest manually re-running the weaver. (Issue [#2310](https://github.com/realm/realm-dotnet/issues/2310))
+* \[Unity] Fixed an issue that would cause the app to hang on exit when using Sync. (PR [#2467](https://github.com/realm/realm-dotnet/pull/2467))
 
 ### Enhancements
 * None

--- a/Realm/Realm.UnityUtils/Initializer.cs
+++ b/Realm/Realm.UnityUtils/Initializer.cs
@@ -34,7 +34,7 @@ namespace UnityUtils
                 Logger.Default = new UnityLogger();
                 UnityEngine.Application.quitting += () =>
                 {
-                    InteropConfig.CleanupNativeResources();
+                    NativeCommon.CleanupNativeResources("Application is exiting");
                 };
             }
         }

--- a/Realm/Realm.UnityUtils/Initializer.cs
+++ b/Realm/Realm.UnityUtils/Initializer.cs
@@ -32,6 +32,10 @@ namespace UnityUtils
             {
                 InteropConfig.AddPotentialStorageFolder(FileHelper.GetStorageFolder());
                 Logger.Default = new UnityLogger();
+                UnityEngine.Application.quitting += () =>
+                {
+                    InteropConfig.CleanupNativeResources();
+                };
             }
         }
     }

--- a/Realm/Realm.UnityUtils/Initializer.cs
+++ b/Realm/Realm.UnityUtils/Initializer.cs
@@ -26,6 +26,7 @@ namespace UnityUtils
     {
         private static int _isInitialized;
 
+        [Preserve]
         public static void Initialize()
         {
             if (Interlocked.CompareExchange(ref _isInitialized, 1, 0) == 0)

--- a/Realm/Realm/Handles/AppHandle.cs
+++ b/Realm/Realm/Handles/AppHandle.cs
@@ -219,10 +219,8 @@ namespace Realms.Sync
             {
                 foreach (var weakHandle in _appHandles)
                 {
-                    if (weakHandle.Target is AppHandle handle)
-                    {
-                        handle?.Close();
-                    }
+                    var appHandle = (AppHandle)weakHandle.Target;
+                    appHandle?.Close();
                 }
 
                 _appHandles.Clear();

--- a/Realm/Realm/Handles/AppHandle.cs
+++ b/Realm/Realm/Handles/AppHandle.cs
@@ -201,7 +201,7 @@ namespace Realms.Sync
 
             lock (_appHandles)
             {
-                _appHandles.RemoveAll(a => a.IsAlive);
+                _appHandles.RemoveAll(a => !a.IsAlive);
                 _appHandles.Add(new WeakReference(this));
             }
         }

--- a/Realm/Realm/Handles/AppHandle.cs
+++ b/Realm/Realm/Handles/AppHandle.cs
@@ -221,7 +221,7 @@ namespace Realms.Sync
                 {
                     if (weakHandle.Target is AppHandle handle)
                     {
-                        handle.Close();
+                        handle?.Close();
                     }
                 }
 

--- a/Realm/Realm/Handles/AppHandle.cs
+++ b/Realm/Realm/Handles/AppHandle.cs
@@ -31,6 +31,8 @@ namespace Realms.Sync
 {
     internal partial class AppHandle : RealmHandle
     {
+        private static readonly List<WeakReference> _appHandles = new List<WeakReference>();
+
         private static class NativeMethods
         {
 #pragma warning disable IDE1006 // Naming Styles
@@ -196,6 +198,12 @@ namespace Realms.Sync
         internal AppHandle(IntPtr handle) : base(null, handle)
         {
             EmailPassword = new EmailPasswordApi(this);
+
+            lock (_appHandles)
+            {
+                _appHandles.RemoveAll(a => a.IsAlive);
+                _appHandles.Add(new WeakReference(this));
+            }
         }
 
         public static AppHandle CreateApp(Native.AppConfiguration config, byte[] encryptionKey)
@@ -203,6 +211,22 @@ namespace Realms.Sync
             var handle = NativeMethods.create_app(config, encryptionKey, out var ex);
             ex.ThrowIfNecessary();
             return new AppHandle(handle);
+        }
+
+        public static void ForceCloseHandles()
+        {
+            lock (_appHandles)
+            {
+                foreach (var weakHandle in _appHandles)
+                {
+                    if (weakHandle.Target is AppHandle handle)
+                    {
+                        handle.Close();
+                    }
+                }
+
+                _appHandles.Clear();
+            }
         }
 
         public string GetRealmPath(User user, string partition)

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -272,7 +272,7 @@ namespace Realms
             nativeException.ThrowIfNecessary();
         }
 
-        public static void CloseAllRealms()
+        public static void ForceCloseNativeRealms()
         {
             NativeMethods.close_all_realms(out var nativeException);
             nativeException.ThrowIfNecessary();

--- a/Realm/Realm/InteropConfig.cs
+++ b/Realm/Realm/InteropConfig.cs
@@ -18,11 +18,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using Realms.Logging;
-using Realms.Sync;
 
 namespace Realms
 {
@@ -91,35 +88,8 @@ namespace Realms
 
             AppDomain.CurrentDomain.DomainUnload += (_, __) =>
             {
-                Logger.LogDefault(LogLevel.Info, "Realm: Domain is unloading, force closing all Realm instances.");
-
-                CleanupNativeResources();
+                NativeCommon.CleanupNativeResources("AppDomain is unloading");
             };
-        }
-
-        /// <summary>
-        /// **WARNING**: This will close all native Realm instances and AppHandles. This method is extremely unsafe
-        /// to call in any circumstance where the user might be accessing anything Realm-related. The only places
-        /// where we do call it is in DomainUnload and Application.quitting on Unity. We expect that at this point
-        /// the Application/Domain is being torn down and the user should not be interracting with Realm.
-        /// </summary>
-        public static void CleanupNativeResources()
-        {
-            try
-            {
-                var sw = new Stopwatch();
-                sw.Start();
-
-                AppHandle.ForceCloseHandles();
-                SharedRealmHandle.ForceCloseNativeRealms();
-
-                sw.Stop();
-                Logger.LogDefault(LogLevel.Info, $"Realm: Closed all native instances in {sw.ElapsedMilliseconds} ms.");
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDefault(LogLevel.Error, $"Realm: Failed to close all native instances. You may need to restart your app. Error: {ex}");
-            }
         }
 
         private static bool TryInitializeUnity()


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

When Unity closes the application, it will suspend garbage collection and wait for all native threads to exit (or at least stop doing work - threads that are waiting on conditional variables are not an issue). This is problematic because the managed AppHandle holds a shared_ptr to the native App, which in turn holds a shared_ptr to the SyncManger. This prevents the destruction of the SyncManager and this is where we actually stop the sync client. Not stopping the sync client means that it'll keep polling the socket in a loop, forcing Unity to wait forever.

The fix is to keep a collection of weak references to each AppHandle we create and force close all of them when the application exits.

##  TODO

* [x] Changelog entry
