### PR TITLE
[Weaver] Fix System.Linq.Queryable not correctly referenced when not imported yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * Fixed a bug that would cause a `NullReferenceException` to be reported during compilation of a class containing a getter-only `RealmObject` property. (Issue [#2576](https://github.com/realm/realm-dotnet/issues/2576))
 * Fixed an issue that would result in `Unable to load DLL 'realm-wrappers'` when deploying a WPF .NET Framework application with ClickOnce. This was due to the incorrect BuildAction type being applied to the native libraries that Realm depends on. (Issue [#1877](https://github.com/realm/realm-dotnet/issues/1877))
+* Fixed a bug that would sometimes result in assemblies not found at runtime in a very specific edge scenario. More details about such a scenario can be found in its [PR](https://github.com/realm/realm-dotnet/pull/2639)'s description. (Issue [#1568](https://github.com/realm/realm-dotnet/issues/1568))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm.Weaver/Extensions/ModuleDefinitionExtensions.cs
+++ b/Realm/Realm.Weaver/Extensions/ModuleDefinitionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2021 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Realm/Realm.Weaver/Extensions/ModuleDefinitionExtensions.cs
+++ b/Realm/Realm.Weaver/Extensions/ModuleDefinitionExtensions.cs
@@ -1,0 +1,42 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System.ComponentModel;
+using System.Linq;
+using Mono.Cecil;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class ModuleDefinitionExtensions
+{
+    public static ModuleDefinition ResolveReference(this ModuleDefinition module, string assembly)
+    {
+        var assemblyNameReference = module.FindReference(assembly);
+        if (assemblyNameReference != null)
+        {
+            return module.AssemblyResolver.Resolve(assemblyNameReference).MainModule;
+        }
+
+        return null;
+    }
+
+    public static AssemblyNameReference FindReference(this ModuleDefinition module, string assembly)
+    {
+        return module.AssemblyReferences.SingleOrDefault(a => a.Name == assembly);
+    }
+
+}

--- a/Realm/Realm.Weaver/Extensions/ModuleDefinitionExtensions.cs
+++ b/Realm/Realm.Weaver/Extensions/ModuleDefinitionExtensions.cs
@@ -38,5 +38,4 @@ internal static class ModuleDefinitionExtensions
     {
         return module.AssemblyReferences.SingleOrDefault(a => a.Name == assembly);
     }
-
 }


### PR DESCRIPTION
## Description
In the unlikely scenario where `System.Linq.Queryable` is not used at all in the user code, but the user calls a method of an interface that `System.Linq.Queryable` implements, the weaver fails to set the correct version number of `System.Linq.Queryable` to import. This resulted in a runtime issue that states that a certain (and wrong) "x.x.x.x" version of `System.Linq.Queryable` can't be found.
The problem comes from the fact that the version number of each assembly was extracted by the weaver from `System.Runtime` giving the wrong number version and only getting it right in most cases by luck. Reading the version number from the assembly with the majority of our dependencies (`Remotion.Linq`) fixed the issue.

Although, to my limited knowledge, no other similar issue has been reported (mostly because of how unlikely this type of usage is), this fix should likely avoid similar problems with other assemblies found in `Remotion.Linq`.

Fixes #1568 

##  TODO

* [ ] Changelog entry