### PR TITLE
Fix Unity NRE when Realm is installed at a non-default location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed an issue that would cause incorrect property implementation to be generated if `PropertyChanged.Fody` runs after the Realm weaver. (Issue [#1873](https://github.com/realm/realm-dotnet/issues/1873))
 * [Unity] Preserved additional constructors necessary to serialize and deserialize Custom User Data. (PR [#2519](https://github.com/realm/realm-dotnet/pull/2519))
 * Fixed an issue that would result in `InvalidOperationException` when concurrently creating a `RealmConfiguration` with an explicitly set `Schema` property. (Issue [#2701](https://github.com/realm/realm-dotnet/issues/2701))
+* [Unity] Fixed an issue that would result in `NullReferenceException` when building for iOS when the Realm package hasn't been installed via the Unity Package Manager. (Issue [#2698](https://github.com/realm/realm-dotnet/issues/2698))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm.UnityWeaver/UnityWeaver.cs
+++ b/Realm/Realm.UnityWeaver/UnityWeaver.cs
@@ -311,15 +311,29 @@ namespace RealmWeaver
         /// </summary>
         private static void UpdateiOSFrameworks(bool enableForDevice, bool enableForSimulator)
         {
-            var simulatorPath = "Packages/io.realm.unity/Runtime/iOS/realm-wrappers.xcframework/ios-arm64_i386_x86_64-simulator/realm-wrappers.framework";
-            var simulatorFrameworkImporter = (PluginImporter)PluginImporter.GetAtPath(simulatorPath);
-            simulatorFrameworkImporter.SetCompatibleWithPlatform(BuildTarget.iOS, enableForSimulator);
-            simulatorFrameworkImporter.SetPlatformData(BuildTarget.iOS, "AddToEmbeddedBinaries", enableForSimulator.ToString().ToLower());
+            const string ErrorMessage = "Failed to find the native Realm framework at '{0}'. " +
+                "Please double check that you have imported Realm correctly and that the file exists. " +
+                "Typically, it should be located at Packages/io.realm.unity/Runtime/iOS";
+            const string SimulatorPath = "ios-arm64_i386_x86_64-simulator";
+            const string DevicePath = "ios-arm64_armv7";
 
-            var devicePath = "Packages/io.realm.unity/Runtime/iOS/realm-wrappers.xcframework/ios-arm64_armv7/realm-wrappers.framework";
-            var deviceFrameworkImporter = (PluginImporter)PluginImporter.GetAtPath(devicePath);
-            deviceFrameworkImporter.SetCompatibleWithPlatform(BuildTarget.iOS, enableForDevice);
-            deviceFrameworkImporter.SetPlatformData(BuildTarget.iOS, "AddToEmbeddedBinaries", enableForDevice.ToString().ToLower());
+            var importers = PluginImporter.GetAllImporters();
+
+            UpdateiOSFramework(SimulatorPath, enableForSimulator);
+            UpdateiOSFramework(DevicePath, enableForDevice);
+
+            void UpdateiOSFramework(string path, bool enabled)
+            {
+                path = $"realm-wrappers.xcframework/{path}/realm-wrappers.framework";
+                var frameworkImporter = importers.SingleOrDefault(i => i.assetPath.Contains(path));
+                if (frameworkImporter == null)
+                {
+                    throw new Exception(string.Format(ErrorMessage, path));
+                }
+
+                frameworkImporter.SetCompatibleWithPlatform(BuildTarget.iOS, enabled);
+                frameworkImporter.SetPlatformData(BuildTarget.iOS, "AddToEmbeddedBinaries", enabled.ToString().ToLower());
+            }
         }
 
         private static Assembly[] GetAssemblies()


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Previously we would look for the iOS native libraries using an exact path match, which would fail when the package is installed at a non-default location. We're now getting all assets and using LINQ to look for the one whose path is a partial match. We're looking for the path relative to the xcframework, which should never be changed, so this is robust enough to cover all meaningful use cases.

Fixes https://github.com/realm/realm-dotnet/issues/2698

##  TODO

* [x] Changelog entry
