### PR TITLE
Don't update unity base path location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ Tests/Tests.Unity/*.sln
 Realm/Realm.Unity/Runtime/iOS/realm-wrappers.xcframework/**/realm-wrappers.framework/realm-wrappers
 Realm/Realm.Unity/Runtime/iOS/realm-wrappers.xcframework/**/Info.plist
 CodeResources
+Tests/Tests.Unity/Assets/Tests/Dependencies

--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -39,10 +39,13 @@ namespace Realms.Tests
 
         static RealmTest()
         {
+            if (!TestHelpers.IsUnity)
+            {
 #pragma warning disable CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
-            InteropConfig.DefaultStorageFolder = Path.Combine(Path.GetTempPath(), $"rt-${System.Diagnostics.Process.GetCurrentProcess().Id}");
+                InteropConfig.DefaultStorageFolder = Path.Combine(Path.GetTempPath(), $"rt-${System.Diagnostics.Process.GetCurrentProcess().Id}");
 #pragma warning restore CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
-            Directory.CreateDirectory(InteropConfig.DefaultStorageFolder);
+                Directory.CreateDirectory(InteropConfig.DefaultStorageFolder);
+            }
         }
 
         [SetUp]


### PR DESCRIPTION
Unity's version of Path.GetTempPath gives us unwritable folder for Android and this was mostly a hack to shorten path names that were a problem on jenkins and won't be an issue on GHA.