### PR TITLE
Enable LTO for all builds

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -12,10 +12,16 @@
 #@ baasTimeout = 20
 #@ wrappersTimeout = 45
 
-#@ def getWrapperBuildCommand(cmd):
-#@ defaultParams =  " -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=" + configuration
+#@ def getWrapperBuildCommand(cmd, enableLto = True):
+#@ defaultParams =  " --configuration=" + configuration
+#@ if enableLto:
+#@   defaultParams = defaultParams + " -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON'"
+#@ end
 #@ if cmd.startswith("powershell"):
-#@   defaultParams = " -EnableLTO -Configuration " + configuration
+#@   defaultParams = " -Configuration " + configuration
+#@   if enableLto:
+#@     defaultParams = defaultParams + " -EnableLTO"
+#@   end
 #@ end
 #@ return cmd + defaultParams
 #@ end
@@ -99,7 +105,7 @@ with:
   retention-days: #@ retentionDays
 #@ end
 
-#@ def buildWrappers(cmd, outputVar, intermediateSteps = []):
+#@ def buildWrappers(cmd, outputVar, intermediateSteps = [], enableLto = True):
 timeout-minutes: #@ wrappersTimeout
 steps:
   - #@ template.replace(checkoutCode("recursive"))
@@ -108,7 +114,7 @@ steps:
   - #@ template.replace(step)
   #@ end
   - name: Build wrappers
-    run: #@ getWrapperBuildCommand(cmd)
+    run: #@ getWrapperBuildCommand(cmd, enableLto)
     if: #@ wrappersCacheCondition
   - #@ uploadArtifacts(outputVar, "wrappers/build/**", 1)
 #@ end
@@ -429,7 +435,7 @@ jobs:
     strategy:
       matrix:
         arch: #@ androidABIs
-    _: #@ template.replace(buildWrappers("./wrappers/build-android.sh --ARCH=${{ matrix.arch }}", "wrappers-android-${{ matrix.arch }}"))
+    _: #@ template.replace(buildWrappers("./wrappers/build-android.sh --ARCH=${{ matrix.arch }}", "wrappers-android-${{ matrix.arch }}", [], False))
   build-wrappers-windows:
     runs-on: windows-latest
     name: Wrappers Windows

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -13,17 +13,15 @@
 #@ wrappersTimeout = 45
 
 #@ def getWrapperBuildCommand(cmd):
-#@ configurationParam =  " --configuration=" + configuration
-#@ ltoParam =  " -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}"
+#@ defaultParams =  " -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=" + configuration
 #@ if cmd.startswith("powershell"):
-#@   configurationParam = " -Configuration " + configuration
-#@   ltoParam =  "${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}"
+#@   defaultParams = " -EnableLTO -Configuration " + configuration
 #@ end
-#@ return cmd + configurationParam + ltoParam
+#@ return cmd + defaultParams
 #@ end
 
 #@ def checkCache(outputVar):
-#@ key = outputVar + "-" + configuration + "-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}"
+#@ key = outputVar + "-" + configuration + "-${{hashFiles('./wrappers/**')}}"
 name: Check cache
 id: check-cache
 uses: #@ actionCache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./wrappers/build/**
-        key: wrappers-macos-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+        key: wrappers-macos-Release-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      run: ./wrappers/build-macos.sh -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-macos
       uses: actions/upload-artifact@v2
@@ -57,9 +57,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./wrappers/build/**
-        key: wrappers-ios-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+        key: wrappers-ios-Release-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      run: ./wrappers/build-ios.sh -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2
@@ -86,7 +86,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./wrappers/build/**
-        key: wrappers-linux-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+        key: wrappers-linux-Release-${{hashFiles('./wrappers/**')}}
     - uses: satackey/action-docker-layer-caching@cc3f3828e75cbb45f0cf5139b95329c88480aa97
       continue-on-error: true
       if: steps.check-cache.outputs.cache-hit != 'true'
@@ -103,7 +103,7 @@ jobs:
         image: wrappers-centos:latest
         shell: bash
         options: -v ${{ github.workspace }}:/work
-        run: /work/wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+        run: /work/wrappers/build.sh -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-linux
       uses: actions/upload-artifact@v2
@@ -137,9 +137,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./wrappers/build/**
-        key: wrappers-android-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+        key: wrappers-android-${{ matrix.arch }}-Release-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+      run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-android-${{ matrix.arch }}
       uses: actions/upload-artifact@v2
@@ -171,7 +171,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./wrappers/build/**
-        key: wrappers-windows-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+        key: wrappers-windows-${{ matrix.arch }}-Release-${{hashFiles('./wrappers/**')}}
     - name: Check Vcpkg cache
       id: check-vcpkg-cache
       uses: actions/cache@v2
@@ -193,7 +193,7 @@ jobs:
       shell: powershell
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Build wrappers
-      run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+      run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -EnableLTO -Configuration Release
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-windows-${{ matrix.arch }}
       uses: actions/upload-artifact@v2
@@ -226,7 +226,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./wrappers/build/**
-        key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}-${{hashFiles('./wrappers/**')}}
+        key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{hashFiles('./wrappers/**')}}
     - name: Check Vcpkg cache
       id: check-vcpkg-cache
       uses: actions/cache@v2
@@ -241,7 +241,7 @@ jobs:
       shell: powershell
       if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
     - name: Build wrappers
-      run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release${{ github.event_name != 'pull_request' && ' -EnableLTO' || '' }}
+      run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -EnableLTO -Configuration Release
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-windows-uwp-${{ matrix.arch }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         path: ./wrappers/build/**
         key: wrappers-macos-Release-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-macos.sh -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
+      run: ./wrappers/build-macos.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON'
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-macos
       uses: actions/upload-artifact@v2
@@ -59,7 +59,7 @@ jobs:
         path: ./wrappers/build/**
         key: wrappers-ios-Release-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-ios.sh -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
+      run: ./wrappers/build-ios.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON'
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-ios
       uses: actions/upload-artifact@v2
@@ -103,7 +103,7 @@ jobs:
         image: wrappers-centos:latest
         shell: bash
         options: -v ${{ github.workspace }}:/work
-        run: /work/wrappers/build.sh -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
+        run: /work/wrappers/build.sh --configuration=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON'
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-linux
       uses: actions/upload-artifact@v2
@@ -139,7 +139,7 @@ jobs:
         path: ./wrappers/build/**
         key: wrappers-android-${{ matrix.arch }}-Release-${{hashFiles('./wrappers/**')}}
     - name: Build wrappers
-      run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} -DCMAKE_INTERPROCEDURAL_OPTIMIZATION='ON' --configuration=Release
+      run: ./wrappers/build-android.sh --ARCH=${{ matrix.arch }} --configuration=Release
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-android-${{ matrix.arch }}
       uses: actions/upload-artifact@v2
@@ -193,7 +193,7 @@ jobs:
       shell: powershell
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Build wrappers
-      run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -EnableLTO -Configuration Release
+      run: powershell ./wrappers/build.ps1 Windows -Platforms ${{ matrix.arch }} -Configuration Release -EnableLTO
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-windows-${{ matrix.arch }}
       uses: actions/upload-artifact@v2
@@ -241,7 +241,7 @@ jobs:
       shell: powershell
       if: steps.check-cache.outputs.cache-hit != 'true' && steps.check-vcpkg-cache.outputs.cache-hit != 'true'
     - name: Build wrappers
-      run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -EnableLTO -Configuration Release
+      run: powershell ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -Configuration Release -EnableLTO
       if: steps.check-cache.outputs.cache-hit != 'true'
     - name: Store artifacts for wrappers-windows-uwp-${{ matrix.arch }}
       uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Added Sync tests for all platforms running on cloud-dev. (Issue [#2049](https://github.com/realm/realm-dotnet/issues/2049))
 * Added Android tests running on the emulator. (Issue [#2680](https://github.com/realm/realm-dotnet/pull/2680))
 * Started publishing prerelease packages to S3 using Sleet ([feed url](https://s3.amazonaws.com/realm.nugetpackages/index.json)). (Issue [#2708](https://github.com/realm/realm-dotnet/issues/2708))
+* Enable LTO for all builds. (PR [#2714](https://github.com/realm/realm-dotnet/pull/2714))
 
 ## 10.6.0 (2021-09-30)
 


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

While LTO builds are slightly slower, they're more likely to be cached (since master builds are LTO enabled anyway).

Fixes #2709

##  TODO

* [x] Changelog entry
