### PR TITLE
Fix some CI publish workflow

### DIFF
--- a/.github/templates/Readme.md
+++ b/.github/templates/Readme.md
@@ -4,7 +4,12 @@ We're using [ytt](https://github.com/vmware-tanzu/carvel-ytt) to generate the gi
 
 ## Prerequisites
 
-Get ytt from your package manager of choice. If, for example, you're on Windows and use chocolatey you can run:<br/> `choco install ytt -y`
+Get ytt from your package manager of choice. If:
+1. on Windows and use chocolatey you can run:  
+`choco install ytt -y`
+1. on MacOS and use brew you can run:  
+`brew tap vmware-tanzu/carvel`  
+`brew install ytt`
 
 If instead ytt isn't in your packager manager or you don't use one you can manually get ytt as follows:
 

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -103,7 +103,7 @@ steps:
 #@ end
 
 #@ def buildDocs():
-#@ docsCondition = "${{ contains(github.ref, 'release') }}"
+#@ docsCondition = "${{ contains(github.head.ref, 'release') }}"
   - name: Check Docfx cache
     id: check-docfx-cache
     if: #@ docsCondition

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -103,7 +103,7 @@ steps:
 #@ end
 
 #@ def buildDocs():
-#@ isRelease = "contains(github.head.ref, 'release')"
+#@ isRelease = "contains(github.head_ref, 'release')"
 #@ docsCondition = "${{ " + isRelease + " }}"
   - name: Check Docfx cache
     id: check-docfx-cache

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -103,7 +103,8 @@ steps:
 #@ end
 
 #@ def buildDocs():
-#@ docsCondition = "${{ contains(github.head.ref, 'release') }}"
+#@ isRelease = "contains(github.head.ref, 'release')"
+#@ docsCondition = "${{ " + isRelease + " }}"
   - name: Check Docfx cache
     id: check-docfx-cache
     if: #@ docsCondition
@@ -112,7 +113,7 @@ steps:
       path: 'C:\docfx'
       key: docfx
   - name: Download docfx
-    if: ${{ steps.check-docfx-cache.outputs.cache-hit != 'true' && contains(github.ref, 'release') }}
+    if: #@ "${{ steps.check-docfx-cache.outputs.cache-hit != 'true' && " + isRelease + " }}"
     run: |
       Invoke-WebRequest -Uri https://github.com/dotnet/docfx/releases/download/v2.58/docfx.zip -OutFile C:\docfx.zip
       Expand-Archive -Path C:\docfx.zip -DestinationPath C:\docfx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,6 +353,7 @@ jobs:
         echo ${{ github.event.pull_request.head.ref }}
         echo $GITHUB_HEAD_REF
         echo $GITHUB_BASE_REF
+      shell: bash
     - name: Find nupkg version
       id: find-nupkg-version
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,24 +357,24 @@ jobs:
       shell: bash
     - name: Check Docfx cache
       id: check-docfx-cache
-      if: ${{ contains(github.head.ref, 'release') }}
+      if: ${{ contains(github.head_ref, 'release') }}
       uses: actions/cache@v2
       with:
         path: C:\docfx
         key: docfx
     - name: Download docfx
-      if: ${{ steps.check-docfx-cache.outputs.cache-hit != 'true' && contains(github.head.ref, 'release') }}
+      if: ${{ steps.check-docfx-cache.outputs.cache-hit != 'true' && contains(github.head_ref, 'release') }}
       run: |
         Invoke-WebRequest -Uri https://github.com/dotnet/docfx/releases/download/v2.58/docfx.zip -OutFile C:\docfx.zip
         Expand-Archive -Path C:\docfx.zip -DestinationPath C:\docfx
       shell: powershell
     - name: Build docs
-      if: ${{ contains(github.head.ref, 'release') }}
+      if: ${{ contains(github.head_ref, 'release') }}
       run: |
         C:\docfx\docfx Docs/docfx.json
         Compress-Archive -Path Docs/_site -DestinationPath "Realm/packages/Docs.zip"
     - name: Store docs artifacts
-      if: ${{ contains(github.head.ref, 'release') }}
+      if: ${{ contains(github.head_ref, 'release') }}
       uses: actions/upload-artifact@v2
       with:
         name: Docs.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -350,7 +350,7 @@ jobs:
     - name: Find nupkg version
       id: find-nupkg-version
       run: |
-        echo $github_ref
+        echo $GITHUB_REF
         cd Realm/packages
         tmpName=$(basename Realm.Fody* .nupkg)
         pkgName=${tmpName#"Realm.Fody."}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -363,7 +363,7 @@ jobs:
         path: C:\docfx
         key: docfx
     - name: Download docfx
-      if: ${{ steps.check-docfx-cache.outputs.cache-hit != 'true' && contains(github.ref, 'release') }}
+      if: ${{ steps.check-docfx-cache.outputs.cache-hit != 'true' && contains(github.head.ref, 'release') }}
       run: |
         Invoke-WebRequest -Uri https://github.com/dotnet/docfx/releases/download/v2.58/docfx.zip -OutFile C:\docfx.zip
         Expand-Archive -Path C:\docfx.zip -DestinationPath C:\docfx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -347,13 +347,6 @@ jobs:
       run: msbuild Realm/Realm.UnityUtils -t:Pack -p:Configuration=Release -restore -p:PackageOutputPath=${{ github.workspace }}/Realm/packages -p:VersionSuffix=${{ steps.set-version-suffix.outputs.build_suffix }}
     - name: Build Realm/Realm.UnityWeaver
       run: msbuild Realm/Realm.UnityWeaver -t:Pack -p:Configuration=Release -restore -p:PackageOutputPath=${{ github.workspace }}/Realm/packages -p:VersionSuffix=${{ steps.set-version-suffix.outputs.build_suffix }}
-    - name: Read env vars
-      run: |
-        echo $GTIHUB_EVENET_PULL_REQUEST_HEAD_REF
-        echo ${{ github.event.pull_request.head.ref }}
-        echo $GITHUB_HEAD_REF
-        echo $GITHUB_BASE_REF
-      shell: bash
     - name: Find nupkg version
       id: find-nupkg-version
       run: |
@@ -364,7 +357,7 @@ jobs:
       shell: bash
     - name: Check Docfx cache
       id: check-docfx-cache
-      if: ${{ contains(github.ref, 'release') }}
+      if: ${{ contains(github.head.ref, 'release') }}
       uses: actions/cache@v2
       with:
         path: C:\docfx
@@ -376,12 +369,12 @@ jobs:
         Expand-Archive -Path C:\docfx.zip -DestinationPath C:\docfx
       shell: powershell
     - name: Build docs
-      if: ${{ contains(github.ref, 'release') }}
+      if: ${{ contains(github.head.ref, 'release') }}
       run: |
         C:\docfx\docfx Docs/docfx.json
         Compress-Archive -Path Docs/_site -DestinationPath "Realm/packages/Docs.zip"
     - name: Store docs artifacts
-      if: ${{ contains(github.ref, 'release') }}
+      if: ${{ contains(github.head.ref, 'release') }}
       uses: actions/upload-artifact@v2
       with:
         name: Docs.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -347,10 +347,15 @@ jobs:
       run: msbuild Realm/Realm.UnityUtils -t:Pack -p:Configuration=Release -restore -p:PackageOutputPath=${{ github.workspace }}/Realm/packages -p:VersionSuffix=${{ steps.set-version-suffix.outputs.build_suffix }}
     - name: Build Realm/Realm.UnityWeaver
       run: msbuild Realm/Realm.UnityWeaver -t:Pack -p:Configuration=Release -restore -p:PackageOutputPath=${{ github.workspace }}/Realm/packages -p:VersionSuffix=${{ steps.set-version-suffix.outputs.build_suffix }}
+    - name: Read env vars
+      run: |
+        echo $GTIHUB_EVENET_PULL_REQUEST_HEAD_REF
+        echo ${{ github.event.pull_request.head.ref }}
+        echo $GITHUB_HEAD_REF
+        echo $GITHUB_BASE_REF
     - name: Find nupkg version
       id: find-nupkg-version
       run: |
-        echo $GITHUB_REF
         cd Realm/packages
         tmpName=$(basename Realm.Fody* .nupkg)
         pkgName=${tmpName#"Realm.Fody."}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -350,6 +350,7 @@ jobs:
     - name: Find nupkg version
       id: find-nupkg-version
       run: |
+        echo $github_ref
         cd Realm/packages
         tmpName=$(basename Realm.Fody* .nupkg)
         pkgName=${tmpName#"Realm.Fody."}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: main.yml
-        commit: ${{ github.event.pull_request.head.sha }}
+        commit: ${{ github.sha }}
         path: ${{ github.workspace }}/Realm/packages/
     - name: Extract release notes
       id: extract-release-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: main.yml
-        branch: ${{ github.ref }}
+        commit: ${{ github.event.pull_request.head.sha }}
         path: ${{ github.workspace }}/Realm/packages/
     - name: Extract release notes
       id: extract-release-notes

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8.0</LangVersion>
     <Title>Realm</Title>
-    <ReleaseNotes>https://docs.mongodb.com/realm-sdks/dotnet/latest/CHANGELOG.html</ReleaseNotes>
+    <PackageReleaseNotes>https://docs.mongodb.com/realm-sdks/dotnet/latest/CHANGELOG.html</PackageReleaseNotes>
     <CodeAnalysisRuleSet>$(ProjectDir)..\..\global.ruleset</CodeAnalysisRuleSet>
     <DisableFody>true</DisableFody>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Fix 2 issues related to release workflow:
1- condition for when to build the docs from the main workflow. The problem was that the var used didn't have the name of the branch in it.
2- The artifacts fetched by the release workflow weren't specified with an exact commit number, so random artifact versions were being fetched

Fixes #2498 , #2499