### PR TITLE
Fix MacOS testing error

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -167,14 +167,14 @@ steps:
 #@ end
 
 #@ def xamarinMacTestSteps():
-  - #@ msbuild("Tests/Tests.XamarinMac", TargetFrameworkVersion="v2.0", RestoreConfigFile="Tests/Test.NuGet.Config", UseRealmNupkgsWithVersion="${{ needs.build-packages.outputs.package_version }}")
+  - #@ msbuild("Tests/Tests.XamarinMac", RestoreConfigFile="Tests/Test.NuGet.Config", UseRealmNupkgsWithVersion="${{ needs.build-packages.outputs.package_version }}")
   - name: Run the tests
     run: #@ "Tests/Tests.XamarinMac/bin/" + configuration + "/Tests.XamarinMac.app/Contents/MacOS/Tests.XamarinMac --headless --labels=All --baasurl=${{ secrets.REALM_BASE_URL }} --result=${{ github.workspace }}/TestResults.macOS.xml"
   - #@ publishTestsResults("TestResults.macOS.xml", "Xamarin.macOS")
 #@ end
 
 #@ def xamariniOSTestSteps():
-  - #@ msbuild("Tests/Tests.iOS", TargetFrameworkVersion="v1.0", Platform="iPhoneSimulator", RestoreConfigFile="Tests/Test.NuGet.Config", UseRealmNupkgsWithVersion="${{ needs.build-packages.outputs.package_version }}")
+  - #@ msbuild("Tests/Tests.iOS", Platform="iPhoneSimulator", RestoreConfigFile="Tests/Test.NuGet.Config", UseRealmNupkgsWithVersion="${{ needs.build-packages.outputs.package_version }}")
   - name: Run the tests
     uses: #@ actionRuniOSSimulator
     with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -679,7 +679,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.macOS
   test-xamarinmacos:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     name: Test Xamarin.macOS
     needs:
     - build-packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -679,7 +679,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.macOS
   test-xamarinmacos:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     name: Test Xamarin.macOS
     needs:
     - build-packages
@@ -708,7 +708,7 @@ jobs:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}
         path: ${{ github.workspace }}/Realm/packages/
     - name: Build Tests/Tests.XamarinMac
-      run: msbuild Tests/Tests.XamarinMac -p:Configuration=Release -restore -p:TargetFrameworkVersion=v2.0 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: msbuild Tests/Tests.XamarinMac -p:Configuration=Release -restore -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
     - name: Run the tests
       run: Tests/Tests.XamarinMac/bin/Release/Tests.XamarinMac.app/Contents/MacOS/Tests.XamarinMac --headless --labels=All --baasurl=${{ secrets.REALM_BASE_URL }} --result=${{ github.workspace }}/TestResults.macOS.xml
     - name: Publish Unit Test Results
@@ -791,7 +791,7 @@ jobs:
         name: Realm.Fody.${{ needs.build-packages.outputs.package_version }}
         path: ${{ github.workspace }}/Realm/packages/
     - name: Build Tests/Tests.iOS
-      run: msbuild Tests/Tests.iOS -p:Configuration=Release -restore -p:TargetFrameworkVersion=v1.0 -p:Platform=iPhoneSimulator -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: msbuild Tests/Tests.iOS -p:Configuration=Release -restore -p:Platform=iPhoneSimulator -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
     - name: Run the tests
       uses: realm/ci-actions/run-ios-simulator@v1
       with:


### PR DESCRIPTION
Test were failing due to a problem with restoring nuget packages. From the logs one could see that msbuild was trying to restore packages for .NET Framework version 1.0 and 2.0. 
This was due to the fact that we were passing `TargetFrameworkVersion` to the project file, and that refers to the .NET Framework (https://docs.microsoft.com/en-us/visualstudio/ide/visual-studio-multi-targeting-overview?view=vs-2019)