### PR TITLE
Close realm in case of exceptions while creating schema

### DIFF
--- a/Realm/Realm/Configurations/InMemoryConfiguration.cs
+++ b/Realm/Realm/Configurations/InMemoryConfiguration.cs
@@ -53,8 +53,8 @@ namespace Realms
             var configuration = CreateNativeConfiguration();
             configuration.in_memory = true;
 
-            var srPtr = SharedRealmHandle.Open(configuration, schema, EncryptionKey);
-            return new Realm(new SharedRealmHandle(srPtr), this, schema);
+            var srHandle = SharedRealmHandle.Open(configuration, schema, EncryptionKey);
+            return new Realm(srHandle, this, schema);
         }
 
         internal override Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken)

--- a/Realm/Realm/Configurations/RealmConfiguration.cs
+++ b/Realm/Realm/Configurations/RealmConfiguration.cs
@@ -142,10 +142,10 @@ namespace Realms
                 configuration.managed_should_compact_delegate = GCHandle.ToIntPtr(shouldCompactHandle.Value);
             }
 
-            var srPtr = IntPtr.Zero;
+            SharedRealmHandle sharedRealmHandle;
             try
             {
-                srPtr = SharedRealmHandle.Open(configuration, schema, EncryptionKey);
+                sharedRealmHandle = SharedRealmHandle.Open(configuration, schema, EncryptionKey);
             }
             catch (ManagedExceptionDuringMigrationException)
             {
@@ -157,22 +157,7 @@ namespace Realms
                 shouldCompactHandle?.Free();
             }
 
-            var srHandle = new SharedRealmHandle(srPtr);
-
-            if (IsDynamic && !schema.Any())
-            {
-                try
-                {
-                    schema = srHandle.GetSchema();
-                }
-                catch (Exception)
-                {
-                    srHandle.Close();
-                    throw;
-                }
-            }
-
-            return new Realm(srHandle, this, schema);
+            return GetRealm(sharedRealmHandle, schema);
         }
 
         internal override Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken)

--- a/Realm/Realm/Configurations/RealmConfiguration.cs
+++ b/Realm/Realm/Configurations/RealmConfiguration.cs
@@ -158,9 +158,18 @@ namespace Realms
             }
 
             var srHandle = new SharedRealmHandle(srPtr);
+
             if (IsDynamic && !schema.Any())
             {
-                schema = srHandle.GetSchema();
+                try
+                {
+                    schema = srHandle.GetSchema();
+                }
+                catch (Exception)
+                {
+                    srHandle.Close();
+                    throw;
+                }
             }
 
             return new Realm(srHandle, this, schema);

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -170,7 +170,7 @@ namespace Realms
                 {
                     schema = sharedRealmHandle.GetSchema();
                 }
-                catch (Exception)
+                catch
                 {
                     sharedRealmHandle.Close();
                     throw;

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Realms.Schema;
@@ -159,6 +160,24 @@ namespace Realms
                 enable_cache = EnableCache,
                 max_number_of_active_versions = MaxNumberOfActiveVersions
             };
+        }
+
+        internal Realm GetRealm(SharedRealmHandle sharedRealmHandle, RealmSchema schema)
+        {
+            if (IsDynamic && !schema.Any())
+            {
+                try
+                {
+                    schema = sharedRealmHandle.GetSchema();
+                }
+                catch (Exception)
+                {
+                    sharedRealmHandle.Close();
+                    throw;
+                }
+            }
+
+            return new Realm(sharedRealmHandle, this, schema);
         }
     }
 }

--- a/Realm/Realm/Configurations/SyncConfiguration.cs
+++ b/Realm/Realm/Configurations/SyncConfiguration.cs
@@ -144,12 +144,7 @@ namespace Realms.Sync
             var syncConfiguration = CreateNativeSyncConfiguration();
 
             var srHandle = SharedRealmHandle.OpenWithSync(configuration, syncConfiguration, schema, EncryptionKey);
-            if (IsDynamic && !schema.Any())
-            {
-                schema = srHandle.GetSchema();
-            }
-
-            return new Realm(srHandle, this, schema);
+            return GetRealm(srHandle, schema);
         }
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The new Realm will take ownership of the handle")]

--- a/Realm/Realm/Configurations/SyncConfiguration.cs
+++ b/Realm/Realm/Configurations/SyncConfiguration.cs
@@ -152,6 +152,7 @@ namespace Realms.Sync
             return new Realm(srHandle, this, schema);
         }
 
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The new Realm will take ownership of the handle")]
         internal override async Task<Realm> CreateRealmAsync(RealmSchema schema, CancellationToken cancellationToken)
         {
             var configuration = CreateNativeConfiguration();
@@ -192,14 +193,8 @@ namespace Realms.Sync
                 }
 
                 using var realmReference = await tcs.Task;
-                var realmPtr = SharedRealmHandle.ResolveFromReference(realmReference);
-                var sharedRealmHandle = new SharedRealmHandle(realmPtr);
-                if (IsDynamic && !schema.Any())
-                {
-                    schema = sharedRealmHandle.GetSchema();
-                }
-
-                return new Realm(sharedRealmHandle, this, schema);
+                var sharedRealmHandle = SharedRealmHandle.ResolveFromReference(realmReference);
+                return GetRealm(sharedRealmHandle, schema);
             }
             finally
             {

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -227,13 +227,13 @@ namespace Realms
             NativeMethods.destroy(handle);
         }
 
-        public static IntPtr Open(Configuration configuration, RealmSchema schema, byte[] encryptionKey)
+        public static SharedRealmHandle Open(Configuration configuration, RealmSchema schema, byte[] encryptionKey)
         {
             var marshaledSchema = new SchemaMarshaler(schema);
 
             var result = NativeMethods.open(configuration, marshaledSchema.Objects, marshaledSchema.Objects.Length, marshaledSchema.Properties, encryptionKey, out var nativeException);
             nativeException.ThrowIfNecessary();
-            return result;
+            return new SharedRealmHandle(result);
         }
 
         public static SharedRealmHandle OpenWithSync(Configuration configuration, Sync.Native.SyncConfiguration syncConfiguration, RealmSchema schema, byte[] encryptionKey)
@@ -255,11 +255,11 @@ namespace Realms
             return new AsyncOpenTaskHandle(asyncTaskPtr);
         }
 
-        public static IntPtr ResolveFromReference(ThreadSafeReferenceHandle referenceHandle)
+        public static SharedRealmHandle ResolveFromReference(ThreadSafeReferenceHandle referenceHandle)
         {
             var result = NativeMethods.resolve_realm_reference(referenceHandle, out var nativeException);
             nativeException.ThrowIfNecessary();
-            return result;
+            return new SharedRealmHandle(result);
         }
 
         public void CloseRealm()


### PR DESCRIPTION
This fix closes the realm if there are exceptions while retrieving the schema from disk when opening the realm in dynamic mode. At the moment it seems that it's actually not possible to make it throw an exception like is shown in the ticket or even in other ways (at least I have not found a way). 
Given this... this is more of a protection in case something changes in the future, more than fixing an actual bug, so I am not sure if I should continue with this. 
If we decide to continue, the same try-catch needs to be put in another two places.


Fixes #1989

