### PR TITLE
Update to latest Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Realm Studio: 11.0.0 or later.
 
 ### Internal
-* Using Core x.y.z.
+* Using Core 11.6.1.
 
 ## 10.7.0 (2021-11-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * None
 
 ### Fixed
-* None
+* A sync user's Realm was not deleted when the user was removed if the Realm path was too long such that it triggered the fallback hashed name (this is OS dependant but is 300 characters on linux). (Core upgrade)
+* Don't keep trying to refresh the access token if the client's clock is more than 30 minutes ahead. (Core upgrade)
+* Don't sleep the sync thread artificially if an auth request fails. This could be observed as a UI hang on applications when sync tries to connect after being offline for more than 30 minutes. (Core upgrade)
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm/Handles/AppHandle.cs
+++ b/Realm/Realm/Handles/AppHandle.cs
@@ -392,13 +392,14 @@ namespace Realms.Sync
         private static void HandleApiKeysCallback(IntPtr tcs_ptr, IntPtr api_keys, IntPtr api_keys_len, AppError error)
         {
             var tcsHandle = GCHandle.FromIntPtr(tcs_ptr);
-            var tcs = (TaskCompletionSource<UserApiKey[]>)tcsHandle.Target;
+            var tcs = (TaskCompletionSource<ApiKey[]>)tcsHandle.Target;
             if (error.is_null)
             {
-                var result = new UserApiKey[api_keys_len.ToInt32()];
+                var result = new ApiKey[api_keys_len.ToInt32()];
                 for (var i = 0; i < api_keys_len.ToInt32(); i++)
                 {
-                    result[i] = Marshal.PtrToStructure<UserApiKey>(IntPtr.Add(api_keys, i * UserApiKey.Size));
+                    var nativeKey = Marshal.PtrToStructure<UserApiKey>(IntPtr.Add(api_keys, i * UserApiKey.Size));
+                    result[i] = new ApiKey(nativeKey);
                 }
 
                 tcs.TrySetResult(result);

--- a/Realm/Realm/Handles/SyncUserHandle.cs
+++ b/Realm/Realm/Handles/SyncUserHandle.cs
@@ -300,9 +300,9 @@ namespace Realms.Sync
 
         #region Api Keys
 
-        public async Task<UserApiKey> CreateApiKeyAsync(AppHandle app, string name)
+        public async Task<ApiKey> CreateApiKeyAsync(AppHandle app, string name)
         {
-            var tcs = new TaskCompletionSource<UserApiKey[]>();
+            var tcs = new TaskCompletionSource<ApiKey[]>();
             var tcsHandle = GCHandle.Alloc(tcs);
 
             try
@@ -322,9 +322,9 @@ namespace Realms.Sync
             }
         }
 
-        public async Task<UserApiKey?> FetchApiKeyAsync(AppHandle app, ObjectId id)
+        public async Task<ApiKey> FetchApiKeyAsync(AppHandle app, ObjectId id)
         {
-            var tcs = new TaskCompletionSource<UserApiKey[]>();
+            var tcs = new TaskCompletionSource<ApiKey[]>();
             var tcsHandle = GCHandle.Alloc(tcs);
 
             try
@@ -337,7 +337,7 @@ namespace Realms.Sync
 
                 Debug.Assert(result == null || result.Length <= 1, "The result of the fetch operation should be either null, or an array of 0 or 1 elements.");
 
-                return result == null || result.Length == 0 ? (UserApiKey?)null : result.Single();
+                return result == null || result.Length == 0 ? null : result.Single();
             }
             finally
             {
@@ -345,9 +345,9 @@ namespace Realms.Sync
             }
         }
 
-        public async Task<UserApiKey[]> FetchAllApiKeysAsync(AppHandle app)
+        public async Task<ApiKey[]> FetchAllApiKeysAsync(AppHandle app)
         {
-            var tcs = new TaskCompletionSource<UserApiKey[]>();
+            var tcs = new TaskCompletionSource<ApiKey[]>();
             var tcsHandle = GCHandle.Alloc(tcs);
 
             try

--- a/Realm/Realm/Native/HttpClientTransport.cs
+++ b/Realm/Realm/Native/HttpClientTransport.cs
@@ -135,7 +135,7 @@ namespace Realms.Native
 
                     using var cts = new CancellationTokenSource((int)request.timeout_ms);
 
-                    var response = await _httpClient.SendAsync(message, cts.Token);
+                    var response = await _httpClient.SendAsync(message, cts.Token).ConfigureAwait(false);
                     var headers = new List<StringStringPair>(response.Headers.Count());
                     foreach (var header in response.Headers)
                     {
@@ -158,7 +158,7 @@ namespace Realms.Native
                     var nativeResponse = new HttpClientResponse
                     {
                         http_status_code = (int)response.StatusCode,
-                        Body = await response.Content.ReadAsStringAsync(),
+                        Body = await response.Content.ReadAsStringAsync().ConfigureAwait(false),
                     };
 
                     respond(nativeResponse, headers.ToArray(), headers.Count, callback);

--- a/Realm/Realm/Sync/User.cs
+++ b/Realm/Realm/Sync/User.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -323,12 +322,11 @@ namespace Realms.Sync
             /// that the <see cref="ApiKey"/> has been created on the server and its <see cref="ApiKey.Value"/> can
             /// be used to create <see cref="Credentials.ApiKey(string)"/>.
             /// </returns>
-            public async Task<ApiKey> CreateAsync(string name)
+            public Task<ApiKey> CreateAsync(string name)
             {
                 Argument.NotNullOrEmpty(name, nameof(name));
 
-                var apiKey = await _user.Handle.CreateApiKeyAsync(_user.App.Handle, name);
-                return new ApiKey(apiKey);
+                return _user.Handle.CreateApiKeyAsync(_user.App.Handle, name);
             }
 
             /// <summary>
@@ -338,11 +336,7 @@ namespace Realms.Sync
             /// <returns>
             /// An awaitable <see cref="Task{T}"/> representing the asynchronous lookup operation.
             /// </returns>
-            public async Task<ApiKey> FetchAsync(ObjectId id)
-            {
-                var apiKey = await Handle404(_user.Handle.FetchApiKeyAsync(_user.App.Handle, id));
-                return apiKey.HasValue ? new ApiKey(apiKey.Value) : null;
-            }
+            public Task<ApiKey> FetchAsync(ObjectId id) => Handle404(_user.Handle.FetchApiKeyAsync(_user.App.Handle, id));
 
             /// <summary>
             /// Fetches all API keys associated with the user.
@@ -353,8 +347,7 @@ namespace Realms.Sync
             /// </returns>
             public async Task<IEnumerable<ApiKey>> FetchAllAsync()
             {
-                var apiKeys = await _user.Handle.FetchAllApiKeysAsync(_user.App.Handle);
-                return apiKeys.Select(k => new ApiKey(k)).ToArray();
+                return await _user.Handle.FetchAllApiKeysAsync(_user.App.Handle);
             }
 
             /// <summary>
@@ -362,10 +355,7 @@ namespace Realms.Sync
             /// </summary>
             /// <param name="id">The id of the key to delete.</param>
             /// <returns>An awaitable <see cref="Task"/> representing the asynchronous delete operation.</returns>
-            public Task DeleteAsync(ObjectId id)
-            {
-                return Handle404(_user.Handle.DeleteApiKeyAsync(_user.App.Handle, id));
-            }
+            public Task DeleteAsync(ObjectId id) => Handle404(_user.Handle.DeleteApiKeyAsync(_user.App.Handle, id));
 
             /// <summary>
             /// Disables an API key by id.
@@ -373,10 +363,7 @@ namespace Realms.Sync
             /// <param name="id">The id of the key to disable.</param>
             /// <returns>An awaitable <see cref="Task"/> representing the asynchronous disable operation.</returns>
             /// <seealso cref="EnableAsync(ObjectId)"/>
-            public Task DisableAsync(ObjectId id)
-            {
-                return Handle404(_user.Handle.DisableApiKeyAsync(_user.App.Handle, id), id);
-            }
+            public Task DisableAsync(ObjectId id) => Handle404(_user.Handle.DisableApiKeyAsync(_user.App.Handle, id), id);
 
             /// <summary>
             /// Enables an API key by id.
@@ -384,10 +371,7 @@ namespace Realms.Sync
             /// <param name="id">The id of the key to enable.</param>
             /// <returns>An awaitable <see cref="Task"/> representing the asynchrounous enable operation.</returns>
             /// <seealso cref="DisableAsync(ObjectId)"/>
-            public Task EnableAsync(ObjectId id)
-            {
-                return Handle404(_user.Handle.EnableApiKeyAsync(_user.App.Handle, id), id);
-            }
+            public Task EnableAsync(ObjectId id) => Handle404(_user.Handle.EnableApiKeyAsync(_user.App.Handle, id), id);
 
             private static async Task<T> Handle404<T>(Task<T> task)
             {


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Updates to latest core master. This uncovered a bug in the way we were marshaling API keys - we used to pass in the native struct through the task completion source, which meant we didn't copy out the strings, thus making them invalid. I'm not sure why this hadn't manifested previously - it's possible that Core was leaking those strings which was fixed in https://github.com/realm/realm-core/pull/5029.

##  TODO

* [x] Changelog entry
