### PR TITLE
Fix DynamicAPI.Set(PK) not validating PK equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## vNext (TBD)
 
 ### Fixed
-* None
+* Fixed an issue that manifested in circumventing the check for changing a primary key when using the dynamic API - i.e. `myObj.DynamicApi.Set("Id", "some-new-value")` will now correctly throw a `NotSupportedException` if `"some-new-value"` is different from `myObj`'s primary key value. (PR [#2601](https://github.com/realm/realm-dotnet/pull/2601))
 
 ### Enhancements
 * None

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -605,7 +605,14 @@ namespace Realms
                     throw new ArgumentException($"{_realmObject.ObjectSchema.Name}.{propertyName} is {property.GetDotnetTypeName()} but the supplied value is {value.AsAny().GetType().Name} ({value}).");
                 }
 
-                _realmObject.SetValue(propertyName, value);
+                if (property.IsPrimaryKey)
+                {
+                    _realmObject.SetValueUnique(propertyName, value);
+                }
+                else
+                {
+                    _realmObject.SetValue(propertyName, value);
+                }
             }
 
             /// <summary>

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -217,7 +217,7 @@ namespace Realms
 
             if (!currentValue.Equals(value))
             {
-                throw new InvalidOperationException("Once set, primary key properties may not be modified.");
+                throw new InvalidOperationException($"Once set, primary key properties may not be modified. Current primary key value: {currentValue}, new value: {value}");
             }
         }
 

--- a/Tests/Realm.Tests/Database/AddOrUpdateTests.cs
+++ b/Tests/Realm.Tests/Database/AddOrUpdateTests.cs
@@ -819,8 +819,8 @@ namespace Realms.Tests.Database
             {
                 _realm.Write(() =>
                 {
-                    _realm.Add(new PrimaryKeyStringObject { StringProperty = "1" });
-                    _realm.Add(new PrimaryKeyStringObject { StringProperty = "1" });
+                    _realm.Add(new PrimaryKeyStringObject { Id = "1" });
+                    _realm.Add(new PrimaryKeyStringObject { Id = "1" });
                 });
             }, Throws.TypeOf<RealmDuplicatePrimaryKeyValueException>());
         }

--- a/Tests/Realm.Tests/Database/DynamicAccessTests.cs
+++ b/Tests/Realm.Tests/Database/DynamicAccessTests.cs
@@ -112,6 +112,13 @@ namespace Realms.Tests.Database
             });
         }
 
+        [Test]
+        public void DynamicApi_WhenObjectIsUnmanaged_Throws()
+        {
+            var ato = new AllTypesObject();
+            Assert.That(() => _ = ato.DynamicApi, Throws.TypeOf<NotSupportedException>());
+        }
+
 #if !UNITY // Unity doesn't support generic test cases
         [TestCaseSource(typeof(AccessTests), nameof(AccessTests.SetAndGetValueCases))]
 #endif

--- a/Tests/Realm.Tests/Database/PrimaryKeyTests.cs
+++ b/Tests/Realm.Tests/Database/PrimaryKeyTests.cs
@@ -150,7 +150,9 @@ namespace Realms.Tests.Database
                 });
             });
 
-            Assert.That(ex.Message, Is.EqualTo("Once set, primary key properties may not be modified."));
+            Assert.That(ex.Message, Does.Contain("Once set, primary key properties may not be modified."));
+            Assert.That(ex.Message, Does.Contain(Operator.Convert<RealmValue>(firstValue).ToString()));
+            Assert.That(ex.Message, Does.Contain(Operator.Convert<RealmValue>(secondValue).ToString()));
 
             if (TestHelpers.IsUnity)
             {
@@ -163,7 +165,9 @@ namespace Realms.Tests.Database
 
             ex = Assert.Throws<InvalidOperationException>(() => SetDynamicValue(secondValue));
 
-            Assert.That(ex.Message, Is.EqualTo("Once set, primary key properties may not be modified."));
+            Assert.That(ex.Message, Does.Contain("Once set, primary key properties may not be modified."));
+            Assert.That(ex.Message, Does.Contain(Operator.Convert<RealmValue>(firstValue).ToString()));
+            Assert.That(ex.Message, Does.Contain(Operator.Convert<RealmValue>(secondValue).ToString()));
 
             void SetDynamicValue(object value)
             {
@@ -323,7 +327,9 @@ namespace Realms.Tests.Database
                 });
             });
 
-            Assert.That(ex.Message, Is.EqualTo("Once set, primary key properties may not be modified."));
+            Assert.That(ex.Message, Does.Contain("Once set, primary key properties may not be modified."));
+            Assert.That(ex.Message, Does.Contain(Operator.Convert<RealmValue>(firstValue).ToString()));
+            Assert.That(ex.Message, Does.Contain(Operator.Convert<RealmValue>(secondValue).ToString()));
         }
 
         private RealmObjectBase FindByPKGeneric(Type type, object primaryKeyValue, PKType pkType)

--- a/Tests/Realm.Tests/Database/RealmObjectTests.cs
+++ b/Tests/Realm.Tests/Database/RealmObjectTests.cs
@@ -26,6 +26,7 @@ using System.Xml.Serialization;
 using MongoDB.Bson;
 using NUnit.Framework;
 using Realms.Exceptions;
+using Realms.Schema;
 
 namespace Realms.Tests.Database
 {
@@ -123,6 +124,24 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void RealmObject_ObjectSchema_ReturnsValueWhenManaged()
+        {
+            var person = new Person();
+
+            Assert.That(person.ObjectSchema, Is.Null);
+
+            _realm.Write(() =>
+            {
+                _realm.Add(person);
+            });
+
+            Assert.That(person.ObjectSchema, Is.Not.Null);
+
+            Assert.That(person.ObjectSchema.TryFindProperty(nameof(Person.FirstName), out var property), Is.True);
+            Assert.That(property.Type, Is.EqualTo(PropertyType.NullableString));
+        }
+
+        [Test]
         public void Realm_Find_InvokesOnManaged()
         {
             _realm.Write(() =>
@@ -189,7 +208,7 @@ namespace Realms.Tests.Database
         [Test]
         public void RealmObject_GetHashCode_ChangesAfterAddingToRealm()
         {
-            var objA = new RequiredPrimaryKeyStringObject { StringProperty = "a" };
+            var objA = new RequiredPrimaryKeyStringObject { Id = "a" };
 
             var unmanagedHash = objA.GetHashCode();
 
@@ -209,8 +228,8 @@ namespace Realms.Tests.Database
         [Test]
         public void RealmObject_GetHashCode_IsDifferentForDifferentObjects()
         {
-            var objA = new RequiredPrimaryKeyStringObject { StringProperty = "a" };
-            var objB = new RequiredPrimaryKeyStringObject { StringProperty = "b" };
+            var objA = new RequiredPrimaryKeyStringObject { Id = "a" };
+            var objB = new RequiredPrimaryKeyStringObject { Id = "b" };
 
             Assert.That(objB.GetHashCode(), Is.Not.EqualTo(objA.GetHashCode()), "Different unmanaged objects should have different hash codes");
 
@@ -228,7 +247,7 @@ namespace Realms.Tests.Database
         {
             var obj = _realm.Write(() =>
             {
-                return _realm.Add(new RequiredPrimaryKeyStringObject { StringProperty = "a" });
+                return _realm.Add(new RequiredPrimaryKeyStringObject { Id = "a" });
             });
 
             var objAgain = _realm.Find<RequiredPrimaryKeyStringObject>("a");
@@ -242,7 +261,7 @@ namespace Realms.Tests.Database
         {
             var obj = _realm.Write(() =>
             {
-                return _realm.Add(new RequiredPrimaryKeyStringObject { StringProperty = "a" });
+                return _realm.Add(new RequiredPrimaryKeyStringObject { Id = "a" });
             });
 
             var managedHash = obj.GetHashCode();

--- a/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
@@ -295,10 +295,10 @@ namespace Realms.Tests.Database
         {
             _realm.Write(() =>
             {
-                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'A' });
-                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'B' });
-                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'c' });
-                _realm.Add(new PrimaryKeyCharObject { CharProperty = 'a' });
+                _realm.Add(new PrimaryKeyCharObject { Id = 'A' });
+                _realm.Add(new PrimaryKeyCharObject { Id = 'B' });
+                _realm.Add(new PrimaryKeyCharObject { Id = 'c' });
+                _realm.Add(new PrimaryKeyCharObject { Id = 'a' });
             });
 
             var A = 'A';
@@ -307,44 +307,44 @@ namespace Realms.Tests.Database
             var a = 'a';
             var X = 'X';
 
-            var equality = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty == 'A').ToArray();
-            var varEquality = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty == A).ToArray();
+            var equality = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id == 'A').ToArray();
+            var varEquality = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id == A).ToArray();
 
             // Assert.That(equality.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A' }));
-            Assert.That(varEquality.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A' }));
+            Assert.That(varEquality.Select(p => p.Id), Is.EquivalentTo(new[] { 'A' }));
 
-            var inequality = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty != 'c').ToArray();
-            var varInequality = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty != c).ToArray();
-            Assert.That(inequality.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
-            Assert.That(varInequality.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
+            var inequality = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id != 'c').ToArray();
+            var varInequality = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id != c).ToArray();
+            Assert.That(inequality.Select(p => p.Id), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
+            Assert.That(varInequality.Select(p => p.Id), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
 
-            var lessThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty < 'c').ToArray();
-            var varLessThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty < c).ToArray();
-            Assert.That(lessThan.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
-            Assert.That(varLessThan.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
+            var lessThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id < 'c').ToArray();
+            var varLessThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id < c).ToArray();
+            Assert.That(lessThan.Select(p => p.Id), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
+            Assert.That(varLessThan.Select(p => p.Id), Is.EquivalentTo(new[] { 'A', 'B', 'a' }));
 
-            var lessThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty <= 'c').ToArray();
-            var varLessThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty <= c).ToArray();
-            Assert.That(lessThanOrEqual.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A', 'B', 'a', 'c' }));
-            Assert.That(varLessThanOrEqual.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'A', 'B', 'a', 'c' }));
+            var lessThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id <= 'c').ToArray();
+            var varLessThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id <= c).ToArray();
+            Assert.That(lessThanOrEqual.Select(p => p.Id), Is.EquivalentTo(new[] { 'A', 'B', 'a', 'c' }));
+            Assert.That(varLessThanOrEqual.Select(p => p.Id), Is.EquivalentTo(new[] { 'A', 'B', 'a', 'c' }));
 
-            var greaterThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty > 'a').ToArray();
-            var varGreaterThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty > a).ToArray();
-            Assert.That(greaterThan.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'c' }));
-            Assert.That(varGreaterThan.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'c' }));
+            var greaterThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id > 'a').ToArray();
+            var varGreaterThan = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id > a).ToArray();
+            Assert.That(greaterThan.Select(p => p.Id), Is.EquivalentTo(new[] { 'c' }));
+            Assert.That(varGreaterThan.Select(p => p.Id), Is.EquivalentTo(new[] { 'c' }));
 
-            var greaterThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty >= 'B').ToArray();
-            var varGreaterThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty >= B).ToArray();
-            Assert.That(greaterThanOrEqual.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'B', 'a', 'c' }));
-            Assert.That(varGreaterThanOrEqual.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'B', 'a', 'c' }));
+            var greaterThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id >= 'B').ToArray();
+            var varGreaterThanOrEqual = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id >= B).ToArray();
+            Assert.That(greaterThanOrEqual.Select(p => p.Id), Is.EquivalentTo(new[] { 'B', 'a', 'c' }));
+            Assert.That(varGreaterThanOrEqual.Select(p => p.Id), Is.EquivalentTo(new[] { 'B', 'a', 'c' }));
 
-            var between = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty > 'A' && p.CharProperty < 'a').ToArray();
-            var varBetween = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty > A && p.CharProperty < a).ToArray();
-            Assert.That(between.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'B' }));
-            Assert.That(varBetween.Select(p => p.CharProperty), Is.EquivalentTo(new[] { 'B' }));
+            var between = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id > 'A' && p.Id < 'a').ToArray();
+            var varBetween = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id > A && p.Id < a).ToArray();
+            Assert.That(between.Select(p => p.Id), Is.EquivalentTo(new[] { 'B' }));
+            Assert.That(varBetween.Select(p => p.Id), Is.EquivalentTo(new[] { 'B' }));
 
-            var missing = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty == 'X').ToArray();
-            var varMissing = _realm.All<PrimaryKeyCharObject>().Where(p => p.CharProperty == X).ToArray();
+            var missing = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id == 'X').ToArray();
+            var varMissing = _realm.All<PrimaryKeyCharObject>().Where(p => p.Id == X).ToArray();
             Assert.That(missing.Length, Is.EqualTo(0));
             Assert.That(varMissing.Length, Is.EqualTo(0));
         }
@@ -354,47 +354,47 @@ namespace Realms.Tests.Database
         {
             _realm.Write(() =>
             {
-                _realm.Add(new PrimaryKeyInt16Object { Int16Property = 0 });
-                _realm.Add(new PrimaryKeyInt16Object { Int16Property = 1 });
-                _realm.Add(new PrimaryKeyInt16Object { Int16Property = 2 });
+                _realm.Add(new PrimaryKeyInt16Object { Id = 0 });
+                _realm.Add(new PrimaryKeyInt16Object { Id = 1 });
+                _realm.Add(new PrimaryKeyInt16Object { Id = 2 });
             });
 
             short zero = 0;
             short one = 1;
             short two = 2;
 
-            var equality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property == 0).ToArray().Select(o => o.Int16Property);
-            var varEquality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property == zero).ToArray().Select(o => o.Int16Property);
+            var equality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id == 0).ToArray().Select(o => o.Id);
+            var varEquality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id == zero).ToArray().Select(o => o.Id);
             Assert.That(equality, Is.EquivalentTo(new short[] { 0 }));
             Assert.That(varEquality, Is.EquivalentTo(new short[] { 0 }));
 
-            var inequality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property != 0).ToArray().Select(o => o.Int16Property);
-            var varInequality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property != zero).ToArray().Select(o => o.Int16Property);
+            var inequality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id != 0).ToArray().Select(o => o.Id);
+            var varInequality = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id != zero).ToArray().Select(o => o.Id);
             Assert.That(inequality, Is.EquivalentTo(new short[] { 1, 2 }));
             Assert.That(varInequality, Is.EquivalentTo(new short[] { 1, 2 }));
 
-            var lessThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property < 1).ToArray().Select(o => o.Int16Property);
-            var varLessThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property < one).ToArray().Select(o => o.Int16Property);
+            var lessThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id < 1).ToArray().Select(o => o.Id);
+            var varLessThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id < one).ToArray().Select(o => o.Id);
             Assert.That(lessThan, Is.EquivalentTo(new short[] { 0 }));
             Assert.That(varLessThan, Is.EquivalentTo(new short[] { 0 }));
 
-            var lessThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property <= 1).ToArray().Select(o => o.Int16Property);
-            var varLessThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property <= one).ToArray().Select(o => o.Int16Property);
+            var lessThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id <= 1).ToArray().Select(o => o.Id);
+            var varLessThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id <= one).ToArray().Select(o => o.Id);
             Assert.That(lessThanOrEqual, Is.EquivalentTo(new short[] { 0, 1 }));
             Assert.That(varLessThanOrEqual, Is.EquivalentTo(new short[] { 0, 1 }));
 
-            var greaterThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property > 1).ToArray().Select(o => o.Int16Property);
-            var varGreaterThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property > one).ToArray().Select(o => o.Int16Property);
+            var greaterThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id > 1).ToArray().Select(o => o.Id);
+            var varGreaterThan = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id > one).ToArray().Select(o => o.Id);
             Assert.That(greaterThan, Is.EquivalentTo(new short[] { 2 }));
             Assert.That(varGreaterThan, Is.EquivalentTo(new short[] { 2 }));
 
-            var greaterThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property >= 1).ToArray().Select(o => o.Int16Property);
-            var varGreaterThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property >= one).ToArray().Select(o => o.Int16Property);
+            var greaterThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id >= 1).ToArray().Select(o => o.Id);
+            var varGreaterThanOrEqual = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id >= one).ToArray().Select(o => o.Id);
             Assert.That(greaterThanOrEqual, Is.EquivalentTo(new short[] { 1, 2 }));
             Assert.That(varGreaterThanOrEqual, Is.EquivalentTo(new short[] { 1, 2 }));
 
-            var between = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property > 0 && o.Int16Property < 2).ToArray().Select(o => o.Int16Property);
-            var varBetween = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Int16Property > zero && o.Int16Property < two).ToArray().Select(o => o.Int16Property);
+            var between = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id > 0 && o.Id < 2).ToArray().Select(o => o.Id);
+            var varBetween = _realm.All<PrimaryKeyInt16Object>().Where(o => o.Id > zero && o.Id < two).ToArray().Select(o => o.Id);
             Assert.That(between, Is.EquivalentTo(new short[] { 1 }));
             Assert.That(varBetween, Is.EquivalentTo(new short[] { 1 }));
         }
@@ -404,47 +404,47 @@ namespace Realms.Tests.Database
         {
             _realm.Write(() =>
             {
-                _realm.Add(new PrimaryKeyByteObject { ByteProperty = 0 });
-                _realm.Add(new PrimaryKeyByteObject { ByteProperty = 1 });
-                _realm.Add(new PrimaryKeyByteObject { ByteProperty = 2 });
+                _realm.Add(new PrimaryKeyByteObject { Id = 0 });
+                _realm.Add(new PrimaryKeyByteObject { Id = 1 });
+                _realm.Add(new PrimaryKeyByteObject { Id = 2 });
             });
 
             byte zero = 0;
             byte one = 1;
             byte two = 2;
 
-            var equality = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty == 0).ToArray().Select(o => o.ByteProperty);
-            var varEquality = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty == zero).ToArray().Select(o => o.ByteProperty);
+            var equality = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id == 0).ToArray().Select(o => o.Id);
+            var varEquality = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id == zero).ToArray().Select(o => o.Id);
             Assert.That(equality, Is.EquivalentTo(new byte[] { 0 }));
             Assert.That(varEquality, Is.EquivalentTo(new byte[] { 0 }));
 
-            var inequality = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty != 0).ToArray().Select(o => o.ByteProperty);
-            var varInequality = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty != zero).ToArray().Select(o => o.ByteProperty);
+            var inequality = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id != 0).ToArray().Select(o => o.Id);
+            var varInequality = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id != zero).ToArray().Select(o => o.Id);
             Assert.That(inequality, Is.EquivalentTo(new byte[] { 1, 2 }));
             Assert.That(varInequality, Is.EquivalentTo(new byte[] { 1, 2 }));
 
-            var lessThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty < 1).ToArray().Select(o => o.ByteProperty);
-            var varLessThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty < one).ToArray().Select(o => o.ByteProperty);
+            var lessThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id < 1).ToArray().Select(o => o.Id);
+            var varLessThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id < one).ToArray().Select(o => o.Id);
             Assert.That(lessThan, Is.EquivalentTo(new byte[] { 0 }));
             Assert.That(varLessThan, Is.EquivalentTo(new byte[] { 0 }));
 
-            var lessThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty <= 1).ToArray().Select(o => o.ByteProperty);
-            var varLessThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty <= one).ToArray().Select(o => o.ByteProperty);
+            var lessThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id <= 1).ToArray().Select(o => o.Id);
+            var varLessThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id <= one).ToArray().Select(o => o.Id);
             Assert.That(lessThanOrEqual, Is.EquivalentTo(new byte[] { 0, 1 }));
             Assert.That(varLessThanOrEqual, Is.EquivalentTo(new byte[] { 0, 1 }));
 
-            var greaterThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty > 1).ToArray().Select(o => o.ByteProperty);
-            var varGreaterThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty > one).ToArray().Select(o => o.ByteProperty);
+            var greaterThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id > 1).ToArray().Select(o => o.Id);
+            var varGreaterThan = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id > one).ToArray().Select(o => o.Id);
             Assert.That(greaterThan, Is.EquivalentTo(new byte[] { 2 }));
             Assert.That(varGreaterThan, Is.EquivalentTo(new byte[] { 2 }));
 
-            var greaterThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty >= 1).ToArray().Select(o => o.ByteProperty);
-            var varGreaterThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty >= one).ToArray().Select(o => o.ByteProperty);
+            var greaterThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id >= 1).ToArray().Select(o => o.Id);
+            var varGreaterThanOrEqual = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id >= one).ToArray().Select(o => o.Id);
             Assert.That(greaterThanOrEqual, Is.EquivalentTo(new byte[] { 1, 2 }));
             Assert.That(varGreaterThanOrEqual, Is.EquivalentTo(new byte[] { 1, 2 }));
 
-            var between = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty > 0 && o.ByteProperty < 2).ToArray().Select(o => o.ByteProperty);
-            var varBetween = _realm.All<PrimaryKeyByteObject>().Where(o => o.ByteProperty > zero && o.ByteProperty < two).ToArray().Select(o => o.ByteProperty);
+            var between = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id > 0 && o.Id < 2).ToArray().Select(o => o.Id);
+            var varBetween = _realm.All<PrimaryKeyByteObject>().Where(o => o.Id > zero && o.Id < two).ToArray().Select(o => o.Id);
             Assert.That(between, Is.EquivalentTo(new byte[] { 1 }));
             Assert.That(varBetween, Is.EquivalentTo(new byte[] { 1 }));
         }

--- a/Tests/Realm.Tests/Database/TestObjects.cs
+++ b/Tests/Realm.Tests/Database/TestObjects.cs
@@ -634,42 +634,42 @@ namespace Realms.Tests
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public char CharProperty { get; set; }
+        public char Id { get; set; }
     }
 
     public class PrimaryKeyByteObject : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public byte ByteProperty { get; set; }
+        public byte Id { get; set; }
     }
 
     public class PrimaryKeyInt16Object : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public short Int16Property { get; set; }
+        public short Id { get; set; }
     }
 
     public class PrimaryKeyInt32Object : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public int Int32Property { get; set; }
+        public int Id { get; set; }
     }
 
     public class PrimaryKeyInt64Object : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public long Int64Property { get; set; }
+        public long Id { get; set; }
     }
 
     public class PrimaryKeyStringObject : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public string StringProperty { get; set; }
+        public string Id { get; set; }
 
         public string Value { get; set; }
     }
@@ -679,7 +679,7 @@ namespace Realms.Tests
         [PrimaryKey]
         [Required]
         [MapTo("_id")]
-        public string StringProperty { get; set; }
+        public string Id { get; set; }
 
         public string Value { get; set; }
     }
@@ -688,63 +688,63 @@ namespace Realms.Tests
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public ObjectId ObjectIdProperty { get; set; }
+        public ObjectId Id { get; set; }
     }
 
     public class PrimaryKeyGuidObject : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public Guid GuidProperty { get; set; }
+        public Guid Id { get; set; }
     }
 
     public class PrimaryKeyNullableCharObject : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public char? CharProperty { get; set; }
+        public char? Id { get; set; }
     }
 
     public class PrimaryKeyNullableByteObject : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public byte? ByteProperty { get; set; }
+        public byte? Id { get; set; }
     }
 
     public class PrimaryKeyNullableInt16Object : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public short? Int16Property { get; set; }
+        public short? Id { get; set; }
     }
 
     public class PrimaryKeyNullableInt32Object : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public int? Int32Property { get; set; }
+        public int? Id { get; set; }
     }
 
     public class PrimaryKeyNullableInt64Object : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public long? Int64Property { get; set; }
+        public long? Id { get; set; }
     }
 
     public class PrimaryKeyNullableObjectIdObject : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public ObjectId? ObjectIdProperty { get; set; }
+        public ObjectId? Id { get; set; }
     }
 
     public class PrimaryKeyNullableGuidObject : RealmObject
     {
         [PrimaryKey]
         [MapTo("_id")]
-        public Guid? GuidProperty { get; set; }
+        public Guid? Id { get; set; }
     }
 
     public class ClassWithUnqueryableMembers : RealmObject

--- a/Tests/Realm.Tests/Sync/AppTests.cs
+++ b/Tests/Realm.Tests/Sync/AppTests.cs
@@ -87,7 +87,7 @@ namespace Realms.Tests.Sync
                 using var realm = await GetRealmAsync(config);
                 realm.Write(() =>
                 {
-                    realm.Add(new PrimaryKeyStringObject { StringProperty = Guid.NewGuid().ToString() });
+                    realm.Add(new PrimaryKeyStringObject { Id = Guid.NewGuid().ToString() });
                 });
 
                 await WaitForUploadAsync(realm);
@@ -113,7 +113,7 @@ namespace Realms.Tests.Sync
                 using var realm = await GetRealmAsync(config);
                 realm.Write(() =>
                 {
-                    realm.Add(new PrimaryKeyStringObject { StringProperty = Guid.NewGuid().ToString() });
+                    realm.Add(new PrimaryKeyStringObject { Id = Guid.NewGuid().ToString() });
                 });
 
                 await WaitForUploadAsync(realm);

--- a/Tests/Realm.Tests/Sync/PartitionKeyTests.cs
+++ b/Tests/Realm.Tests/Sync/PartitionKeyTests.cs
@@ -102,52 +102,52 @@ namespace Realms.Tests.Sync
             var fromRealm1 = realm1.Write(() =>
             {
                 return (
-                    realm1.Add(new PrimaryKeyInt64Object { Int64Property = 1234567890987654321 }),
-                    realm1.Add(new PrimaryKeyObjectIdObject { ObjectIdProperty = ObjectId.GenerateNewId() }),
-                    realm1.Add(new PrimaryKeyGuidObject { GuidProperty = Guid.NewGuid() }),
-                    realm1.Add(new RequiredPrimaryKeyStringObject { StringProperty = "abcdef" }),
-                    realm1.Add(new PrimaryKeyNullableInt64Object { Int64Property = null }),
-                    realm1.Add(new PrimaryKeyNullableObjectIdObject { ObjectIdProperty = null }),
-                    realm1.Add(new PrimaryKeyNullableGuidObject { GuidProperty = null }),
-                    realm1.Add(new PrimaryKeyStringObject { StringProperty = null }));
+                    realm1.Add(new PrimaryKeyInt64Object { Id = 1234567890987654321 }),
+                    realm1.Add(new PrimaryKeyObjectIdObject { Id = ObjectId.GenerateNewId() }),
+                    realm1.Add(new PrimaryKeyGuidObject { Id = Guid.NewGuid() }),
+                    realm1.Add(new RequiredPrimaryKeyStringObject { Id = "abcdef" }),
+                    realm1.Add(new PrimaryKeyNullableInt64Object { Id = null }),
+                    realm1.Add(new PrimaryKeyNullableObjectIdObject { Id = null }),
+                    realm1.Add(new PrimaryKeyNullableGuidObject { Id = null }),
+                    realm1.Add(new PrimaryKeyStringObject { Id = null }));
             });
 
             await WaitForUploadAsync(realm1);
             await WaitForDownloadAsync(realm2);
 
-            Assert.That(realm2.Find<PrimaryKeyInt64Object>(fromRealm1.Item1.Int64Property)?.IsValid, Is.True);
-            Assert.That(realm2.Find<PrimaryKeyObjectIdObject>(fromRealm1.Item2.ObjectIdProperty)?.IsValid, Is.True);
-            Assert.That(realm2.Find<PrimaryKeyGuidObject>(fromRealm1.Item3.GuidProperty)?.IsValid, Is.True);
-            Assert.That(realm2.Find<RequiredPrimaryKeyStringObject>(fromRealm1.Item4.StringProperty)?.IsValid, Is.True);
-            Assert.That(realm2.Find<PrimaryKeyNullableInt64Object>(fromRealm1.Item5.Int64Property)?.IsValid, Is.True);
-            Assert.That(realm2.Find<PrimaryKeyNullableGuidObject>(fromRealm1.Item6.ObjectIdProperty)?.IsValid, Is.True);
-            Assert.That(realm2.Find<PrimaryKeyNullableGuidObject>(fromRealm1.Item7.GuidProperty)?.IsValid, Is.True);
-            Assert.That(realm2.Find<PrimaryKeyStringObject>(fromRealm1.Item8.StringProperty)?.IsValid, Is.True);
+            Assert.That(realm2.Find<PrimaryKeyInt64Object>(fromRealm1.Item1.Id)?.IsValid, Is.True);
+            Assert.That(realm2.Find<PrimaryKeyObjectIdObject>(fromRealm1.Item2.Id)?.IsValid, Is.True);
+            Assert.That(realm2.Find<PrimaryKeyGuidObject>(fromRealm1.Item3.Id)?.IsValid, Is.True);
+            Assert.That(realm2.Find<RequiredPrimaryKeyStringObject>(fromRealm1.Item4.Id)?.IsValid, Is.True);
+            Assert.That(realm2.Find<PrimaryKeyNullableInt64Object>(fromRealm1.Item5.Id)?.IsValid, Is.True);
+            Assert.That(realm2.Find<PrimaryKeyNullableGuidObject>(fromRealm1.Item6.Id)?.IsValid, Is.True);
+            Assert.That(realm2.Find<PrimaryKeyNullableGuidObject>(fromRealm1.Item7.Id)?.IsValid, Is.True);
+            Assert.That(realm2.Find<PrimaryKeyStringObject>(fromRealm1.Item8.Id)?.IsValid, Is.True);
 
             var fromRealm2 = realm2.Write(() =>
             {
                 return (
-                    realm2.Add(new PrimaryKeyInt64Object { Int64Property = 0 }),
-                    realm2.Add(new PrimaryKeyObjectIdObject { ObjectIdProperty = ObjectId.GenerateNewId() }),
-                    realm2.Add(new PrimaryKeyGuidObject { GuidProperty = Guid.NewGuid() }),
-                    realm2.Add(new RequiredPrimaryKeyStringObject { StringProperty = string.Empty }),
-                    realm2.Add(new PrimaryKeyNullableInt64Object { Int64Property = 123 }),
-                    realm2.Add(new PrimaryKeyNullableObjectIdObject { ObjectIdProperty = ObjectId.GenerateNewId() }),
-                    realm2.Add(new PrimaryKeyNullableGuidObject { GuidProperty = Guid.NewGuid() }),
-                    realm2.Add(new PrimaryKeyStringObject { StringProperty = "hola" }));
+                    realm2.Add(new PrimaryKeyInt64Object { Id = 0 }),
+                    realm2.Add(new PrimaryKeyObjectIdObject { Id = ObjectId.GenerateNewId() }),
+                    realm2.Add(new PrimaryKeyGuidObject { Id = Guid.NewGuid() }),
+                    realm2.Add(new RequiredPrimaryKeyStringObject { Id = string.Empty }),
+                    realm2.Add(new PrimaryKeyNullableInt64Object { Id = 123 }),
+                    realm2.Add(new PrimaryKeyNullableObjectIdObject { Id = ObjectId.GenerateNewId() }),
+                    realm2.Add(new PrimaryKeyNullableGuidObject { Id = Guid.NewGuid() }),
+                    realm2.Add(new PrimaryKeyStringObject { Id = "hola" }));
             });
 
             await WaitForUploadAsync(realm2);
             await WaitForDownloadAsync(realm1);
 
-            Assert.That(realm1.Find<PrimaryKeyInt64Object>(fromRealm2.Item1.Int64Property)?.IsValid, Is.True);
-            Assert.That(realm1.Find<PrimaryKeyObjectIdObject>(fromRealm2.Item2.ObjectIdProperty)?.IsValid, Is.True);
-            Assert.That(realm1.Find<PrimaryKeyGuidObject>(fromRealm2.Item3.GuidProperty)?.IsValid, Is.True);
-            Assert.That(realm1.Find<RequiredPrimaryKeyStringObject>(fromRealm2.Item4.StringProperty)?.IsValid, Is.True);
-            Assert.That(realm1.Find<PrimaryKeyNullableInt64Object>(fromRealm2.Item5.Int64Property)?.IsValid, Is.True);
-            Assert.That(realm1.Find<PrimaryKeyNullableObjectIdObject>(fromRealm2.Item6.ObjectIdProperty)?.IsValid, Is.True);
-            Assert.That(realm1.Find<PrimaryKeyNullableGuidObject>(fromRealm2.Item7.GuidProperty)?.IsValid, Is.True);
-            Assert.That(realm1.Find<PrimaryKeyStringObject>(fromRealm2.Item8.StringProperty)?.IsValid, Is.True);
+            Assert.That(realm1.Find<PrimaryKeyInt64Object>(fromRealm2.Item1.Id)?.IsValid, Is.True);
+            Assert.That(realm1.Find<PrimaryKeyObjectIdObject>(fromRealm2.Item2.Id)?.IsValid, Is.True);
+            Assert.That(realm1.Find<PrimaryKeyGuidObject>(fromRealm2.Item3.Id)?.IsValid, Is.True);
+            Assert.That(realm1.Find<RequiredPrimaryKeyStringObject>(fromRealm2.Item4.Id)?.IsValid, Is.True);
+            Assert.That(realm1.Find<PrimaryKeyNullableInt64Object>(fromRealm2.Item5.Id)?.IsValid, Is.True);
+            Assert.That(realm1.Find<PrimaryKeyNullableObjectIdObject>(fromRealm2.Item6.Id)?.IsValid, Is.True);
+            Assert.That(realm1.Find<PrimaryKeyNullableGuidObject>(fromRealm2.Item7.Id)?.IsValid, Is.True);
+            Assert.That(realm1.Find<PrimaryKeyStringObject>(fromRealm2.Item8.Id)?.IsValid, Is.True);
         }
     }
 }


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This adds additional tests for RealmObjectBase, which uncovered a bug with setting the PK property via the dynamic API - it didn't go through the PK equality check and happily sent the value down to native. This is now fixed, but writing the tests required renaming a bunch of properties, resulting in a lot of noise in the PR. I've highlighted the important bits.

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
