### PR TITLE
Add two tests to verify bundled Sync Realms can actually sync.

### DIFF
--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -359,6 +359,126 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
+        public void WriteCopy_DoesReceiveNewData([Values(true, false)] bool originalEncrypted,
+                                                                 [Values(true, false)] bool copyEncrypted)
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                var partition = Guid.NewGuid().ToString();
+
+                var originalConfig = await GetIntegrationConfigAsync(partition);
+                if (originalEncrypted)
+                {
+                    originalConfig.EncryptionKey = TestHelpers.GetEncryptionKey(42);
+                }
+
+                var copyConfig = await GetIntegrationConfigAsync(partition);
+                Assert.That(originalConfig.Partition, Is.EqualTo(copyConfig.Partition));
+                if (copyEncrypted)
+                {
+                    copyConfig.EncryptionKey = TestHelpers.GetEncryptionKey(14);
+                }
+
+                File.Delete(copyConfig.DatabasePath);
+
+                using var originalRealm = GetRealm(originalConfig);
+
+                AddDummyData(originalRealm, true);
+
+                await WaitForUploadAsync(originalRealm);
+                await WaitForDownloadAsync(originalRealm);
+
+                originalRealm.WriteCopy(copyConfig);
+
+                AddDummyData(originalRealm, true);
+                await WaitForUploadAsync(originalRealm);
+
+                TaskCompletionSource<Exception> tcs = new TaskCompletionSource<Exception>();
+                Session.Error += (sender, args) =>
+                {
+                    tcs.TrySetResult(args.Exception);
+                };
+
+                using var copiedRealm = GetRealm(copyConfig);
+                Assert.AreEqual(copiedRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), originalRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count() / 2);
+
+                // TODO: This wait is only used while the bug in Core exists that fails the download. As soon as it is fixed we can re-work this to not wait.
+                await Task.Delay(1000);
+                var session = copiedRealm.GetSession();
+                var result = await Task.WhenAny(tcs.Task, session.WaitForDownloadAsync());
+                session.CloseHandle();
+
+                if (result == tcs.Task)
+                {
+                    Assert.Fail($"Session exception has occured while waiting for download: {tcs.Task.Result}");
+                }
+
+                Assert.AreEqual(copiedRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), originalRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count());
+            });
+        }
+
+        [Test]
+        public void WriteCopy_CanUploadData([Values(true, false)] bool originalEncrypted,
+                                                                 [Values(true, false)] bool copyEncrypted)
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                var partition = Guid.NewGuid().ToString();
+
+                var originalConfig = await GetIntegrationConfigAsync(partition);
+                if (originalEncrypted)
+                {
+                    originalConfig.EncryptionKey = TestHelpers.GetEncryptionKey(42);
+                }
+
+                var copyConfig = await GetIntegrationConfigAsync(partition);
+                Assert.That(originalConfig.Partition, Is.EqualTo(copyConfig.Partition));
+                if (copyEncrypted)
+                {
+                    copyConfig.EncryptionKey = TestHelpers.GetEncryptionKey(14);
+                }
+
+                File.Delete(copyConfig.DatabasePath);
+
+                using var originalRealm = GetRealm(originalConfig);
+
+                AddDummyData(originalRealm, true);
+
+                await WaitForUploadAsync(originalRealm);
+                await WaitForDownloadAsync(originalRealm);
+
+                originalRealm.WriteCopy(copyConfig);
+
+                TaskCompletionSource<Exception> tcs = new TaskCompletionSource<Exception>();
+                Session.Error += (sender, args) =>
+                {
+                    tcs.TrySetResult(args.Exception);
+                };
+
+                using var copiedRealm = GetRealm(copyConfig);
+                Assert.AreEqual(copiedRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), originalRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count());
+
+                AddDummyData(copiedRealm, true);
+
+                Assert.That(copiedRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count() > originalRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count());
+
+                // TODO: This wait is only used while the bug in Core exists that fails the download. As soon as it is fixed we can re-work this to not wait.
+                await Task.Delay(1000);
+                var session = copiedRealm.GetSession();
+                var result = await Task.WhenAny(tcs.Task, session.WaitForUploadAsync());
+                session.CloseHandle();
+
+                if (result == tcs.Task)
+                {
+                    Assert.Fail($"Session exception has occured while waiting for download: {tcs.Task.Result}");
+                }
+
+                await WaitForDownloadAsync(originalRealm);
+                Assert.AreEqual(copiedRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), originalRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count());
+            });
+        }
+
+        [Test]
         public void WriteCopy_FailsWhenPartitionsDiffer([Values(true, false)] bool originalEncrypted,
                                                                  [Values(true, false)] bool copyEncrypted)
         {


### PR DESCRIPTION
This PR adds two tests to verify a bundled Sync Realm can sync correctly.

It will remain a draft until the Core fix is merged, see https://github.com/realm/realm-core/pull/4878.
The tests are written to provoke the Core bug and need to be updated (e.g. the `Delay` needs to be removed again) as soon as the fix is merged.

##  TODO

* [X] Changelog entry
* [X] Tests (if applicable)
