### PR TITLE
Minor refactoring of uploading artifacts in main.yml template

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -28,20 +28,11 @@ with:
   key: #@ key
 #@ end
 
-#@ def storeWrapperBinaries(outputVar):
-name: Store artifacts
+#@ def uploadArtifacts(artifactName, relPath, retentionDays = "${{ github.event_name != 'pull_request' && 30 || 1 }}"):
+name: #@ "Store artifacts for " + artifactName
 uses: #@ actionUploadArtifact
 with:
-  name: #@ outputVar
-  path: wrappers/build/**
-  retention-days: 1
-#@ end
-
-#@ def uploadArtifacts(titleName, uploadName, relPath, retentionDays = "${{ github.event_name != 'pull_request' && 30 || 1 }}"):
-name: #@ "Store artifacts for " + titleName
-uses: #@ actionUploadArtifact
-with:
-  name: #@ uploadName
+  name: #@ artifactName
   path: #@ "${{ github.workspace }}/" + relPath
   retention-days: #@ retentionDays
 #@ end
@@ -56,7 +47,7 @@ steps:
   - name: Build wrappers
     run: #@ getWrapperBuildCommand(cmd)
     if: #@ wrappersCacheCondition
-  - #@ storeWrapperBinaries(outputVar)
+  - #@ uploadArtifacts(outputVar, "wrappers/build/**", 1)
 #@ end
 
 #@ def setupWin81SDK():
@@ -85,7 +76,7 @@ steps:
 #@ finalPkgName = "io.realm.unity-" + "${{ steps.find-nupkg-version.outputs.package_version }}.tgz"
   - name: #@ "Build Unity"
     run: #@ "dotnet run --project Tools/SetupUnityPackage/ -- realm --packages-path Realm/packages --pack"
-  - #@ uploadArtifacts("Unity", finalPkgName, "Realm/Realm.Unity/" + finalPkgName)
+  - #@ uploadArtifacts(finalPkgName, "Realm/Realm.Unity/" + finalPkgName)
 #@ end
 
 #@ def buildDocs():
@@ -109,19 +100,14 @@ steps:
     run: |
       C:\docfx\docfx Docs/docfx.json
       Compress-Archive -Path Docs/_site -DestinationPath "Realm/packages/Docs.zip"
-  - name: Store docs artifacts
+  - _: #@ template.replace(uploadArtifacts("Docs.zip", "Realm/packages/Docs.zip"))
     if: #@ docsCondition
-    uses: #@ actionUploadArtifact
-    with:
-      name: Docs.zip
-      path: ${{ github.workspace }}/Realm/packages/Docs.zip
-      retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
 #@ end
 
 #@ def uploadPackageArtifacts():
 #@ for pkgName in [ 'Realm.Fody', 'Realm' ]:
 #@  finalPkgName = pkgName + ".${{ steps.find-nupkg-version.outputs.package_version }}"
-  - #@ uploadArtifacts(pkgName, finalPkgName, "Realm/packages/" + finalPkgName + ".*nupkg")
+  - #@ uploadArtifacts(finalPkgName, "Realm/packages/" + finalPkgName + ".*nupkg")
 #@ end
 #@ end
 
@@ -268,7 +254,7 @@ jobs:
           options: -v ${{ github.workspace }}:/work
           run: #@ getWrapperBuildCommand("/work/wrappers/build.sh")
         if: #@ wrappersCacheCondition
-      - #@ storeWrapperBinaries("wrappers-linux")
+      - #@ uploadArtifacts("wrappers-linux", "wrappers/build/**", 1)
   build-wrappers-android:
     runs-on: ubuntu-20.04
     name: Wrappers Android
@@ -329,7 +315,7 @@ jobs:
       - #@ template.replace(buildDocs())
       - #@ template.replace(uploadPackageArtifacts())
       - #@ template.replace(buildUnityPackage())
-      - #@ uploadArtifacts("ExtractedChangelog.md", "ExtractedChangelog", "Realm/Realm/ExtractedChangelog.md")
+      - #@ uploadArtifacts("ExtractedChangelog", "Realm/Realm/ExtractedChangelog.md")
   run-tests-net-framework:
     runs-on: windows-latest
     name: Test .NET Framework
@@ -499,4 +485,4 @@ jobs:
           file: ${{ github.workspace }}/BenchmarkDotNet.Artifacts/results/${{ steps.find-results-file.outputs.benchmark-results }}
           dashboard-path: dashboard.charts
           nuget-package: ${{ github.workspace }}/Realm/packages/Realm.${{ needs.build-packages.outputs.package_version }}.nupkg
-      - #@ uploadArtifacts("Charts Dashboard", "dashboard.charts", "dashboard.charts", "30")
+      - #@ uploadArtifacts("dashboard.charts", "dashboard.charts", 30)

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -37,6 +37,15 @@ with:
   retention-days: 1
 #@ end
 
+#@ def uploadArtifacts(titleName, uploadName, relPath, retentionDays = "${{ github.event_name != 'pull_request' && 30 || 1 }}"):
+name: #@ "Store artifacts for " + titleName
+uses: #@ actionUploadArtifact
+with:
+  name: #@ uploadName
+  path: #@ "${{ github.workspace }}/" + relPath
+  retention-days: #@ retentionDays
+#@ end
+
 #@ def buildWrappers(cmd, outputVar, intermediateSteps = []):
 steps:
   - #@ template.replace(checkoutCode("recursive"))
@@ -76,12 +85,7 @@ steps:
 #@ finalPkgName = "io.realm.unity-" + "${{ steps.find-nupkg-version.outputs.package_version }}.tgz"
   - name: #@ "Build Unity"
     run: #@ "dotnet run --project Tools/SetupUnityPackage/ -- realm --packages-path Realm/packages --pack"
-  - name: Store Unity artifacts
-    uses: #@ actionUploadArtifact
-    with:
-      name: #@ finalPkgName
-      path: #@ "${{ github.workspace }}/Realm/Realm.Unity/" + finalPkgName
-      retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
+  - #@ uploadArtifacts("Unity", finalPkgName, "Realm/Realm.Unity/" + finalPkgName)
 #@ end
 
 #@ def buildDocs():
@@ -116,13 +120,8 @@ steps:
 
 #@ def uploadPackageArtifacts():
 #@ for pkgName in [ 'Realm.Fody', 'Realm' ]:
-#@ finalPkgName = pkgName + ".${{ steps.find-nupkg-version.outputs.package_version }}"
-  - name: #@ "Store artifacts for " + pkgName
-    uses: #@ actionUploadArtifact
-    with:
-      name: #@ finalPkgName
-      path: #@ "${{ github.workspace }}/Realm/packages/" + finalPkgName + ".*nupkg"
-      retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
+#@  finalPkgName = pkgName + ".${{ steps.find-nupkg-version.outputs.package_version }}"
+  - #@ uploadArtifacts(pkgName, finalPkgName, "Realm/packages/" + finalPkgName + ".*nupkg")
 #@ end
 #@ end
 
@@ -330,12 +329,7 @@ jobs:
       - #@ template.replace(buildDocs())
       - #@ template.replace(uploadPackageArtifacts())
       - #@ template.replace(buildUnityPackage())
-      - name: Store artifacts for ExtractedChangelog.md
-        uses: #@ actionUploadArtifact
-        with:
-          name: ExtractedChangelog
-          path: ${{ github.workspace }}/Realm/Realm/ExtractedChangelog.md
-          retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
+      - #@ uploadArtifacts("ExtractedChangelog.md", "ExtractedChangelog", "Realm/Realm/ExtractedChangelog.md")
   run-tests-net-framework:
     runs-on: windows-latest
     name: Test .NET Framework
@@ -505,9 +499,4 @@ jobs:
           file: ${{ github.workspace }}/BenchmarkDotNet.Artifacts/results/${{ steps.find-results-file.outputs.benchmark-results }}
           dashboard-path: dashboard.charts
           nuget-package: ${{ github.workspace }}/Realm/packages/Realm.${{ needs.build-packages.outputs.package_version }}.nupkg
-      - name: Upload Charts Dashboard File
-        uses: #@ actionUploadArtifact
-        with:
-          name: dashboard.charts
-          path: ${{ github.workspace }}/dashboard.charts
-          retention-days: 30
+      - #@ uploadArtifacts("Charts Dashboard", "dashboard.charts", "dashboard.charts", "30")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -396,7 +396,7 @@ jobs:
         retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
     - name: Build Unity
       run: dotnet run --project Tools/SetupUnityPackage/ -- realm --packages-path Realm/packages --pack
-    - name: Store Unity artifacts
+    - name: Store artifacts for Unity
       uses: actions/upload-artifact@v2
       with:
         name: io.realm.unity-${{ steps.find-nupkg-version.outputs.package_version }}.tgz
@@ -870,9 +870,9 @@ jobs:
         file: ${{ github.workspace }}/BenchmarkDotNet.Artifacts/results/${{ steps.find-results-file.outputs.benchmark-results }}
         dashboard-path: dashboard.charts
         nuget-package: ${{ github.workspace }}/Realm/packages/Realm.${{ needs.build-packages.outputs.package_version }}.nupkg
-    - name: Upload Charts Dashboard File
+    - name: Store artifacts for Charts Dashboard
       uses: actions/upload-artifact@v2
       with:
         name: dashboard.charts
         path: ${{ github.workspace }}/dashboard.charts
-        retention-days: 30
+        retention-days: "30"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,11 @@ jobs:
     - name: Build wrappers
       run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
       if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
+    - name: Store artifacts for wrappers-macos
       uses: actions/upload-artifact@v2
       with:
         name: wrappers-macos
-        path: wrappers/build/**
+        path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-wrappers-ios:
     runs-on: macos-latest
@@ -58,11 +58,11 @@ jobs:
     - name: Build wrappers
       run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
       if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
+    - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2
       with:
         name: wrappers-ios
-        path: wrappers/build/**
+        path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-wrappers-linux:
     runs-on: ubuntu-latest
@@ -101,11 +101,11 @@ jobs:
         options: -v ${{ github.workspace }}:/work
         run: /work/wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
       if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
+    - name: Store artifacts for wrappers-linux
       uses: actions/upload-artifact@v2
       with:
         name: wrappers-linux
-        path: wrappers/build/**
+        path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-wrappers-android:
     runs-on: ubuntu-20.04
@@ -136,11 +136,11 @@ jobs:
     - name: Build wrappers
       run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
       if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
+    - name: Store artifacts for wrappers-android-${{ matrix.arch }}
       uses: actions/upload-artifact@v2
       with:
         name: wrappers-android-${{ matrix.arch }}
-        path: wrappers/build/**
+        path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-wrappers-windows:
     runs-on: windows-latest
@@ -189,11 +189,11 @@ jobs:
     - name: Build wrappers
       run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
       if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
+    - name: Store artifacts for wrappers-windows-${{ matrix.arch }}
       uses: actions/upload-artifact@v2
       with:
         name: wrappers-windows-${{ matrix.arch }}
-        path: wrappers/build/**
+        path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-wrappers-windows-uwp:
     runs-on: windows-latest
@@ -236,11 +236,11 @@ jobs:
     - name: Build wrappers
       run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
       if: steps.check-cache.outputs.cache-hit != 'true'
-    - name: Store artifacts
+    - name: Store artifacts for wrappers-windows-uwp-${{ matrix.arch }}
       uses: actions/upload-artifact@v2
       with:
         name: wrappers-windows-uwp-${{ matrix.arch }}
-        path: wrappers/build/**
+        path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-packages:
     runs-on: windows-latest
@@ -375,20 +375,20 @@ jobs:
       run: |
         C:\docfx\docfx Docs/docfx.json
         Compress-Archive -Path Docs/_site -DestinationPath "Realm/packages/Docs.zip"
-    - name: Store docs artifacts
-      if: ${{ contains(github.head_ref, 'release') }}
+    - name: Store artifacts for Docs.zip
       uses: actions/upload-artifact@v2
       with:
         name: Docs.zip
         path: ${{ github.workspace }}/Realm/packages/Docs.zip
         retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
-    - name: Store artifacts for Realm.Fody
+      if: ${{ contains(github.head_ref, 'release') }}
+    - name: Store artifacts for Realm.Fody.${{ steps.find-nupkg-version.outputs.package_version }}
       uses: actions/upload-artifact@v2
       with:
         name: Realm.Fody.${{ steps.find-nupkg-version.outputs.package_version }}
         path: ${{ github.workspace }}/Realm/packages/Realm.Fody.${{ steps.find-nupkg-version.outputs.package_version }}.*nupkg
         retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
-    - name: Store artifacts for Realm
+    - name: Store artifacts for Realm.${{ steps.find-nupkg-version.outputs.package_version }}
       uses: actions/upload-artifact@v2
       with:
         name: Realm.${{ steps.find-nupkg-version.outputs.package_version }}
@@ -396,13 +396,13 @@ jobs:
         retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
     - name: Build Unity
       run: dotnet run --project Tools/SetupUnityPackage/ -- realm --packages-path Realm/packages --pack
-    - name: Store artifacts for Unity
+    - name: Store artifacts for io.realm.unity-${{ steps.find-nupkg-version.outputs.package_version }}.tgz
       uses: actions/upload-artifact@v2
       with:
         name: io.realm.unity-${{ steps.find-nupkg-version.outputs.package_version }}.tgz
         path: ${{ github.workspace }}/Realm/Realm.Unity/io.realm.unity-${{ steps.find-nupkg-version.outputs.package_version }}.tgz
         retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
-    - name: Store artifacts for ExtractedChangelog.md
+    - name: Store artifacts for ExtractedChangelog
       uses: actions/upload-artifact@v2
       with:
         name: ExtractedChangelog
@@ -870,9 +870,9 @@ jobs:
         file: ${{ github.workspace }}/BenchmarkDotNet.Artifacts/results/${{ steps.find-results-file.outputs.benchmark-results }}
         dashboard-path: dashboard.charts
         nuget-package: ${{ github.workspace }}/Realm/packages/Realm.${{ needs.build-packages.outputs.package_version }}.nupkg
-    - name: Store artifacts for Charts Dashboard
+    - name: Store artifacts for dashboard.charts
       uses: actions/upload-artifact@v2
       with:
         name: dashboard.charts
         path: ${{ github.workspace }}/dashboard.charts
-        retention-days: "30"
+        retention-days: 30


### PR DESCRIPTION
## Description
Just a minor refactoring in the template of main.yml where all the artifacts uploads now use a function instead of writing the same code over and over. I tried to make the function simple enough, so more complicated uploads can't use this function but needs to write the upload code by hand. I don't think we should over complicate the helper as what it does covers already 90% of our use cases.

Fixes: no issue was created