### PR TITLE
Use new XCode build system for iOS wrappers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-wrappers-ios:
-    runs-on: macos-latest
+    runs-on: macos-11
     name: Wrappers iOS
     steps:
     - name: Checkout code
@@ -56,7 +56,7 @@ jobs:
         path: ./wrappers/build/**
         key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON'
+      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
     - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,6 @@ jobs:
         key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
       run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON'
-      if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         path: ${{ github.workspace }}/wrappers/build/**
         retention-days: 1
   build-wrappers-ios:
-    runs-on: macos-11
+    runs-on: macos-latest
     name: Wrappers iOS
     steps:
     - name: Checkout code
@@ -56,7 +56,8 @@ jobs:
         path: ./wrappers/build/**
         key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         path: ./wrappers/build/**
         key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON'
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         path: ./wrappers/build/**
         key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
     - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 ### Internal
 * Using Core 11.4.1.
 * Moved perf tests to run on a self-hosted runner. (PR [#2638](https://github.com/realm/realm-dotnet/pull/2638))
+* iOS wrappers are now built with the "new build system" introduced by Xcode 10 and used as default by Xcode 12. More info can be found in cmake's [docs](https://cmake.org/cmake/help/git-stage/variable/CMAKE_XCODE_BUILD_SYSTEM.html#variable:CMAKE_XCODE_BUILD_SYSTEM).
 
 ## 10.5.1 (2021-09-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Internal
 * Using Core x.y.z.
+* iOS wrappers are now built with the "new build system" introduced by Xcode 10 and used as default by Xcode 12. More info can be found in cmake's [docs](https://cmake.org/cmake/help/git-stage/variable/CMAKE_XCODE_BUILD_SYSTEM.html#variable:CMAKE_XCODE_BUILD_SYSTEM).
 
 ## 10.6.0 (2021-09-30)
 
@@ -92,7 +93,6 @@
 ### Internal
 * Using Core 11.4.1.
 * Moved perf tests to run on a self-hosted runner. (PR [#2638](https://github.com/realm/realm-dotnet/pull/2638))
-* iOS wrappers are now built with the "new build system" introduced by Xcode 10 and used as default by Xcode 12. More info can be found in cmake's [docs](https://cmake.org/cmake/help/git-stage/variable/CMAKE_XCODE_BUILD_SYSTEM.html#variable:CMAKE_XCODE_BUILD_SYSTEM).
 
 ## 10.5.1 (2021-09-22)
 

--- a/wrappers/build-ios.sh
+++ b/wrappers/build-ios.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 REALM_CMAKE_CONFIGURATION=Debug
-EXTRA_CMAKE_ARGS="-T buildsystem=1"
+# EXTRA_CMAKE_ARGS="-T buildsystem=1"
 
 for i in "$@"
 do

--- a/wrappers/build-ios.sh
+++ b/wrappers/build-ios.sh
@@ -3,7 +3,6 @@
 SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 REALM_CMAKE_CONFIGURATION=Debug
-# EXTRA_CMAKE_ARGS="-T buildsystem=1"
 
 for i in "$@"
 do

--- a/wrappers/build-ios.sh
+++ b/wrappers/build-ios.sh
@@ -3,6 +3,7 @@
 SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 REALM_CMAKE_CONFIGURATION=Debug
+EXTRA_CMAKE_ARGS=""
 
 for i in "$@"
 do


### PR DESCRIPTION
## Description
The issue has been fixed with newer versions of CMake. So all it took was removing the cmake arg to force Cmake to use the old build system,

Fixes #2171

##  TODO

* [ ] Changelog entry