### PR TITLE
Remove get_is_frozen on all object/collection handles

### DIFF
--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -121,7 +121,7 @@ namespace Realms
         public bool IsValid => Handle.Value.IsValid;
 
         [IgnoreDataMember]
-        public bool IsFrozen => Handle.Value.IsFrozen;
+        public bool IsFrozen => Realm?.IsFrozen == true;
 
         [IgnoreDataMember]
         public Realm Realm { get; }

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -135,7 +135,7 @@ namespace Realms
         /// <value><c>true</c> if the object is frozen and immutable; <c>false</c> otherwise.</value>
         /// <seealso cref="FrozenObjectsExtensions.Freeze{T}(T)"/>
         [IgnoreDataMember]
-        public bool IsFrozen => _objectHandle?.IsFrozen == true;
+        public bool IsFrozen => _realm?.IsFrozen == true;
 
         /// <summary>
         /// Gets the <see cref="Realm"/> instance this object belongs to, or <c>null</c> if it is unmanaged.

--- a/Realm/Realm/Handles/DictionaryHandle.cs
+++ b/Realm/Realm/Handles/DictionaryHandle.cs
@@ -60,10 +60,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_dictionary_get_thread_safe_reference", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_thread_safe_reference(DictionaryHandle handle, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_dictionary_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool get_is_frozen(DictionaryHandle handle, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_dictionary_freeze", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr freeze(DictionaryHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
 
@@ -162,16 +158,6 @@ namespace Realms
         protected override IntPtr GetFilteredResultsCore(string query, PrimitiveValue[] arguments, out NativeException ex)
         {
             throw new NotImplementedException("Dictionaries can't be filtered yet.");
-        }
-
-        public override bool IsFrozen
-        {
-            get
-            {
-                var result = NativeMethods.get_is_frozen(this, out var nativeException);
-                nativeException.ThrowIfNecessary();
-                return result;
-            }
         }
 
         public override CollectionHandleBase Freeze(SharedRealmHandle frozenRealmHandle)

--- a/Realm/Realm/Handles/ListHandle.cs
+++ b/Realm/Realm/Handles/ListHandle.cs
@@ -78,10 +78,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_snapshot", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr snapshot(ListHandle list, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool get_is_frozen(ListHandle list, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "list_freeze", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr freeze(ListHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
 
@@ -100,16 +96,6 @@ namespace Realms
             get
             {
                 var result = NativeMethods.get_is_valid(this, out var nativeException);
-                nativeException.ThrowIfNecessary();
-                return result;
-            }
-        }
-
-        public override bool IsFrozen
-        {
-            get
-            {
-                var result = NativeMethods.get_is_frozen(this, out var nativeException);
                 nativeException.ThrowIfNecessary();
                 return result;
             }

--- a/Realm/Realm/Handles/NotifiableObjectHandleBase.cs
+++ b/Realm/Realm/Handles/NotifiableObjectHandleBase.cs
@@ -54,8 +54,6 @@ namespace Realms
 
         public abstract ThreadSafeReferenceHandle GetThreadSafeReference();
 
-        public abstract bool IsFrozen { get; }
-
         [MonoPInvokeCallback(typeof(NotificationCallback))]
         public static void NotifyObjectChanged(IntPtr managedHandle, IntPtr changes, IntPtr exception)
         {

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -84,10 +84,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_backlink_count", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_backlink_count(ObjectHandle objectHandle, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool get_is_frozen(ObjectHandle objectHandle, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_freeze", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr freeze(ObjectHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
 
@@ -127,16 +123,6 @@ namespace Realms
             nativeException.ThrowIfNecessary();
 
             return result;
-        }
-
-        public override bool IsFrozen
-        {
-            get
-            {
-                var result = NativeMethods.get_is_frozen(this, out var nativeException);
-                nativeException.ThrowIfNecessary();
-                return result;
-            }
         }
 
         protected override void Unbind()

--- a/Realm/Realm/Handles/ResultsHandle.cs
+++ b/Realm/Realm/Handles/ResultsHandle.cs
@@ -70,10 +70,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_descriptor_ordering", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_sort_descriptor(ResultsHandle results, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool get_is_frozen(ResultsHandle results, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "results_freeze", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr freeze(ResultsHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
         }
@@ -83,16 +79,6 @@ namespace Realms
             get
             {
                 var result = NativeMethods.get_is_valid(this, out var nativeException);
-                nativeException.ThrowIfNecessary();
-                return result;
-            }
-        }
-
-        public override bool IsFrozen
-        {
-            get
-            {
-                var result = NativeMethods.get_is_frozen(this, out var nativeException);
                 nativeException.ThrowIfNecessary();
                 return result;
             }

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -48,10 +48,6 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_snapshot", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr snapshot(SetHandle handle, out NativeException ex);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool get_is_frozen(SetHandle handle, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "realm_set_freeze", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr freeze(SetHandle handle, SharedRealmHandle frozen_realm, out NativeException ex);
 
@@ -119,16 +115,6 @@ namespace Realms
         }
 
         public override bool CanSnapshot => true;
-
-        public override bool IsFrozen
-        {
-            get
-            {
-                var result = NativeMethods.get_is_frozen(this, out var nativeException);
-                nativeException.ThrowIfNecessary();
-                return result;
-            }
-        }
 
         public SetHandle(RealmHandle root, IntPtr handle) : base(root, handle)
         {

--- a/wrappers/src/dictionary_cs.cpp
+++ b/wrappers/src/dictionary_cs.cpp
@@ -215,13 +215,6 @@ REALM_EXPORT ThreadSafeReference* realm_dictionary_get_thread_safe_reference(con
     });
 }
 
-REALM_EXPORT bool realm_dictionary_get_is_frozen(const object_store::Dictionary& dictionary, NativeException::Marshallable& ex)
-{
-    return handle_errors(ex, [&]() {
-        return dictionary.is_frozen();
-    });
-}
-
 REALM_EXPORT object_store::Dictionary* realm_dictionary_freeze(const object_store::Dictionary& dictionary, const SharedRealm& realm, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {

--- a/wrappers/src/list_cs.cpp
+++ b/wrappers/src/list_cs.cpp
@@ -260,13 +260,6 @@ REALM_EXPORT Results* list_snapshot(const List& list, NativeException::Marshalla
     });
 }
 
-REALM_EXPORT bool list_get_is_frozen(const List& list, NativeException::Marshallable& ex)
-{
-    return handle_errors(ex, [&]() {
-        return list.is_frozen();
-    });
-}
-
 REALM_EXPORT List* list_freeze(const List& list, const SharedRealm& realm, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -296,13 +296,6 @@ extern "C" {
         });
     }
 
-    REALM_EXPORT bool object_get_is_frozen(const Object& object, NativeException::Marshallable& ex)
-    {
-        return handle_errors(ex, [&]() {
-            return object.is_frozen();
-        });
-    }
-
     REALM_EXPORT Object* object_freeze(const Object& object, const SharedRealm& realm, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -166,13 +166,6 @@ REALM_EXPORT size_t results_find_value(Results& results, realm_value_t value, Na
     });
 }
 
-REALM_EXPORT bool results_get_is_frozen(Results& results, NativeException::Marshallable& ex)
-{
-    return handle_errors(ex, [&]() {
-        return results.is_frozen();
-    });
-}
-
 REALM_EXPORT Results* results_freeze(Results& results, const SharedRealm& realm, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {

--- a/wrappers/src/set_cs.cpp
+++ b/wrappers/src/set_cs.cpp
@@ -182,13 +182,6 @@ REALM_EXPORT Results* realm_set_snapshot(const object_store::Set& set, NativeExc
     });
 }
 
-REALM_EXPORT bool realm_set_get_is_frozen(const object_store::Set& set, NativeException::Marshallable& ex)
-{
-    return handle_errors(ex, [&]() {
-        return set.is_frozen();
-    });
-}
-
 REALM_EXPORT object_store::Set* realm_set_freeze(const object_store::Set& set, const SharedRealm& realm, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description
Remove get_is_frozen on all object/collection handles since a ref to realm is always available to objects and collections. Hence just return `realm.IsFrozen()`.

Fixes #2631

##  TODO

* [ ] Changelog entry
* [ ] ~Tests (if applicable)~
