### PR TITLE
Fixed bug from freed handle in HandleSessionProgress

### DIFF
--- a/Realm/Realm/Handles/SessionHandle.cs
+++ b/Realm/Realm/Handles/SessionHandle.cs
@@ -237,8 +237,15 @@ namespace Realms.Sync
         [MonoPInvokeCallback(typeof(NativeMethods.SessionProgressCallback))]
         private static void HandleSessionProgress(IntPtr tokenPtr, ulong transferredBytes, ulong transferableBytes)
         {
-            var token = (ProgressNotificationToken)GCHandle.FromIntPtr(tokenPtr).Target;
-            token.Notify(transferredBytes, transferableBytes);
+            try
+            {
+                var token = (ProgressNotificationToken)GCHandle.FromIntPtr(tokenPtr).Target;
+                token.Notify(transferredBytes, transferableBytes);
+            }
+            catch
+            {
+                 // do nothing if either the pointer is IntPtr.Zero or Target has been freed or never initialized
+            }
         }
 
         [MonoPInvokeCallback(typeof(NativeMethods.SessionWaitCallback))]


### PR DESCRIPTION
## Description
A user reported a native crash while executing the OnProgress callback for a synced Realm. Investigating the issue it was understood that a `GCHandle` was still being de-referenced after being freed .
We don't want to crash the whole user application for issues coming from this specific callback. Hence, avoiding to throw is a good fix for now. However, this whole issue allowed us to discover that a deeper [bug](https://github.com/realm/realm-core/issues/4919) in core was the culprit.

Fixes #2632 

##  TODO

* [ ] Changelog entry
