### PR TITLE
Don't try to serialize the `DynamicApi` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 * Fixed an issue that would cause `Logger.Default` on Unity to always revert to `Debug.Log`, even when a custom logger was set. (Issue [#2481](https://github.com/realm/realm-dotnet/issues/2481))
 * Fixed an issue where `Logger.Console` on Unity would still use `Console.WriteLine` instead of `Debug.Log`. (Issue [#2481](https://github.com/realm/realm-dotnet/issues/2481))
+* Added serialization annotations to RealmObjectBase to prevent Newtonsoft.Json and similar serializers from attempting to serialize the base properties. (Issue [#2579](https://github.com/realm/realm-dotnet/issues/2579))
 
 ### Enhancements
 * Added two extension methods on `IList` to get an `IQueryable` collection wrapping the list:
@@ -23,6 +24,7 @@
 * Use the Win81 SDK when building the Windows wrappers on Github Actions. (Issue [#2530](https://github.com/realm/realm-dotnet/issues/2530))
 * Added CodeQL workflow. (Issue [#2155](https://github.com/realm/realm-dotnet/issues/2155))
 * Started tracking package and wrapper sizes over time. (Issue [#2225](https://github.com/realm/realm-dotnet/issues/2225))
+* Removed the `[Serializable]` attribute from RealmObjectBase as `BinarySerializer` is now obsolete. (PR [#2578](https://github.com/realm/realm-dotnet/pull/2578))
 
 ## 10.3.0 (2021-07-07)
 

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Xml.Serialization;
 using Realms.DataBinding;
 using Realms.Exceptions;
@@ -47,22 +48,22 @@ namespace Realms
           INotifiable<NotifiableObjectHandleBase.CollectionChangeSet>,
           IReflectableType
     {
-        [NonSerialized, XmlIgnore]
+        [NonSerialized, IgnoreDataMember]
         private Lazy<int> _hashCode;
 
-        [NonSerialized, XmlIgnore]
+        [NonSerialized, IgnoreDataMember]
         private Realm _realm;
 
-        [NonSerialized, XmlIgnore]
+        [NonSerialized, IgnoreDataMember]
         private ObjectHandle _objectHandle;
 
-        [NonSerialized, XmlIgnore]
+        [NonSerialized, IgnoreDataMember]
         private Metadata _metadata;
 
-        [NonSerialized, XmlIgnore]
+        [NonSerialized, IgnoreDataMember]
         private NotificationTokenHandle _notificationToken;
 
-        [field: NonSerialized, XmlIgnore]
+        [field: NonSerialized, IgnoreDataMember]
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "This is the private event - the public is uppercased.")]
         private event PropertyChangedEventHandler _propertyChanged;
 
@@ -93,10 +94,10 @@ namespace Realms
             }
         }
 
-        [XmlIgnore]
+        [IgnoreDataMember]
         internal ObjectHandle ObjectHandle => _objectHandle;
 
-        [XmlIgnore]
+        [IgnoreDataMember]
         internal Metadata ObjectMetadata => _metadata;
 
         /// <summary>
@@ -104,14 +105,14 @@ namespace Realms
         /// <see cref="Realm.Add{T}(T, bool)"/>.
         /// </summary>
         /// <value><c>true</c> if object belongs to a Realm; <c>false</c> if standalone.</value>
-        [XmlIgnore]
+        [IgnoreDataMember]
         public bool IsManaged => _realm != null;
 
         /// <summary>
         /// Gets an object encompassing the dynamic API for this RealmObjectBase instance.
         /// </summary>
         /// <value>A <see cref="Dynamic"/> instance that wraps this RealmObject.</value>
-        [XmlIgnore]
+        [IgnoreDataMember]
         public Dynamic DynamicApi
         {
             get
@@ -132,7 +133,7 @@ namespace Realms
         /// Unmanaged objects are always considered valid.
         /// </summary>
         /// <value><c>true</c> if managed and part of the Realm or unmanaged; <c>false</c> if managed but deleted.</value>
-        [XmlIgnore]
+        [IgnoreDataMember]
         public bool IsValid => _objectHandle?.IsValid != false;
 
         /// <summary>
@@ -142,21 +143,21 @@ namespace Realms
         /// </summary>
         /// <value><c>true</c> if the object is frozen and immutable; <c>false</c> otherwise.</value>
         /// <seealso cref="FrozenObjectsExtensions.Freeze{T}(T)"/>
-        [XmlIgnore]
+        [IgnoreDataMember]
         public bool IsFrozen => _objectHandle?.IsFrozen == true;
 
         /// <summary>
         /// Gets the <see cref="Realm"/> instance this object belongs to, or <c>null</c> if it is unmanaged.
         /// </summary>
         /// <value>The <see cref="Realm"/> instance this object belongs to.</value>
-        [XmlIgnore]
+        [IgnoreDataMember]
         public Realm Realm => _realm;
 
         /// <summary>
         /// Gets the <see cref="Schema.ObjectSchema"/> instance that describes how the <see cref="Realm"/> this object belongs to sees it.
         /// </summary>
         /// <value>A collection of properties describing the underlying schema of this object.</value>
-        [XmlIgnore]
+        [IgnoreDataMember, XmlIgnore]
         public ObjectSchema ObjectSchema => _metadata?.Schema;
 
         /// <summary>
@@ -166,7 +167,7 @@ namespace Realms
         /// This property is not observable so the <see cref="PropertyChanged"/> event will not fire when its value changes.
         /// </remarks>
         /// <value>The number of objects referring to this one.</value>
-        [XmlIgnore]
+        [IgnoreDataMember]
         public int BacklinksCount => _objectHandle?.GetBacklinkCount() ?? 0;
 
         internal RealmObjectBase FreezeImpl()
@@ -182,7 +183,7 @@ namespace Realms
         }
 
         /// <inheritdoc/>
-        [XmlIgnore]
+        [IgnoreDataMember]
         Metadata IMetadataObject.Metadata => ObjectMetadata;
 
         /// <inheritdoc/>

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -108,7 +108,7 @@ namespace Realms
         /// Gets an object encompassing the dynamic API for this RealmObjectBase instance.
         /// </summary>
         /// <value>A <see cref="Dynamic"/> instance that wraps this RealmObject.</value>
-        [NonSerialized, XmlIgnore]
+        [XmlIgnore]
         public Dynamic DynamicApi
         {
             get

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -41,29 +41,22 @@ namespace Realms
     /// Base for any object that can be persisted in a <see cref="Realm"/>.
     /// </summary>
     [Preserve(AllMembers = true)]
-    [Serializable]
     public abstract class RealmObjectBase
         : INotifyPropertyChanged,
           IThreadConfined,
           INotifiable<NotifiableObjectHandleBase.CollectionChangeSet>,
           IReflectableType
     {
-        [NonSerialized, IgnoreDataMember]
         private Lazy<int> _hashCode;
 
-        [NonSerialized, IgnoreDataMember]
         private Realm _realm;
 
-        [NonSerialized, IgnoreDataMember]
         private ObjectHandle _objectHandle;
 
-        [NonSerialized, IgnoreDataMember]
         private Metadata _metadata;
 
-        [NonSerialized, IgnoreDataMember]
         private NotificationTokenHandle _notificationToken;
 
-        [field: NonSerialized, IgnoreDataMember]
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "This is the private event - the public is uppercased.")]
         private event PropertyChangedEventHandler _propertyChanged;
 
@@ -94,10 +87,8 @@ namespace Realms
             }
         }
 
-        [IgnoreDataMember]
         internal ObjectHandle ObjectHandle => _objectHandle;
 
-        [IgnoreDataMember]
         internal Metadata ObjectMetadata => _metadata;
 
         /// <summary>
@@ -157,7 +148,7 @@ namespace Realms
         /// Gets the <see cref="Schema.ObjectSchema"/> instance that describes how the <see cref="Realm"/> this object belongs to sees it.
         /// </summary>
         /// <value>A collection of properties describing the underlying schema of this object.</value>
-        [IgnoreDataMember, XmlIgnore]
+        [IgnoreDataMember, XmlIgnore] // XmlIgnore seems to be needed here as IgnoreDataMember is not sufficient for XmlSerializer.
         public ObjectSchema ObjectSchema => _metadata?.Schema;
 
         /// <summary>
@@ -183,7 +174,6 @@ namespace Realms
         }
 
         /// <inheritdoc/>
-        [IgnoreDataMember]
         Metadata IMetadataObject.Metadata => ObjectMetadata;
 
         /// <inheritdoc/>

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -108,6 +108,7 @@ namespace Realms
         /// Gets an object encompassing the dynamic API for this RealmObjectBase instance.
         /// </summary>
         /// <value>A <see cref="Dynamic"/> instance that wraps this RealmObject.</value>
+        [NonSerialized, XmlIgnore]
         public Dynamic DynamicApi
         {
             get

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -93,8 +93,10 @@ namespace Realms
             }
         }
 
+        [XmlIgnore]
         internal ObjectHandle ObjectHandle => _objectHandle;
 
+        [XmlIgnore]
         internal Metadata ObjectMetadata => _metadata;
 
         /// <summary>
@@ -102,6 +104,7 @@ namespace Realms
         /// <see cref="Realm.Add{T}(T, bool)"/>.
         /// </summary>
         /// <value><c>true</c> if object belongs to a Realm; <c>false</c> if standalone.</value>
+        [XmlIgnore]
         public bool IsManaged => _realm != null;
 
         /// <summary>
@@ -129,6 +132,7 @@ namespace Realms
         /// Unmanaged objects are always considered valid.
         /// </summary>
         /// <value><c>true</c> if managed and part of the Realm or unmanaged; <c>false</c> if managed but deleted.</value>
+        [XmlIgnore]
         public bool IsValid => _objectHandle?.IsValid != false;
 
         /// <summary>
@@ -138,18 +142,21 @@ namespace Realms
         /// </summary>
         /// <value><c>true</c> if the object is frozen and immutable; <c>false</c> otherwise.</value>
         /// <seealso cref="FrozenObjectsExtensions.Freeze{T}(T)"/>
+        [XmlIgnore]
         public bool IsFrozen => _objectHandle?.IsFrozen == true;
 
         /// <summary>
         /// Gets the <see cref="Realm"/> instance this object belongs to, or <c>null</c> if it is unmanaged.
         /// </summary>
         /// <value>The <see cref="Realm"/> instance this object belongs to.</value>
+        [XmlIgnore]
         public Realm Realm => _realm;
 
         /// <summary>
         /// Gets the <see cref="Schema.ObjectSchema"/> instance that describes how the <see cref="Realm"/> this object belongs to sees it.
         /// </summary>
         /// <value>A collection of properties describing the underlying schema of this object.</value>
+        [XmlIgnore]
         public ObjectSchema ObjectSchema => _metadata?.Schema;
 
         /// <summary>
@@ -159,6 +166,7 @@ namespace Realms
         /// This property is not observable so the <see cref="PropertyChanged"/> event will not fire when its value changes.
         /// </remarks>
         /// <value>The number of objects referring to this one.</value>
+        [XmlIgnore]
         public int BacklinksCount => _objectHandle?.GetBacklinkCount() ?? 0;
 
         internal RealmObjectBase FreezeImpl()
@@ -174,6 +182,7 @@ namespace Realms
         }
 
         /// <inheritdoc/>
+        [XmlIgnore]
         Metadata IMetadataObject.Metadata => ObjectMetadata;
 
         /// <inheritdoc/>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnitLite" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" Condition="!$(TargetFramework.StartsWith('uap'))" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UnityBuild)' == 'true'">

--- a/Tests/Tests.UWP/Tests.UWP.csproj
+++ b/Tests/Tests.UWP/Tests.UWP.csproj
@@ -170,6 +170,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.1</Version>
+    </PackageReference>
     <PackageReference Include="Nito.AsyncEx.Context">
       <Version>5.1.0</Version>
     </PackageReference>

--- a/Tests/Tests.iOS/Tests.iOS.csproj
+++ b/Tests/Tests.iOS/Tests.iOS.csproj
@@ -29,7 +29,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchExtraArgs>--nosymbolstrip --linkskip=nunit.framework --linkskip=Realm.Tests --nolinkaway</MtouchExtraArgs>
+    <MtouchExtraArgs>--nosymbolstrip --linkskip=nunit.framework --linkskip=Realm.Tests --nolinkaway --linkskip=Newtonsoft.Json</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -40,7 +40,7 @@
     <MtouchLink>Full</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <MtouchExtraArgs>--linkskip=nunit.framework --linkskip=Realm.Tests --nolinkaway</MtouchExtraArgs>
+    <MtouchExtraArgs>--linkskip=nunit.framework --linkskip=Realm.Tests --nolinkaway --linkskip=Newtonsoft.Json</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -55,7 +55,8 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchExtraArgs>--linkskip=nunit.runner.iOS --linkskip=nunit.framework --nolinkaway</MtouchExtraArgs>
+    <MtouchExtraArgs>--linkskip=nunit.runner.iOS --linkskip=nunit.framework --nolinkaway --linkskip=Newtonsoft.Json</MtouchExtraArgs>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -67,7 +68,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchExtraArgs>--nosymbolstrip --linkskip=nunit.runner.iOS --linkskip=nunit.framework --nolinkaway</MtouchExtraArgs>
+    <MtouchExtraArgs>--nosymbolstrip --linkskip=nunit.runner.iOS --linkskip=nunit.framework --nolinkaway --linkskip=Newtonsoft.Json</MtouchExtraArgs>
     <MtouchLink>Full</MtouchLink>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This replaces `[XmlIgnore]` with `[IgnoreDataMember]` as that works for both the Xml and Json serializer. It removes `[Serializable]` as that was only used in the `BinarySerializer` which is very strongly obsoleted.

Finally, it annotates the RealmCollectionBase properties with `[IgnoreDataMember]` to make sure a json serializer doesn't try to touch them and adds tests for both Xml and Json serialization.

A couple of caveats:
1. Newtonsoft.Json doesn't work on Unity out of the box, so we only test on the other platforms.
2. MongoDB.Bson and XmlSerializer don't serialize collections by default, so we're not validating it.

Fixes https://github.com/realm/realm-dotnet/issues/2579

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
