### PR TITLE
Update to Core 11.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,20 @@
 * [Unity] Preserved additional constructors necessary to serialize and deserialize Custom User Data. (PR [#2519](https://github.com/realm/realm-dotnet/pull/2519))
 * Fixed an issue that would result in `InvalidOperationException` when concurrently creating a `RealmConfiguration` with an explicitly set `Schema` property. (Issue [#2701](https://github.com/realm/realm-dotnet/issues/2701))
 * [Unity] Fixed an issue that would result in `NullReferenceException` when building for iOS when the Realm package hasn't been installed via the Unity Package Manager. (Issue [#2698](https://github.com/realm/realm-dotnet/issues/2698))
+* Fixed a bug that could cause properties of frozen objects to return incorrect value/throw an exception if the provided Realm schema didn't match the schema on disk. (Issue [#2670](https://github.com/realm/realm-dotnet/issues/2670))
+* Fixed a rare assertion failure or deadlock when a sync session is racing to close at the same time that external reference to the Realm is being released. (Core upgrade)
+* Fixed an assertion failure when opening a sync Realm with a user who had been removed. Instead an exception will be thrown. (Core upgrade)
+* Fixed a rare segfault which could trigger if a user was being logged out while the access token refresh response comes in. (Core upgrade)
+* Fixed a bug where progress notifiers continue to be called after the download of a synced realm is complete. (Core upgrade)
+* Allow for EPERM to be returned from fallocate(). This improves support for running on Linux environments with interesting filesystems, like AWS Lambda. Thanks to [@ztane](https://github.com/ztane) for reporting and suggesting a fix. (Core upgrade)
+* Fixed a user being left in the logged in state when the user's refresh token expires. (Core upgrade)
+* SyncManager had some inconsistent locking which could result in data races and/or deadlocks, mostly in ways that would never be hit outside of tests doing very strange things. (Core upgrade)
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.
 
 ### Internal
-* Using Core x.y.z.
+* Using Core 11.6.0.
 * iOS wrappers are now built with the "new build system" introduced by Xcode 10 and used as default by Xcode 12. More info can be found in cmake's [docs](https://cmake.org/cmake/help/git-stage/variable/CMAKE_XCODE_BUILD_SYSTEM.html#variable:CMAKE_XCODE_BUILD_SYSTEM).
 * We now refresh the resulting Realm instance when opening a synchronized Realm with `GetInstanceAsync`. (Issue [#2256](https://github.com/realm/realm-dotnet/issues/2256))
 * Added Sync tests for all platforms running on cloud-dev. (Issue [#2049](https://github.com/realm/realm-dotnet/issues/2049))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Added the `Realm.SyncSession` property which will return the sync session for this Realm if the Realm is a synchronized one or `null` for local Realms. This is replacing the `GetSession(this Realm)` extension method which is now deprecated. (PR [#2711](https://github.com/realm/realm-dotnet/pull/2711))
 
 ### Fixed
 * Fixed a bug that would result in a `RealmException` being thrown when opening a readonly Realm with schema that is a superset of the schema on disk. Now the code will just work and treat any classes not present in the on-disk schema to be treated as empty collections - e.g. `realm.All<ThisIsNotInOnDiskSchema>().Count == 0`. (Issue [#2619](https://github.com/realm/realm-dotnet/issues/2619))

--- a/Realm/Realm/Extensions/RealmSyncExtensions.cs
+++ b/Realm/Realm/Extensions/RealmSyncExtensions.cs
@@ -35,13 +35,13 @@ namespace Realms.Sync
         /// <param name="realm">An instance of the <see cref="Realm"/> class created with a <see cref="SyncConfiguration"/> object.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="realm"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown if the <paramref name="realm"/> was not created with a <see cref="SyncConfiguration"/> object.</exception>
+        [Obsolete("Use Realm.SyncSession instead.")]
         public static Session GetSession(this Realm realm)
         {
             Argument.NotNull(realm, nameof(realm));
-            var syncConfig = Argument.EnsureType<SyncConfiguration>(realm.Config, "Cannot get a Session for a Realm without a SyncConfiguration", nameof(realm));
+            Argument.EnsureType<SyncConfiguration>(realm.Config, "Cannot get a Session for a Realm without a SyncConfiguration", nameof(realm));
 
-            var session = syncConfig.User.App.Handle.GetSessionForRealm(realm.SharedRealmHandle);
-            return new Session(session);
+            return realm.SyncSession;
         }
     }
 }

--- a/Realm/Realm/Handles/AppHandle.cs
+++ b/Realm/Realm/Handles/AppHandle.cs
@@ -63,9 +63,6 @@ namespace Realms.Sync
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_app_destroy", CallingConvention = CallingConvention.Cdecl)]
             public static extern void destroy(IntPtr syncuserHandle);
 
-            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_app_sync_get_session_from_path", CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr get_session(AppHandle app, SharedRealmHandle realm, out NativeException ex);
-
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_app_sync_get_path_for_realm", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_path_for_realm(AppHandle app, SyncUserHandle user, [MarshalAs(UnmanagedType.LPWStr)] string partition, IntPtr partition_len, IntPtr buffer, IntPtr bufsize, out NativeException ex);
 
@@ -230,13 +227,6 @@ namespace Realms.Sync
                 isNull = false;
                 return NativeMethods.get_path_for_realm(this, user.Handle, partition, (IntPtr)partition.Length, buffer, bufferLength, out ex);
             });
-        }
-
-        public SessionHandle GetSessionForRealm(SharedRealmHandle realm)
-        {
-            var ptr = NativeMethods.get_session(this, realm, out var ex);
-            ex.ThrowIfNecessary();
-            return new SessionHandle(ptr);
         }
 
         public bool ImmediatelyRunFileActions(string path)

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -27,6 +27,7 @@ using Realms.Exceptions;
 using Realms.Logging;
 using Realms.Native;
 using Realms.Schema;
+using Realms.Sync;
 using static Realms.RealmConfiguration;
 
 namespace Realms
@@ -193,6 +194,9 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_remove_type", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool remove_type(SharedRealmHandle sharedRealm, [MarshalAs(UnmanagedType.LPWStr)] string typeName, IntPtr typeLength, out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_sync_session", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr get_session(SharedRealmHandle realm, out NativeException ex);
 
 #pragma warning restore SA1121 // Use built-in type alias
 #pragma warning restore IDE0049 // Use built-in type alias
@@ -496,6 +500,13 @@ namespace Realms
             var result = NativeMethods.create_results(this, tableKey.Value, out var nativeException);
             nativeException.ThrowIfNecessary();
             return new ResultsHandle(this, result);
+        }
+
+        public SessionHandle GetSession()
+        {
+            var ptr = NativeMethods.get_session(this, out var ex);
+            ex.ThrowIfNecessary();
+            return new SessionHandle(ptr);
         }
 
         [MonoPInvokeCallback(typeof(NativeMethods.GetNativeSchemaCallback))]

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -121,6 +121,7 @@ namespace Realms
             using var realm = GetInstance(config);
             if (config is SyncConfiguration)
             {
+                // For synchronized Realms, shutdown the session.
                 var session = realm.SyncSession;
                 session.CloseHandle(waitForShutdown: true);
             }
@@ -211,7 +212,7 @@ namespace Realms
             {
                 if (Config is SyncConfiguration)
                 {
-                    if (_sessionRef == null || !_sessionRef.TryGetTarget(out var session))
+                    if (_sessionRef == null || !_sessionRef.TryGetTarget(out var session) || session.IsClosed)
                     {
                         var sessionHandle = SharedRealmHandle.GetSession();
                         session = new Session(sessionHandle);

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -47,9 +47,6 @@ namespace Realms
     {
         #region static
 
-        // TODO: this will go away once https://github.com/realm/realm-dotnet/pull/2251 is merged, but due to a Mono bug, this needs to be a function rather than a lambda
-        private static IDictionary<TKey, TValue> DictionaryConstructor<TKey, TValue>() => new Dictionary<TKey, TValue>();
-
         /// <summary>
         /// Factory for obtaining a <see cref="Realm"/> instance for this thread.
         /// </summary>
@@ -124,7 +121,7 @@ namespace Realms
             using var realm = GetInstance(config);
             if (config is SyncConfiguration)
             {
-                var session = realm.GetSession();
+                var session = realm.SyncSession;
                 session.CloseHandle(waitForShutdown: true);
             }
 
@@ -150,6 +147,7 @@ namespace Realms
         #endregion static
 
         private State _state;
+        private WeakReference<Session> _sessionRef;
 
         internal readonly SharedRealmHandle SharedRealmHandle;
         internal readonly RealmMetadata Metadata;
@@ -198,6 +196,42 @@ namespace Realms
         /// </summary>
         /// <value>The Realm's configuration.</value>
         public RealmConfigurationBase Config { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Session"/> for this <see cref="Realm"/>.
+        /// </summary>
+        /// <value>
+        /// The <see cref="Session"/> that is responsible for synchronizing with the MongoDB Realm
+        /// server if the Realm instance was created with a <see cref="SyncConfiguration"/>; <c>null</c>
+        /// otherwise.
+        /// </value>
+        public Session SyncSession
+        {
+            get
+            {
+                if (Config is SyncConfiguration)
+                {
+                    if (_sessionRef == null || !_sessionRef.TryGetTarget(out var session))
+                    {
+                        var sessionHandle = SharedRealmHandle.GetSession();
+                        session = new Session(sessionHandle);
+
+                        if (_sessionRef == null)
+                        {
+                            _sessionRef = new WeakReference<Session>(session);
+                        }
+                        else
+                        {
+                            _sessionRef.SetTarget(session);
+                        }
+                    }
+
+                    return session;
+                }
+
+                return null;
+            }
+        }
 
         internal Realm(SharedRealmHandle sharedRealmHandle, RealmConfigurationBase config, RealmSchema schema)
         {
@@ -328,6 +362,11 @@ namespace Realms
                 if (SharedRealmHandle.OwnsNativeRealm)
                 {
                     _state.RemoveRealm(this);
+                }
+
+                if (_sessionRef.TryGetTarget(out var session))
+                {
+                    session.CloseHandle();
                 }
 
                 _state = null;

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -121,7 +121,7 @@ namespace Realms
             using var realm = GetInstance(config);
             if (config is SyncConfiguration)
             {
-                // For synchronized Realms, shutdown the session.
+                // For synchronized Realms, shutdown the session, otherwise Compact will fail.
                 var session = realm.SyncSession;
                 session.CloseHandle(waitForShutdown: true);
             }
@@ -365,7 +365,7 @@ namespace Realms
                     _state.RemoveRealm(this);
                 }
 
-                if (_sessionRef.TryGetTarget(out var session))
+                if (_sessionRef != null && _sessionRef.TryGetTarget(out var session))
                 {
                     session.CloseHandle();
                 }

--- a/Realm/Realm/Sync/Session.cs
+++ b/Realm/Realm/Sync/Session.cs
@@ -34,6 +34,8 @@ namespace Realms.Sync
         /// </summary>
         public static event EventHandler<ErrorEventArgs> Error;
 
+        internal bool IsClosed => _handle.IsClosed;
+
         /// <summary>
         /// Gets the session’s current state.
         /// </summary>
@@ -171,7 +173,7 @@ namespace Realms.Sync
         internal void CloseHandle(bool waitForShutdown = false)
         {
             GC.SuppressFinalize(this);
-            if (!_handle.IsClosed)
+            if (!IsClosed)
             {
                 if (waitForShutdown)
                 {

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -28,7 +28,7 @@ namespace Realms.Tests.Sync
     public class SessionTests : SyncTestBase
     {
         [Test]
-        public void Realm_GetSession_WhenSyncedRealm()
+        public void Realm_SyncSession_WhenSyncedRealm()
         {
             var config = GetFakeConfig();
 
@@ -39,10 +39,18 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
+        [Obsolete("tests obsolete functionality")]
         public void Realm_GetSession_WhenLocalRealm_ShouldThrow()
         {
             using var realm = GetRealm();
-            Assert.Throws<ArgumentException>(() => GetSession(realm));
+            Assert.Throws<ArgumentException>(() => realm.GetSession());
+        }
+
+        [Test]
+        public void Realm_SyncSession_WhenLocalRealm_ShouldReturnNull()
+        {
+            using var realm = GetRealm();
+            Assert.That(realm.SyncSession, Is.Null);
         }
 
         [Test]
@@ -232,7 +240,7 @@ namespace Realms.Tests.Sync
             var first = GetSession(realm);
             var second = GetSession(realm);
 
-            Assert.That(ReferenceEquals(first, second), Is.False);
+            Assert.That(ReferenceEquals(first, second));
             Assert.That(first.Equals(second));
             Assert.That(second.Equals(first));
         }

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -40,6 +40,19 @@ namespace Realms.Tests.Sync
 
         [Test]
         [Obsolete("tests obsolete functionality")]
+        public void Realm_GetSession_WhenSyncedRealm()
+        {
+            var config = GetFakeConfig();
+
+            using var realm = GetRealm(config);
+            var session = realm.GetSession();
+            CleanupOnTearDown(session);
+
+            Assert.That(session.User, Is.EqualTo(config.User));
+        }
+
+        [Test]
+        [Obsolete("tests obsolete functionality")]
         public void Realm_GetSession_WhenLocalRealm_ShouldThrow()
         {
             using var realm = GetRealm();

--- a/Tests/Realm.Tests/Sync/SyncTestBase.cs
+++ b/Tests/Realm.Tests/Sync/SyncTestBase.cs
@@ -74,21 +74,21 @@ namespace Realms.Tests.Sync
 
         protected Session GetSession(Realm realm)
         {
-            var result = realm.GetSession();
+            var result = realm.SyncSession;
             CleanupOnTearDown(result);
             return result;
         }
 
         protected static async Task WaitForUploadAsync(Realm realm)
         {
-            var session = realm.GetSession();
+            var session = realm.SyncSession;
             await session.WaitForUploadAsync();
             session.CloseHandle();
         }
 
         protected static async Task WaitForDownloadAsync(Realm realm)
         {
-            var session = realm.GetSession();
+            var session = realm.SyncSession;
             await session.WaitForDownloadAsync();
             session.CloseHandle();
         }

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -509,21 +509,19 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
-        public void DeleteRealm_WhileSessionIsOpen_Fails()
+        public void RealmDispose_ClosesSessions()
         {
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
                 var realm = await GetIntegrationRealmAsync();
-                var session = GetSession(realm);
+                var session = realm.SyncSession;
                 realm.Dispose();
 
                 await Task.Delay(100);
 
-                Assert.Throws<RealmInUseException>(() => Realm.DeleteRealm(realm.Config));
+                Assert.That(session.IsClosed);
 
-                session.CloseHandle(waitForShutdown: true);
-
-                // We've closed the session, so we should be able to delete the Realm.
+                // Dispose should close the session and allow us to delete the Realm.
                 Assert.That(DeleteRealmWithRetries(realm), Is.True);
             });
         }

--- a/wrappers/src/app_cs.cpp
+++ b/wrappers/src/app_cs.cpp
@@ -38,7 +38,6 @@ using namespace realm::binding;
 using namespace app;
 
 using SharedSyncUser = std::shared_ptr<SyncUser>;
-using SharedSyncSession = std::shared_ptr<SyncSession>;
 
 using LogMessageCallbackT = void(void* managed_handler, realm_value_t message, util::Logger::Level level);
 using UserCallbackT = void(void* tcs_ptr, SharedSyncUser* user, MarshaledAppError err);
@@ -259,13 +258,6 @@ extern "C" {
                 // ignore errors
                 s_void_callback(tcs_ptr, MarshaledAppError());
             });
-        });
-    }
-
-    REALM_EXPORT SharedSyncSession* shared_app_sync_get_session_from_path(SharedApp& app, SharedRealm& realm, NativeException::Marshallable& ex)
-    {
-        return handle_errors(ex, [&] {
-            return new SharedSyncSession(app->sync_manager()->get_existing_active_session(realm->config().path));
         });
     }
 

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -38,6 +38,7 @@
 #include <sstream>
 
 using SharedAsyncOpenTask = std::shared_ptr<AsyncOpenTask>;
+using SharedSyncSession = std::shared_ptr<SyncSession>;
 
 using namespace realm;
 using namespace realm::binding;
@@ -603,6 +604,13 @@ REALM_EXPORT bool shared_realm_remove_type(const SharedRealm& realm, uint16_t* t
 
         realm->read_group().remove_table(table->get_key());
         return true;
+    });
+}
+
+REALM_EXPORT SharedSyncSession* shared_app_sync_get_session_from_path(SharedRealm& realm, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&] {
+        return new SharedSyncSession(realm->sync_session());
     });
 }
 

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -607,7 +607,7 @@ REALM_EXPORT bool shared_realm_remove_type(const SharedRealm& realm, uint16_t* t
     });
 }
 
-REALM_EXPORT SharedSyncSession* shared_app_sync_get_session_from_path(SharedRealm& realm, NativeException::Marshallable& ex)
+REALM_EXPORT SharedSyncSession* shared_realm_get_sync_session(SharedRealm& realm, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&] {
         return new SharedSyncSession(realm->sync_session());

--- a/wrappers/src/sync_session_cs.cpp
+++ b/wrappers/src/sync_session_cs.cpp
@@ -73,7 +73,8 @@ REALM_EXPORT CSharpSessionState realm_syncsession_get_state(const SharedSyncSess
 {
     return handle_errors(ex, [&] {
         switch (session->state()) {
-        case SyncSession::PublicState::Inactive:
+        case SyncSession::State::Inactive:
+        case SyncSession::State::Dying:
             return CSharpSessionState::Inactive;
         default:
             return CSharpSessionState::Active;


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This updates to latest Core and adds a `Realm.SyncSession` property that replaces the extension method. The motivation here is threefold - 1) we no longer ship non-sync binaries, so `GetSession` being an extension method is kind of weird, 2)  it improves discoverability, and 3) it allows us to do some weak reference caching to avoid creating a new session every time the property is accessed.

##  TODO

* [x] Changelog entry
