### PR TITLE
Tweaks for the publish release workflow

### DIFF
--- a/.github/templates/publish-release.yml
+++ b/.github/templates/publish-release.yml
@@ -1,12 +1,13 @@
 #@ load("@ytt:template", "template")
 
-#@ def uploadToNuget(packageName, isSymbols = False):
-#@ extension = "nupkg"
-#@ if isSymbols:
-#@   extension = "snupkg"
-#@ end
+#@ def uploadToNuget(packageName, includeSymbols = False):
   - name: #@ "NuGet Publish " + packageName + ".${{ steps.get-version.outputs.version }}"
-    run: #@ "dotnet nuget push ${{ github.workspace }}/Realm/packages/" + packageName + ".${{ steps.get-version.outputs.version }}/" + packageName + ".${{ steps.get-version.outputs.version }}." + extension + " --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json"
+    run: #@ "dotnet nuget push ${{ github.workspace }}/Realm/packages/" + packageName + ".${{ steps.get-version.outputs.version }}/" + packageName + ".${{ steps.get-version.outputs.version }}.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json"
+
+#@ if includeSymbols:
+  - name: #@ "NuGet Publish Symbols " + packageName + ".${{ steps.get-version.outputs.version }}"
+    run: #@ "dotnet nuget push ${{ github.workspace }}/Realm/packages/" + packageName + ".${{ steps.get-version.outputs.version }}/" + packageName + ".${{ steps.get-version.outputs.version }}.snupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json"
+#@ end
 #@ end
 
 #@ def uploadToNpm(packageName):
@@ -88,6 +89,5 @@ jobs:
     - #@ template.replace(publishGithubRelease())
     - #@ template.replace(uploadDocsToS3())
     - #@ template.replace(uploadToNuget("Realm.Fody"))
-    - #@ template.replace(uploadToNuget("Realm"))
     - #@ template.replace(uploadToNuget("Realm", True))
     - #@ template.replace(uploadToNpm("io.realm.unity"))

--- a/.github/templates/publish-release.yml
+++ b/.github/templates/publish-release.yml
@@ -1,0 +1,93 @@
+#@ load("@ytt:template", "template")
+
+#@ def uploadToNuget(packageName, isSymbols = False):
+#@ extension = "nupkg"
+#@ if isSymbols:
+#@   extension = "snupkg"
+#@ end
+  - name: #@ "NuGet Publish " + packageName + ".${{ steps.get-version.outputs.version }}"
+    run: #@ "dotnet nuget push ${{ github.workspace }}/Realm/packages/" + packageName + ".${{ steps.get-version.outputs.version }}/" + packageName + ".${{ steps.get-version.outputs.version }}." + extension + " --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json"
+#@ end
+
+#@ def uploadToNpm(packageName):
+  - uses: actions/setup-node@v2
+    with:
+      node-version: '12.x'
+      registry-url: 'https://registry.npmjs.org'
+  - name: #@ "Npm Publish " + packageName + "-${{ steps.get-version.outputs.version }}"
+    run: #@ "npm publish ${{ github.workspace }}/Realm/packages/" + packageName + "-${{ steps.get-version.outputs.version }}.tgz/" + packageName + "-${{ steps.get-version.outputs.version }}.tgz"
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+#@ end
+
+#@ def publishGithubRelease():
+  - name: Create Github Release
+    uses: ncipollo/release-action@v1
+    with:
+      artifacts: ${{ github.workspace }}/Realm/packages/io.realm.unity-${{ steps.get-version.outputs.version }}.tgz/io.realm.unity-${{ steps.get-version.outputs.version }}.tgz
+      bodyFile: ${{ steps.extract-release-notes.outputs.release-notes-path }}
+      name: ${{ steps.get-version.outputs.version }}
+      commit: ${{ github.ref }}
+      tag: ${{ steps.get-version.outputs.version }}
+      token: ${{ secrets.GITHUB_TOKEN }}
+      draft: true
+#@ end
+
+#@ def uploadDocsToS3():
+  - name: Configure AWS Credentials
+    uses: aws-actions/configure-aws-credentials@v1
+    with:
+      aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
+      aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
+      aws-region: us-east-2
+  - name: Upload docs
+    run: |
+      Expand-Archive -Path Realm/packages/Docs.zip/Docs.zip -DestinationPath Realm/packages
+      $versions = "${{ steps.get-version.outputs.version }}", "latest"
+      Foreach ($ver in $versions)
+      {
+        aws s3 sync --acl public-read "${{ github.workspace }}\Realm\packages\_site" s3://realm-sdks/realm-sdks/dotnet/$ver/
+      }
+#@ end
+---
+name: Publish Release
+"on":
+  workflow_dispatch
+
+jobs:
+  main:
+    runs-on: windows-latest
+    environment: Production
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Download all artifacts
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: main.yml
+        commit: ${{ github.sha }}
+        path: ${{ github.workspace }}/Realm/packages/
+    - name: Extract release notes
+      id: extract-release-notes
+      run: |
+        $changelogContent = Get-Content -Raw -Path "./CHANGELOG.md"
+        $output_file = "./RELEASE_NOTES.md"
+        $regex = "(?sm)^(## \d{1,2}\.\d{1,2}\.\d{1,2}(?:-[a-zA-Z]*\.\d{1,2})? \(\d{4}-\d{2}-\d{2}\))(.+?)(\n## \d{1,2}\.\d{1,2}\.\d{1,2}(?:-[a-zA-Z]*\.\d{1,2})? \(\d{4}-\d{2}-\d{2}\))"
+        $changelogContent -match $regex
+        Set-Content -Path $output_file -Value $Matches[2]
+        echo "::set-output name=release-notes-path::$output_file"
+    - name: Read version
+      id: get-version
+      run: |
+        $nupkgName = ls "Realm/packages" | Select -expandproperty Name | Select-String Realm.Fody
+        $nupkgName -match "(?sm)\d{1,2}\.\d{1,2}\.\d{1,2}(?:-[a-zA-Z]*\.\d{1,2})?"
+        $version = $Matches[0]
+        echo "::set-output name=version::$version"
+    - #@ template.replace(publishGithubRelease())
+    - #@ template.replace(uploadDocsToS3())
+    - #@ template.replace(uploadToNuget("Realm.Fody"))
+    - #@ template.replace(uploadToNuget("Realm"))
+    - #@ template.replace(uploadToNuget("Realm", True))
+    - #@ template.replace(uploadToNpm("io.realm.unity"))

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -59,7 +59,7 @@ jobs:
       run: dotnet nuget push ${{ github.workspace }}/Realm/packages/Realm.Fody.${{ steps.get-version.outputs.version }}/Realm.Fody.${{ steps.get-version.outputs.version }}.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
     - name: NuGet Publish Realm.${{ steps.get-version.outputs.version }}
       run: dotnet nuget push ${{ github.workspace }}/Realm/packages/Realm.${{ steps.get-version.outputs.version }}/Realm.${{ steps.get-version.outputs.version }}.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-    - name: NuGet Publish Realm.${{ steps.get-version.outputs.version }}
+    - name: NuGet Publish Symbols Realm.${{ steps.get-version.outputs.version }}
       run: dotnet nuget push ${{ github.workspace }}/Realm/packages/Realm.${{ steps.get-version.outputs.version }}/Realm.${{ steps.get-version.outputs.version }}.snupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
     - uses: actions/setup-node@v2
       with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,14 +1,14 @@
-name: release
-on:
-  workflow_dispatch
-
+name: Publish Release
+"on": workflow_dispatch
 jobs:
-  publish-to-nuget:
+  main:
     runs-on: windows-latest
-    name: Publish release
+    environment: Production
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        submodules: false
     - name: Download all artifacts
       uses: dawidd6/action-download-artifact@v2
       with:
@@ -31,19 +31,6 @@ jobs:
         $nupkgName -match "(?sm)\d{1,2}\.\d{1,2}\.\d{1,2}(?:-[a-zA-Z]*\.\d{1,2})?"
         $version = $Matches[0]
         echo "::set-output name=version::$version"
-    - name: Upload to nuget
-      run: |
-        $version = ${{ steps.get-version.outputs.version }}
-        echo "Would upload to nuget 'Realm/packages/Realm.Fody.$version.nupkg/Realm.Fody.$version.nupkg'"
-        echo "Would upload to nuget 'Realm/packages/Realm.$version.nupkg/Realm.$version.nupkg'"
-    #     dotnet nuget push "Realm/packages/Realm.Fody.$version.nupkg/Realm.Fody.$version.nupkg" --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-    #     dotnet nuget push "Realm/packages/Realm.$version.nupkg/Realm.$version.nupkg" --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-    - name: Temp - List artifacts
-      run: |
-        ls  ${{ github.workspace }}/Realm/packages/
-    - name: Temp - List Unity package
-      run: |
-        ls  ${{ github.workspace }}/Realm/packages/io.realm.unity-${{ steps.get-version.outputs.version }}.tgz
     - name: Create Github Release
       uses: ncipollo/release-action@v1
       with:
@@ -59,7 +46,6 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.DOCS_S3_ACCESS_KEY }}
         aws-secret-access-key: ${{ secrets.DOCS_S3_SECRET_KEY }}
-        # aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }} # if you have/need it
         aws-region: us-east-2
     - name: Upload docs
       run: |
@@ -69,3 +55,17 @@ jobs:
         {
           aws s3 sync --acl public-read "${{ github.workspace }}\Realm\packages\_site" s3://realm-sdks/realm-sdks/dotnet/$ver/
         }
+    - name: NuGet Publish Realm.Fody.${{ steps.get-version.outputs.version }}
+      run: dotnet nuget push ${{ github.workspace }}/Realm/packages/Realm.Fody.${{ steps.get-version.outputs.version }}/Realm.Fody.${{ steps.get-version.outputs.version }}.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+    - name: NuGet Publish Realm.${{ steps.get-version.outputs.version }}
+      run: dotnet nuget push ${{ github.workspace }}/Realm/packages/Realm.${{ steps.get-version.outputs.version }}/Realm.${{ steps.get-version.outputs.version }}.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+    - name: NuGet Publish Realm.${{ steps.get-version.outputs.version }}
+      run: dotnet nuget push ${{ github.workspace }}/Realm/packages/Realm.${{ steps.get-version.outputs.version }}/Realm.${{ steps.get-version.outputs.version }}.snupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+        registry-url: https://registry.npmjs.org
+    - name: Npm Publish io.realm.unity-${{ steps.get-version.outputs.version }}
+      run: npm publish ${{ github.workspace }}/Realm/packages/io.realm.unity-${{ steps.get-version.outputs.version }}.tgz/io.realm.unity-${{ steps.get-version.outputs.version }}.tgz
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This PR introduces several changes to the release workflow:
1. Renames it to publish-release to better differentiate from prepare-release
2. Adds a template to generate it
3. Enables uploading to nuget
4. Uploads the symbols package for Realm
5. Uploads the unity package to npm
6. Assigns the workflow to the production environment

Fixes https://github.com/realm/realm-dotnet/issues/2491
Fixes https://github.com/realm/realm-dotnet/issues/2582

##  TODO

* [ ] Changelog entry
* [ ] Move S3 secrets to the production environment