### PR TITLE
Don't try to get the app from a removed user

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 @Library('realm-ci') _
 
-configuration = 'Release'
+configuration = 'Debug'
 
 def AndroidABIs = [ 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64' ]
 def WindowsPlatforms = [ 'Win32', 'x64' ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 @Library('realm-ci') _
 
-configuration = 'Debug'
+configuration = 'Release'
 
 def AndroidABIs = [ 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64' ]
 def WindowsPlatforms = [ 'Win32', 'x64' ]

--- a/Tests/Realm.Tests/Sync/SyncTestBase.cs
+++ b/Tests/Realm.Tests/Sync/SyncTestBase.cs
@@ -110,7 +110,7 @@ namespace Realms.Tests.Sync
             refreshToken ??= "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoicmVmcmVzaCB0b2tlbiIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoyNTM2MjM5MDIyfQ.SWH98a-UYBEoJ7DLxpP7mdibleQFeCbGt4i3CrsyT2M";
             accessToken ??= "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiYWNjZXNzIHRva2VuIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjI1MzYyMzkwMjJ9.bgnlxP_mGztBZsImn7HaF-6lDevFDn2U_K7D8WUC2GQ";
             var handle = app.Handle.GetUserForTesting(id, refreshToken, accessToken);
-            return new User(handle);
+            return new User(handle, app);
         }
 
         protected async Task<Realm> GetIntegrationRealmAsync(string partition = null, App app = null)

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -228,8 +228,12 @@ extern "C" {
     REALM_EXPORT SharedApp* realm_syncuser_get_app(SharedSyncUser& user, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&] {
-            if (auto shared_app = user->sync_manager()->app().lock()) {
-                return new SharedApp(shared_app);
+            // If the user is detached from the sync manager, we'll hit an assert, so this early check avoids that. 
+            if (user->state() != SyncUser::State::Removed)
+            {
+                if (auto shared_app = user->sync_manager()->app().lock()) {
+                    return new SharedApp(shared_app);
+                }
             }
 
             return (SharedApp*)nullptr;


### PR DESCRIPTION
Getting the app from a detached user would result in a segfault. This returns `nullptr` instead.