### PR TITLE
Test net6 on win81

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -362,7 +362,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        os: [ macos-latest, windows-latest, ubuntu-latest, win81 ]
         targetFramework: [ netcoreapp3.1, net5.0, net6.0 ]
     steps:
       - #@ template.replace(checkoutCode())
@@ -374,20 +374,6 @@ jobs:
           include-prerelease: true
       - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After"))
       - #@ publishTestsResults("TestResults.xml", ".NET (${{ matrix.os }}, ${{ matrix.targetFramework }})")
-  #! This should be folded in run-tests-netcore once we fix the TLS issues on win81
-  run-tests-netcore-win81:
-    name: Test .NET on Win81
-    needs: build-packages
-    runs-on: win81
-    strategy:
-      fail-fast: false
-      matrix:
-        targetFramework: [ netcoreapp3.1, net5.0 ]
-    steps:
-      - #@ template.replace(checkoutCode())
-      - #@ template.replace(fetchPackageArtifacts())
-      - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After"))
-      - #@ publishTestsResults("TestResults.xml", ".NET (win81, ${{ matrix.targetFramework }})")
   run-tests-xamarin-macos:
     runs-on: macos-latest
     name: Test Xamarin.macOS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -502,6 +502,7 @@ jobs:
         - macos-latest
         - windows-latest
         - ubuntu-latest
+        - win81
         targetFramework:
         - netcoreapp3.1
         - net5.0
@@ -545,50 +546,6 @@ jobs:
         files: TestResults.xml
         comment_mode: "off"
         check_name: Results .NET (${{ matrix.os }}, ${{ matrix.targetFramework }})
-  run-tests-netcore-win81:
-    name: Test .NET on Win81
-    needs: build-packages
-    runs-on: win81
-    strategy:
-      fail-fast: false
-      matrix:
-        targetFramework:
-        - netcoreapp3.1
-        - net5.0
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        submodules: false
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Register csc problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/csc.json"
-    - name: Register msvc problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/msvc.json"
-    - name: Fetch Realm
-      uses: actions/download-artifact@v2
-      with:
-        name: Realm.${{ needs.build-packages.outputs.package_version }}
-        path: ${{ github.workspace }}/Realm/packages/
-    - name: Fetch Realm.Fody
-      uses: actions/download-artifact@v2
-      with:
-        name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}
-        path: ${{ github.workspace }}/Realm/packages/
-    - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.targetFramework }} -r ${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }} -p:AdditionalFrameworks=${{ matrix.targetFramework }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} --no-self-contained
-    - name: Output executable path
-      id: dotnet-publish
-      run: echo '::set-output name=executable-path::./Tests/Realm.Tests/bin/Release/${{ matrix.targetFramework }}/${{ (runner.os == 'macOS' && 'osx-x64') || (runner.os == 'Windows' && 'win-x64') || (runner.os == 'Linux' && 'linux-x64') || '???' }}'
-    - name: Run the tests
-      run: ${{ steps.dotnet-publish.outputs.executable-path }}/Realm.Tests --result=TestResults.xml --labels=After
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      if: always()
-      with:
-        files: TestResults.xml
-        comment_mode: "off"
-        check_name: Results .NET (win81, ${{ matrix.targetFramework }})
   run-tests-xamarin-macos:
     runs-on: macos-latest
     name: Test Xamarin.macOS


### PR DESCRIPTION
Start running Win81 tests using net6.0 now that the TLS issues have been resolved.