### PR TITLE
Fix Where clause with `string.Contains(string a, System.StringComparison)`

### DIFF
--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -21,6 +21,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Realms.Helpers;
+using Remotion.Linq.Parsing.ExpressionVisitors;
+using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
 
 namespace Realms
 {
@@ -71,9 +73,15 @@ namespace Realms
             }
 
             // do all the LINQ expression evaluation to build a query
+            var expression = PartialEvaluatingExpressionVisitor.EvaluateIndependentSubtrees(Expression, new EvaluatableExpressionFilter());
+
             var qv = ((RealmResultsProvider)Provider).MakeVisitor();
-            qv.Visit(Expression);
+            qv.Visit(expression);
             return qv.MakeResultsForQuery();
+        }
+
+        private class EvaluatableExpressionFilter : EvaluatableExpressionFilterBase
+        {
         }
 
         protected override T GetValueAtIndex(int index) => ResultsHandle.GetValueAtIndex(index, Realm).As<T>();

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -315,7 +315,12 @@ namespace Realms
                 }
                 else if (IsStringContainsWithComparison(node.Method, out var index))
                 {
-                    member = node.Arguments[0] as MemberExpression;
+                    // if the signature has only 2 elements, node.Arguments[0] is the value to translate
+                    if (index == 1)
+                    {
+                        member = node.Arguments[0] as MemberExpression;
+                    }
+
                     stringArgumentIndex = index;
                     queryMethod = (q, r, p, v) => q.StringContains(r, p, v, GetComparisonCaseSensitive(node));
                 }

--- a/Realm/Realm/Linq/RealmResultsVisitor.cs
+++ b/Realm/Realm/Linq/RealmResultsVisitor.cs
@@ -315,11 +315,7 @@ namespace Realms
                 }
                 else if (IsStringContainsWithComparison(node.Method, out var index))
                 {
-                    // if the signature has only 2 elements, node.Arguments[0] is the value to translate
-                    if (index == 1)
-                    {
-                        member = node.Arguments[0] as MemberExpression;
-                    }
+                    member = node.Arguments[0] as MemberExpression;
 
                     stringArgumentIndex = index;
                     queryMethod = (q, r, p, v) => q.StringContains(r, p, v, GetComparisonCaseSensitive(node));

--- a/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
@@ -221,6 +221,33 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void SearchComparingStringIQueryable()
+        {
+            var searchString = "et";
+            var containsCaptured = _realm.All<Person>().Where(p => p.FirstName.Contains(searchString));
+            foreach (var p in containsCaptured)
+            {
+                Assert.AreEqual(p.FullName, "Peter Jameson");
+            }
+
+            // case sensitive
+            var searchStringSensitive = "Smi";
+            var containsOrdinalCaptured = _realm.All<Person>().Where(p => p.FirstName.Contains(searchStringSensitive, StringComparison.Ordinal));
+            foreach (var p in containsOrdinalCaptured)
+            {
+                Assert.AreEqual(p.FullName, "John Smith");
+            }
+
+            // ignore case
+            var searchStringInsensitive = "smi";
+            var containsIgnorecaseCaptured = _realm.All<Person>().Where(p => p.FirstName.Contains(searchStringInsensitive, StringComparison.OrdinalIgnoreCase));
+            foreach (var p in containsIgnorecaseCaptured)
+            {
+                Assert.AreEqual(p.FullName, "John Smith");
+            }
+        }
+
+        [Test]
         public void SearchComparingDateTimeOffset()
         {
             var d1960 = new DateTimeOffset(1960, 1, 1, 0, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description
Generating a LINQ query with `string.Contains(string a, System.StringComparison)` where `a` is a captured string, does not substitute right away the captured string. Because of this such parameter is [seen as a `MemberExpression`](https://github.com/realm/realm-dotnet/blob/134936ca02297864dae4664a1412c1f7a17b05ad/Realm/Realm/Linq/RealmResultsVisitor.cs#L318) by `RealmResultVisitor.VisitMethodCall`. Afterwards `RealmResultVisitor.VisitMethodCall` tries to resolve such string `a` param as a Realm [ColumnName](https://github.com/realm/realm-dotnet/blob/134936ca02297864dae4664a1412c1f7a17b05ad/Realm/Realm/Linq/RealmResultsVisitor.cs#L385).


Fixes #2747

##  TODO
* [ ] Find a fix
* [ ] Changelog entry
* [ ] Tests (need advice on what other tests could be added)
