### PR TITLE
Update wrapper props to handle the new TFIs shipping with net6

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -44,21 +44,10 @@ steps:
 #@ end
 
 #@ def setupWin81SDK():
-  - name: Check Win8.1 SDK Cache
-    id: check-win81-sdk-cache
-    uses: actions/cache@v2
-    with:
-      path: 'C:\win81sdk'
-      key: win81sdk
-    if: #@ wrappersCacheCondition
-  - name: Download Win8.1 SDK
+  - name: Install Win8.1 SDK
     run: |
       md C:\win81sdk
       Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile C:\win81sdk\sdksetup.exe -UseBasicParsing
-    shell: powershell
-    if: #@ wrappersCacheCondition + " && steps.check-win81-sdk-cache.outputs.cache-hit != 'true'"
-  - name: Install Win8.1 SDK
-    run: |
       Start-Process -Wait C:\win81sdk\sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
     shell: powershell
     if: #@ wrappersCacheCondition

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -172,7 +172,7 @@ steps:
 #@
 #@ runtime = "${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}"
   - name: #@ "Publish " + projectPath
-    run: #@ "dotnet publish " + projectPath + " -c " + configuration + " -f " + framework + " -r " + runtime + propsArg
+    run: #@ "dotnet publish " + projectPath + " -c " + configuration + " -f " + framework + " -r " + runtime + propsArg + " --no-self-contained"
     shell: bash
   - name: Run the tests
     run: #@ "./" + projectPath + "/bin/" + configuration + "/" + framework + "/" + runtime + "/" + executeCommand

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -154,9 +154,9 @@ steps:
 #@ end
 #@ end
 
-#@ def dotnetPublishAndRunTests(projectPath, framework, executeCommand, additionalFrameworks):
+#@ def dotnetPublishAndRunTests(projectPath, framework, executeCommand):
 #@ properties = {
-#@   "AdditionalFrameworks": additionalFrameworks,
+#@   "AdditionalFrameworks": framework,
 #@   "RestoreConfigFile": "Tests/Test.NuGet.Config",
 #@   "UseRealmNupkgsWithVersion": "${{ needs.build-packages.outputs.package_version }}"
 #@ }
@@ -365,7 +365,7 @@ jobs:
         with:
           dotnet-version: '6.0.x'
           include-prerelease: true
-      - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After", "${{ (matrix.targetFramework == 'net5.0' || matrix.targetFramework == 'net6.0') && matrix.targetFramework || '' }}"))
+      - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After"))
       - #@ publishTestsResults("TestResults.xml", ".NET (${{ matrix.os }}, ${{ matrix.targetFramework }})")
   run-tests-xamarin-macos:
     runs-on: macos-latest
@@ -421,7 +421,7 @@ jobs:
     steps:
       - #@ template.replace(checkoutCode())
       - #@ template.replace(fetchPackageArtifacts())
-      - #@ template.replace(dotnetPublishAndRunTests("Tests/Benchmarks/PerformanceTests", "net5.0", "PerformanceTests -f \"*\" --join", "true"))
+      - #@ template.replace(dotnetPublishAndRunTests("Tests/Benchmarks/PerformanceTests", "net5.0", "PerformanceTests -f \"*\" --join"))
       - name: Find Results file
         id: find-results-file
         run: |

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -154,9 +154,9 @@ steps:
 #@ end
 #@ end
 
-#@ def dotnetPublishAndRunTests(projectPath, framework, executeCommand, addNet5):
+#@ def dotnetPublishAndRunTests(projectPath, framework, executeCommand, additionalFrameworks):
 #@ properties = {
-#@   "AddNet5Framework": addNet5,
+#@   "AdditionalFrameworks": additionalFrameworks,
 #@   "RestoreConfigFile": "Tests/Test.NuGet.Config",
 #@   "UseRealmNupkgsWithVersion": "${{ needs.build-packages.outputs.package_version }}"
 #@ }
@@ -356,11 +356,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
-        targetFramework: [ netcoreapp3.1, net5.0 ]
+        targetFramework: [ netcoreapp3.1, net5.0, net6.0 ]
     steps:
       - #@ template.replace(checkoutCode())
       - #@ template.replace(fetchPackageArtifacts())
-      - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After", "${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }}"))
+      - uses: actions/setup-dotnet@v1
+        if: matrix.targetFramework == 'net6.0'
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
+      - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After", "${{ (matrix.targetFramework == 'net5.0' || matrix.targetFramework == 'net6.0') && matrix.targetFramework || '' }}"))
       - #@ publishTestsResults("TestResults.xml", ".NET (${{ matrix.os }}, ${{ matrix.targetFramework }})")
   run-tests-xamarin-macos:
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,21 +177,10 @@ jobs:
         Expand-Archive -Path C:\vcpkg.zip -DestinationPath C:\
       shell: powershell
       if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
-    - name: Check Win8.1 SDK Cache
-      id: check-win81-sdk-cache
-      uses: actions/cache@v2
-      with:
-        path: C:\win81sdk
-        key: win81sdk
-      if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Download Win8.1 SDK
+    - name: Install Win8.1 SDK
       run: |
         md C:\win81sdk
         Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile C:\win81sdk\sdksetup.exe -UseBasicParsing
-      shell: powershell
-      if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-win81-sdk-cache.outputs.cache-hit != 'true'
-    - name: Install Win8.1 SDK
-      run: |
         Start-Process -Wait C:\win81sdk\sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
       shell: powershell
       if: steps.check-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -531,6 +531,7 @@ jobs:
         targetFramework:
         - netcoreapp3.1
         - net5.0
+        - net6.0
     steps:
     - name: Disable Analytics
       run: |
@@ -554,8 +555,13 @@ jobs:
       with:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}.nupkg
         path: ${{ github.workspace }}/Realm/packages/
+    - uses: actions/setup-dotnet@v1
+      if: matrix.targetFramework == 'net6.0'
+      with:
+        dotnet-version: 6.0.x
+        include-prerelease: true
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AddNet5Framework=${{ matrix.targetFramework == 'net5.0' && 'true' || 'false' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=${{ (matrix.targetFramework == 'net5.0' || matrix.targetFramework == 'net6.0') && matrix.targetFramework || '' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
       shell: bash
     - name: Run the tests
       run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.xml --labels=After
@@ -761,7 +767,7 @@ jobs:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}.nupkg
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Benchmarks/PerformanceTests
-      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net5.0 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AddNet5Framework=true -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net5.0 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=true -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
       shell: bash
     - name: Run the tests
       run: ./Tests/Benchmarks/PerformanceTests/bin/Release/net5.0/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/PerformanceTests -f "*" --join

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -561,7 +561,7 @@ jobs:
         dotnet-version: 6.0.x
         include-prerelease: true
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=${{ matrix.targetFramework }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=${{ matrix.targetFramework }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} --no-self-contained
       shell: bash
     - name: Run the tests
       run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.xml --labels=After
@@ -671,7 +671,7 @@ jobs:
     - name: Register msvc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Publish Tests/Weaver/Realm.Fody.Tests
-      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}
+      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f netcoreapp3.1 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} --no-self-contained
       shell: bash
     - name: Run the tests
       run: ./Tests/Weaver/Realm.Fody.Tests/bin/Release/netcoreapp3.1/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Fody.Tests --result=TestResults.Weaver.xml --labels=After
@@ -767,7 +767,7 @@ jobs:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}.nupkg
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Benchmarks/PerformanceTests
-      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net5.0 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=net5.0 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net5.0 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=net5.0 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} --no-self-contained
       shell: bash
     - name: Run the tests
       run: ./Tests/Benchmarks/PerformanceTests/bin/Release/net5.0/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/PerformanceTests -f "*" --join

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -561,7 +561,7 @@ jobs:
         dotnet-version: 6.0.x
         include-prerelease: true
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=${{ (matrix.targetFramework == 'net5.0' || matrix.targetFramework == 'net6.0') && matrix.targetFramework || '' }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=${{ matrix.targetFramework }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
       shell: bash
     - name: Run the tests
       run: ./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/Realm.Tests --result=TestResults.xml --labels=After
@@ -767,7 +767,7 @@ jobs:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}.nupkg
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Benchmarks/PerformanceTests
-      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net5.0 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=true -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net5.0 -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=net5.0 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
       shell: bash
     - name: Run the tests
       run: ./Tests/Benchmarks/PerformanceTests/bin/Release/net5.0/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}/PerformanceTests -f "*" --join

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -354,14 +354,9 @@ def NetCoreTest(String nodeName, String targetFramework) {
       unstash 'dotnet-source'
       dir('Realm/packages') { unstash 'packages' }
 
-      def additionalFrameworks = ''
-      if (targetFramework == 'net5.0') {
-        additionalFrameworks = 'net5.0'
-      }
-
       String script = """
         cd ${env.WORKSPACE}/Tests/Realm.Tests
-        dotnet build -c ${configuration} -f ${targetFramework} -p:RestoreConfigFile=${env.WORKSPACE}/Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${packageVersion} -p:AdditionalFrameworks=${additionalFrameworks}
+        dotnet build -c ${configuration} -f ${targetFramework} -p:RestoreConfigFile=${env.WORKSPACE}/Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${packageVersion} -p:AdditionalFrameworks=${targetFramework}
       """.trim()
 
       if (isUnix() && nodeName == 'docker') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -354,11 +354,14 @@ def NetCoreTest(String nodeName, String targetFramework) {
       unstash 'dotnet-source'
       dir('Realm/packages') { unstash 'packages' }
 
-      def addNet5Framework = targetFramework == 'net5.0'
+      def additionalFrameworks = ''
+      if (targetFramework == 'net5.0') {
+        additionalFrameworks = 'net5.0'
+      }
 
       String script = """
         cd ${env.WORKSPACE}/Tests/Realm.Tests
-        dotnet build -c ${configuration} -f ${targetFramework} -p:RestoreConfigFile=${env.WORKSPACE}/Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${packageVersion} -p:AddNet5Framework=${addNet5Framework}
+        dotnet build -c ${configuration} -f ${targetFramework} -p:RestoreConfigFile=${env.WORKSPACE}/Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${packageVersion} -p:AdditionalFrameworks=${additionalFrameworks}
       """.trim()
 
       if (isUnix() && nodeName == 'docker') {

--- a/Realm/Realm.Fody/ModuleWeaver.cs
+++ b/Realm/Realm.Fody/ModuleWeaver.cs
@@ -97,8 +97,6 @@ public partial class ModuleWeaver : Fody.BaseModuleWeaver, ILogger
             {
                 return "osx";
             }
-
-            return "windows";
         }
         catch
         {
@@ -108,6 +106,8 @@ public partial class ModuleWeaver : Fody.BaseModuleWeaver, ILogger
             throw;
 #endif
         }
+
+        return "windows";
     }
 
     void ILogger.Debug(string message)

--- a/Realm/Realm.Fody/ModuleWeaver.cs
+++ b/Realm/Realm.Fody/ModuleWeaver.cs
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
@@ -57,32 +58,47 @@ public partial class ModuleWeaver : Fody.BaseModuleWeaver, ILogger
             RunAnalytics = !disableAnalytics,
         };
 
-        var version = "UNKNOWN";
+        config.FrameworkVersion = frameworkName.Version.ToString();
+        config.TargetOSName = GetTargetOSName(frameworkName);
 
-        // Default to windows for backward compatibility
-        var name = "windows";
+        // For backward compatibility
+        config.TargetOSVersion = frameworkName.Version.ToString();
 
+        return config;
+    }
+
+    private static string GetTargetOSName(FrameworkName frameworkName)
+    {
         try
         {
             // Legacy reporting used ios, osx, and android
             switch (frameworkName.Identifier)
             {
                 case "Xamarin.iOS":
-                    name = "ios";
-                    break;
+                    return "ios";
                 case "Xamarin.Mac":
-                    name = "osx";
-                    break;
+                    return "osx";
                 case "MonoAndroid":
                 case "Mono.Android":
-                    name = "android";
-                    break;
-                default:
-                    name = frameworkName.Identifier;
-                    break;
+                    return "android";
             }
 
-            version = frameworkName.Version.ToString();
+            if (frameworkName.Identifier.EndsWith("-android", StringComparison.OrdinalIgnoreCase))
+            {
+                return "android";
+            }
+
+            if (frameworkName.Identifier.EndsWith("-ios", StringComparison.OrdinalIgnoreCase))
+            {
+                return "ios";
+            }
+
+            if (frameworkName.Identifier.EndsWith("-maccatalyst", StringComparison.OrdinalIgnoreCase))
+            {
+                return "osx";
+            }
+
+            return "windows";
         }
         catch
         {
@@ -92,14 +108,6 @@ public partial class ModuleWeaver : Fody.BaseModuleWeaver, ILogger
             throw;
 #endif
         }
-
-        config.FrameworkVersion = version;
-        config.TargetOSName = name;
-
-        // For backward compatibility
-        config.TargetOSVersion = version;
-
-        return config;
     }
 
     void ILogger.Debug(string message)

--- a/Realm/Realm/RealmWrappersReferences.props
+++ b/Realm/Realm/RealmWrappersReferences.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <_RealmNugetNativePath Condition="'$(_RealmNugetNativePath)' == ''">$(MSBuildThisFileDirectory)..\native\</_RealmNugetNativePath>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' || $(TargetFramework.Contains('-ios'))">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' Or $(TargetFramework.Contains('-ios'))">
     <NativeReference Include="$(_RealmNugetNativePath)ios\universal\realm-wrappers.xcframework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
@@ -12,12 +12,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac' || $(TargetFramework.Contains('-maccatalyst'))">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac' Or $(TargetFramework.Contains('-maccatalyst'))">
     <NativeReference Include="$(_RealmNugetNativePath)..\runtimes\osx-x64\native\librealm-wrappers.dylib">
       <Kind>Dynamic</Kind>
     </NativeReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' || $(TargetFramework.Contains('-android'))">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' Or $(TargetFramework.Contains('-android'))">
     <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\armeabi-v7a\librealm-wrappers.so">
       <Link>$(_RealmNugetNativePath)android\armeabi-v7a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>

--- a/Realm/Realm/RealmWrappersReferences.props
+++ b/Realm/Realm/RealmWrappersReferences.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <_RealmNugetNativePath Condition="'$(_RealmNugetNativePath)' == ''">$(MSBuildThisFileDirectory)..\native\</_RealmNugetNativePath>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' || $(TargetFramework.Contains('-ios'))">
     <NativeReference Include="$(_RealmNugetNativePath)ios\universal\realm-wrappers.xcframework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
@@ -12,19 +12,18 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac' || $(TargetFramework.Contains('-maccatalyst'))">
     <NativeReference Include="$(_RealmNugetNativePath)..\runtimes\osx-x64\native\librealm-wrappers.dylib">
       <Kind>Dynamic</Kind>
     </NativeReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' || $(TargetFramework.Contains('-android'))">
     <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\armeabi-v7a\librealm-wrappers.so">
       <Link>$(_RealmNugetNativePath)android\armeabi-v7a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
     <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\x86\librealm-wrappers.so">
       <Link>$(_RealmNugetNativePath)android\x86\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>
-    <!-- 64bit -->
     <AndroidNativeLibrary Include="$(_RealmNugetNativePath)android\arm64-v8a\librealm-wrappers.so">
       <Link>$(_RealmNugetNativePath)android\arm64-v8a\librealm-wrappers.so</Link>
     </AndroidNativeLibrary>

--- a/Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj
+++ b/Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType Condition="$(TargetFramework) == 'net5.0'">Exe</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <!-- AdditionalFrameworks here is net5.0 or net6.0. There's a bug on older .NET versions that prevents restore from working when TargetFrameworks includes net5.0 -->
+    <TargetFrameworks>netstandard2.0;$(AdditionalFrameworks)</TargetFrameworks>
     <CodeAnalysisRuleSet>../../../global.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8.0</LangVersion>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -16,9 +16,9 @@
 
   <PropertyGroup Condition="'$(UnityBuild)' != 'true'">
     <TargetFrameworks>net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(LocalDev)' != 'true'">$(TargetFrameworks);netcoreapp3.1;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
+    <!-- AdditionalFrameworks here is net5.0 or net6.0. There's a bug on older .NET versions that prevents restore from working when TargetFrameworks includes net5.0 -->
+    <TargetFrameworks Condition="'$(LocalDev)' != 'true'">$(TargetFrameworks);netcoreapp3.1;monoandroid90;xamarin.ios10;xamarin.mac20;$(AdditionalFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' AND '$(LocalDev)' != 'true'">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
-    <TargetFrameworks Condition="'$(AdditionalFrameworks)' != ''">$(TargetFrameworks);$(AdditionalFrameworks)</TargetFrameworks>
 
     <OutputType Condition="$(TargetFramework.StartsWith('net'))">Exe</OutputType>
   </PropertyGroup>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -5,7 +5,7 @@
     <LocalDev Condition="'$(LocalDev)' == ''">false</LocalDev>
     <UnityBuild>false</UnityBuild>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(UnityBuild)' == 'true'">
     <PackageId>Realm.Tests</PackageId>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -18,19 +18,21 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(LocalDev)' != 'true'">$(TargetFrameworks);netcoreapp3.1;monoandroid90;xamarin.ios10;xamarin.mac20</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' AND '$(LocalDev)' != 'true'">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
-    <TargetFrameworks Condition="'$(AddNet5Framework)' == 'true' AND '$(LocalDev)' != 'true'">$(TargetFrameworks);net5.0</TargetFrameworks>
-  
+    <TargetFrameworks Condition="'$(AdditionalFrameworks)' != ''">$(TargetFrameworks);$(AdditionalFrameworks)</TargetFrameworks>
+
     <OutputType Condition="$(TargetFramework.StartsWith('net'))">Exe</OutputType>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <RootNamespace>Realms.Tests</RootNamespace>
     <IsTestProject>true</IsTestProject>
     <LangVersion>8.0</LangVersion>
+    <LangVersion Condition="$(TargetFramework.Contains('net6.0'))">10.0</LangVersion>
     <GenerateProgramFile>false</GenerateProgramFile>
     <AndroidUseIntermediateDesignerFile>False</AndroidUseIntermediateDesignerFile>
     <CodeAnalysisRuleSet>../../global.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UnityBuild)' != 'true'">
@@ -44,7 +46,7 @@
       <HintPath>..\Tests.Unity\Library\PackageCache\com.unity.ext.nunit@1.0.6\net35\unity-custom\nunit.framework.dll</HintPath>
     </Reference>
 
-    <!-- 
+    <!--
     In the Unity Tests project, we're referincing Realm.dll that has bundled dependencies in it. We should reference
     the same dll here, otherwise when we try to ilrepack the test dependencies, we won't find MongoDB.Bson and friends.
     -->


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

The new TargetFrameworkIdentifiers shipping with .NET 6 are `net6.0-android`, `net6.0-maccatalyst`, `net6.0-ios`, so this PR updates them.
