### PR TITLE
Read-only realm properly throws when refreshed

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -511,7 +511,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest, win81 ]
+        os: [ macOS-10.15, windows-latest, ubuntu-latest, win81 ]
         targetFramework: [ netcoreapp3.1, net5.0, net6.0 ]
     timeout-minutes: #@ testTimeout
     steps:
@@ -527,9 +527,9 @@ jobs:
           include-prerelease: true
       - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After"))
       - #@ publishTestsResults("TestResults.xml", ".NET (${{ matrix.os }}, ${{ matrix.targetFramework }})")
-  _: #@ template.replace(testJob("Xamarin.macOS", "macos-latest", xamarinMacTestSteps()))
-  _: #@ template.replace(testJob("Xamarin.iOS", "macos-latest", xamariniOSTestSteps()))
-  _: #@ template.replace(testJob("Xamarin.Android", "macos-latest", xamarinAndroidTestSteps()))
+  _: #@ template.replace(testJob("Xamarin.macOS", "macOS-10.15", xamarinMacTestSteps()))
+  _: #@ template.replace(testJob("Xamarin.iOS", "macOS-10.15", xamariniOSTestSteps()))
+  _: #@ template.replace(testJob("Xamarin.Android", "macOS-10.15", xamarinAndroidTestSteps()))
   run-tests-weaver:
     runs-on: windows-latest
     name: Test Weaver

--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -511,7 +511,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macOS-10.15, windows-latest, ubuntu-latest, win81 ]
+        os: [ macos-latest, windows-latest, ubuntu-latest, win81 ]
         targetFramework: [ netcoreapp3.1, net5.0, net6.0 ]
     timeout-minutes: #@ testTimeout
     steps:
@@ -527,9 +527,9 @@ jobs:
           include-prerelease: true
       - #@ template.replace(dotnetPublishAndRunTests("Tests/Realm.Tests", "${{ matrix.targetFramework }}", "Realm.Tests --result=TestResults.xml --labels=After"))
       - #@ publishTestsResults("TestResults.xml", ".NET (${{ matrix.os }}, ${{ matrix.targetFramework }})")
-  _: #@ template.replace(testJob("Xamarin.macOS", "macOS-10.15", xamarinMacTestSteps()))
-  _: #@ template.replace(testJob("Xamarin.iOS", "macOS-10.15", xamariniOSTestSteps()))
-  _: #@ template.replace(testJob("Xamarin.Android", "macOS-10.15", xamarinAndroidTestSteps()))
+  _: #@ template.replace(testJob("Xamarin.macOS", "macos-latest", xamarinMacTestSteps()))
+  _: #@ template.replace(testJob("Xamarin.iOS", "macos-latest", xamariniOSTestSteps()))
+  _: #@ template.replace(testJob("Xamarin.Android", "macos-latest", xamarinAndroidTestSteps()))
   run-tests-weaver:
     runs-on: windows-latest
     name: Test Weaver

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -637,7 +637,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macOS-10.15
+        - macos-latest
         - windows-latest
         - ubuntu-latest
         - win81
@@ -713,7 +713,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.macOS
   test-xamarinmacos:
-    runs-on: macOS-10.15
+    runs-on: macos-latest
     name: Test Xamarin.macOS
     needs:
     - build-packages
@@ -796,7 +796,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.iOS
   test-xamarinios:
-    runs-on: macOS-10.15
+    runs-on: macos-latest
     name: Test Xamarin.iOS
     needs:
     - build-packages
@@ -884,7 +884,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.Android
   test-xamarinandroid:
-    runs-on: macOS-10.15
+    runs-on: macos-latest
     name: Test Xamarin.Android
     needs:
     - build-packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -637,7 +637,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macos-latest
+        - macOS-10.15
         - windows-latest
         - ubuntu-latest
         - win81
@@ -713,7 +713,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.macOS
   test-xamarinmacos:
-    runs-on: macos-latest
+    runs-on: macOS-10.15
     name: Test Xamarin.macOS
     needs:
     - build-packages
@@ -796,7 +796,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.iOS
   test-xamarinios:
-    runs-on: macos-latest
+    runs-on: macOS-10.15
     name: Test Xamarin.iOS
     needs:
     - build-packages
@@ -884,7 +884,7 @@ jobs:
         appsPath: ${{ github.workspace }}/Tests/TestApps
         differentiator: Xamarin.Android
   test-xamarinandroid:
-    runs-on: macos-latest
+    runs-on: macOS-10.15
     name: Test Xamarin.Android
     needs:
     - build-packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * Fixed a race condition that could result in `Sharing violation on path ...` error when opening a Unity project on macOS. (Issue [#2720](https://github.com/realm/realm-dotnet/issues/2720), fix by [@tomkrikorian](https://github.com/tomkrikorian))
-* A read-only Realm now throws an exception when refreshed. Before calling `Realm.Refresh()` on a read-only Realm once would silently do nothing, while calling it more than once would result in a hard to understand exception. (Issue [#2731](https://github.com/realm/realm-dotnet/pull/2731))
+* Fixed an error being thrown when `Realm.GetInstance` is called multiple times on a readonly Realm. (Issue [#2731](https://github.com/realm/realm-dotnet/pull/2731))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Fixed a race condition that could result in `Sharing violation on path ...` error when opening a Unity project on macOS. (Issue [#2720](https://github.com/realm/realm-dotnet/issues/2720), fix by [@tomkrikorian](https://github.com/tomkrikorian))
+* A read-only Realm now throws an exception when refreshed. Before calling `Realm.Refresh()` on a read-only Realm once would silently do nothing, while calling it more than once would result in a hard to understand exception. (Issue [#2731](https://github.com/realm/realm-dotnet/pull/2731))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -40,6 +40,23 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void ReadOnlyInstance_ThrowsOnRefresh()
+        {
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "temp.realm");
+            var realm = Realm.GetInstance(path);
+            realm.Dispose();
+            var config = new RealmConfiguration(path)
+            {
+                IsReadOnly = true
+            };
+
+            realm = Realm.GetInstance(config);
+            Assert.Throws<RealmException>(() => realm.Refresh(), "Can't refresh a read-only Realm.");
+            realm.Dispose();
+            DeleteRealmWithRetries(realm);
+        }
+
+        [Test]
         public void InstanceIsClosedByDispose()
         {
             Realm temp;

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -42,18 +42,16 @@ namespace Realms.Tests.Database
         [Test]
         public void ReadOnlyInstance_ThrowsOnRefresh()
         {
-            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "temp.realm");
-            var realm = Realm.GetInstance(path);
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Guid.NewGuid().ToString());
+            var realm = GetRealm(path);
             realm.Dispose();
             var config = new RealmConfiguration(path)
             {
                 IsReadOnly = true
             };
 
-            realm = Realm.GetInstance(config);
+            realm = GetRealm(config);
             Assert.Throws<RealmException>(() => realm.Refresh(), "Can't refresh a read-only Realm.");
-            realm.Dispose();
-            DeleteRealmWithRetries(realm);
         }
 
         [Test]

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -42,16 +42,27 @@ namespace Realms.Tests.Database
         [Test]
         public void ReadOnlyInstance_ThrowsOnRefresh()
         {
-            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Guid.NewGuid().ToString());
-            var realm = GetRealm(path);
+            var config = new RealmConfiguration(Guid.NewGuid().ToString());
+            var realm = GetRealm(config);
             realm.Dispose();
-            var config = new RealmConfiguration(path)
-            {
-                IsReadOnly = true
-            };
+
+            config.IsReadOnly = true;
 
             realm = GetRealm(config);
             Assert.Throws<RealmException>(() => realm.Refresh(), "Can't refresh a read-only Realm.");
+        }
+
+        [Test]
+        public void GetTwice_ReadOnlyInstance_DoesNotThrow()
+        {
+            var config = new RealmConfiguration(Guid.NewGuid().ToString());
+            var realm = GetRealm(config);
+            realm.Dispose();
+
+            config.IsReadOnly = true;
+
+            _ = GetRealm(config);
+            Assert.DoesNotThrow(() => GetRealm(config));
         }
 
         [Test]

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -935,6 +935,21 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void Realm_Freeze_ReadOnly()
+        {
+            var config = new RealmConfiguration(Guid.NewGuid().ToString());
+            var realm = GetRealm(config);
+            realm.Dispose();
+
+            config.IsReadOnly = true;
+
+            realm = GetRealm(config);
+            Realm frozenRealm = null;
+            Assert.DoesNotThrow(() => frozenRealm = realm.Freeze());
+            frozenRealm.Dispose();
+        }
+
+        [Test]
         public void Realm_HittingMaxNumberOfVersions_Throws()
         {
             var config = new RealmConfiguration(Guid.NewGuid().ToString())

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -42,27 +42,16 @@ namespace Realms.Tests.Database
         [Test]
         public void ReadOnlyInstance_ThrowsOnRefresh()
         {
-            var config = new RealmConfiguration(Guid.NewGuid().ToString());
-            var realm = GetRealm(config);
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Guid.NewGuid().ToString());
+            var realm = GetRealm(path);
             realm.Dispose();
-
-            config.IsReadOnly = true;
+            var config = new RealmConfiguration(path)
+            {
+                IsReadOnly = true
+            };
 
             realm = GetRealm(config);
             Assert.Throws<RealmException>(() => realm.Refresh(), "Can't refresh a read-only Realm.");
-        }
-
-        [Test]
-        public void GetTwice_ReadOnlyInstance_DoesNotThrow()
-        {
-            var config = new RealmConfiguration(Guid.NewGuid().ToString());
-            var realm = GetRealm(config);
-            realm.Dispose();
-
-            config.IsReadOnly = true;
-
-            _ = GetRealm(config);
-            Assert.DoesNotThrow(() => GetRealm(config));
         }
 
         [Test]

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -128,8 +128,10 @@ Realm::Config get_shared_realm_config(Configuration configuration, SyncConfigura
 
 inline SharedRealm* new_realm(SharedRealm realm)
 {
-    if (!realm->refresh()) {
-        realm->read_group();
+    if (!realm->config().immutable()) {
+        if (!realm->refresh()) {
+            realm->read_group();
+        }
     }
 
     return new SharedRealm(realm);
@@ -517,7 +519,7 @@ REALM_EXPORT SharedRealm* shared_realm_freeze(const SharedRealm& realm, NativeEx
 {
     return handle_errors(ex, [&]() {
         auto frozen_realm = realm->freeze();
-        return new_realm(std::move(frozen_realm));
+        return new SharedRealm(frozen_realm);
     });
 }
 

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -519,7 +519,7 @@ REALM_EXPORT SharedRealm* shared_realm_freeze(const SharedRealm& realm, NativeEx
 {
     return handle_errors(ex, [&]() {
         auto frozen_realm = realm->freeze();
-        return new_realm(std::move(frozen_realm));
+        return new SharedRealm{ frozen_realm };
     });
 }
 

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -130,8 +130,12 @@ inline SharedRealm* new_realm(SharedRealm realm)
 {
     if (!realm->config().immutable()) {
         if (!realm->refresh()) {
+            // this should only be needed for immutable frozen realms
             realm->read_group();
         }
+    }
+    else {
+        realm->read_group();
     }
 
     return new SharedRealm(realm);
@@ -519,7 +523,7 @@ REALM_EXPORT SharedRealm* shared_realm_freeze(const SharedRealm& realm, NativeEx
 {
     return handle_errors(ex, [&]() {
         auto frozen_realm = realm->freeze();
-        return new_realm(std::move(realm));
+        return new_realm(std::move(frozen_realm));
     });
 }
 

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -519,7 +519,7 @@ REALM_EXPORT SharedRealm* shared_realm_freeze(const SharedRealm& realm, NativeEx
 {
     return handle_errors(ex, [&]() {
         auto frozen_realm = realm->freeze();
-        return new SharedRealm{ frozen_realm };
+        return new_realm(std::move(realm));
     });
 }
 

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -128,13 +128,11 @@ Realm::Config get_shared_realm_config(Configuration configuration, SyncConfigura
 
 inline SharedRealm* new_realm(SharedRealm realm)
 {
-    if (!realm->config().immutable()) {
-        if (!realm->refresh()) {
-            // this should only be needed for immutable frozen realms
-            realm->read_group();
-        }
-    }
-    else {
+    // If a Realm is immutable, it can't be refreshed
+    // If we can't refresh the Realm, make sure we begin a read transaction
+    // as a lot of functionality expects an active read transaction and
+    // ObjectStore doesn't always start one automatically.
+    if (realm->config().immutable() || !realm->refresh()) {
         realm->read_group();
     }
 

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -519,7 +519,7 @@ REALM_EXPORT SharedRealm* shared_realm_freeze(const SharedRealm& realm, NativeEx
 {
     return handle_errors(ex, [&]() {
         auto frozen_realm = realm->freeze();
-        return new SharedRealm(frozen_realm);
+        return new_realm(std::move(frozen_realm));
     });
 }
 


### PR DESCRIPTION
## Description
Because the change [#5065](https://github.com/realm/realm-core/pull/5065) in core, the wrappers needed a small change to stop a refresh call when getting a shared instance of a read-only realm.
An extra unit test was added to verify that freezing a read-only realm worked as expected.

Fixes #2718 

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
