### PR TITLE
Disable analytics on CI

### DIFF
--- a/.github/templates/codeql.yml
+++ b/.github/templates/codeql.yml
@@ -35,6 +35,8 @@ name: "CodeQL"
     branches: [ master, main ]
   pull_request:
     branches: [ master, main ]
+env:
+  REALM_DISABLE_ANALYTICS: true
 jobs:
   analyze-cpp:
     name: Analyze C++

--- a/.github/templates/common.lib.yml
+++ b/.github/templates/common.lib.yml
@@ -2,9 +2,6 @@
 #@ nugetPackages = [ 'Realm.Fody', 'Realm', 'Realm.UnityUtils', 'Realm.UnityWeaver' ]
 
 #@ def checkoutCode(submodules=False, registerProblemMatchers=True):
-  - name: Disable Analytics
-    run: |
-      echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
   - name: Checkout code
     uses: actions/checkout@v2
     with:

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -228,6 +228,8 @@ name: main
       - main
       - master
   pull_request:
+env:
+  REALM_DISABLE_ANALYTICS: true
 jobs:
   build-wrappers-macos:
     runs-on: macos-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ name: CodeQL
     branches:
     - master
     - main
+env:
+  REALM_DISABLE_ANALYTICS: true
 jobs:
   analyze-cpp:
     name: Analyze C++
@@ -17,9 +19,6 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -55,9 +54,6 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,13 @@ name: main
     - main
     - master
   pull_request: null
+env:
+  REALM_DISABLE_ANALYTICS: true
 jobs:
   build-wrappers-macos:
     runs-on: macos-latest
     name: Wrappers macOS
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -41,9 +40,6 @@ jobs:
     runs-on: macos-latest
     name: Wrappers iOS
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -72,9 +68,6 @@ jobs:
     runs-on: ubuntu-20.04
     name: Wrappers Linux
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -110,9 +103,6 @@ jobs:
         - x86
         - x86_64
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -146,9 +136,6 @@ jobs:
         - Win32
         - x64
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -203,9 +190,6 @@ jobs:
         - x64
         - ARM
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -258,9 +242,6 @@ jobs:
     steps:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -411,9 +392,6 @@ jobs:
     name: Test .NET Framework
     needs: build-packages
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -451,9 +429,6 @@ jobs:
     name: Test UWP managed
     needs: build-packages
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -532,9 +507,6 @@ jobs:
         - net5.0
         - net6.0
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -584,9 +556,6 @@ jobs:
         - netcoreapp3.1
         - net5.0
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -625,9 +594,6 @@ jobs:
     name: Test Xamarin.macOS
     needs: build-packages
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -663,9 +629,6 @@ jobs:
     name: Test Xamarin.iOS
     needs: build-packages
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -705,9 +668,6 @@ jobs:
     runs-on: windows-latest
     name: Test Weaver
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -736,9 +696,6 @@ jobs:
     name: Code Coverage
     needs: build-packages
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -892,9 +849,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
     steps:
-    - name: Disable Analytics
-      run: |
-        echo "REALM_DISABLE_ANALYTICS=true" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/Realm/Realm.Weaver/Analytics.cs
+++ b/Realm/Realm.Weaver/Analytics.cs
@@ -132,7 +132,9 @@ namespace RealmWeaver
 
         internal string SubmitAnalytics()
         {
-            if (!_config.RunAnalytics || Environment.GetEnvironmentVariable("REALM_DISABLE_ANALYTICS") != null)
+            if (!_config.RunAnalytics ||
+                Environment.GetEnvironmentVariable("REALM_DISABLE_ANALYTICS") != null ||
+                Environment.GetEnvironmentVariable("CI") != null)
             {
                 return "Analytics disabled";
             }

--- a/Tests/Tests.UWP/FodyWeavers.xml
+++ b/Tests/Tests.UWP/FodyWeavers.xml
@@ -1,3 +1,3 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Realm />
+  <Realm DisableAnalytics="true"/>
 </Weavers>


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Most CI services will set the environment variable `CI` to some value, so it's a good idea to check for it and make sure we don't count CI builds as actual developers.

* [Github Actions](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables)
* [Travis CI](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)
* [Appveyor](https://www.appveyor.com/docs/environment-variables/)
* [Jenkins](https://github.com/jenkinsci/jenkins/pull/5370)

Additionally, this cleans up our workflow to set `REALM_DISABLE_ANALYTICS` statically on the entire workflow rather than per at runtime for each job, similarly to https://github.com/realm/realm-js/pull/3918.