### PR TITLE
Fix a build warning due to unreachable code

### DIFF
--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -143,9 +143,8 @@ try
 catch (Exception ex)
 {
     Log.LogError($"The changelog could not be extracted because of the following exception:\n{ex.ToString()}\nAborting the build.");
-    return false;
+    Success = false;
 }
-return true;
 ]]>
       </Code>
     </Task>


### PR DESCRIPTION
Noticed that we're getting a compile time warning about unreachable code and it turned out that the inline task generator will generate a `return Success` at the end of the method.