### PR TITLE
Use lowercase "pr" for prerelease packages

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -469,14 +469,14 @@ jobs:
       - #@ template.replace(checkoutCode())
       - name: Set version suffix
         id: set-version-suffix
-        #! Build suffix is PR-1234.5 for PR builds or alpha.123 for branch builds.
+        #! Build suffix is pr-1234.5 for pr builds or alpha.123 for branch builds.
         run: |
           $suffix = ""
           if ($env:GITHUB_EVENT_NAME -eq "pull_request")
           {
             if (-Not "${{ github.head_ref }}".Contains("release"))
             {
-              $suffix = "PR-${{ github.event.number }}.$env:GITHUB_RUN_NUMBER"
+              $suffix = "pr-${{ github.event.number }}.$env:GITHUB_RUN_NUMBER"
             }
           }
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,7 +282,7 @@ jobs:
         {
           if (-Not "${{ github.head_ref }}".Contains("release"))
           {
-            $suffix = "PR-${{ github.event.number }}.$env:GITHUB_RUN_NUMBER"
+            $suffix = "pr-${{ github.event.number }}.$env:GITHUB_RUN_NUMBER"
           }
         }
         else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Internal
 * Using Core x.y.z.
+* Updated naming of prerelease packages to use lowercase "pr" - e.g. `10.7.1-pr-2695.1703` instead of `10.7.1-PR-2695.1703`. (PR [#2765](https://github.com/realm/realm-dotnet/pull/2765))
 
 ## 10.7.1 (2021-11-19)
 


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

S3 urls are case sensitive and nuget package names are lowercased, but versions are not, which resulted in the wrong url being generated - i.e. https://s3.amazonaws.com/realm.nugetpackages/flatcontainer/realm/10.7.1-PR-2695.1703/realm.10.7.1-PR-2695.1703.nupkg instead of https://s3.amazonaws.com/realm.nugetpackages/flatcontainer/realm/10.7.1-pr-2695.1703/realm.10.7.1-pr-2695.1703.nupkg.

##  TODO

* [x] Changelog entry
* [ ] Tests (if applicable)
