### PR TITLE
Changed RefreshAsync implementation

### DIFF
--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -171,6 +171,15 @@ namespace Realms
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool has_changed(SharedRealmHandle sharedRealm);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_latest_version", CallingConvention = CallingConvention.Cdecl)]
+            public static extern UInt64 get_latest_version(SharedRealmHandle sharedRealm);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_current_version", CallingConvention = CallingConvention.Cdecl)]
+            public static extern UInt64 get_current_version(SharedRealmHandle sharedRealm);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_notify", CallingConvention = CallingConvention.Cdecl)]
+            public static extern void notify(SharedRealmHandle realm);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_is_frozen", CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool get_is_frozen(SharedRealmHandle sharedRealm, out NativeException ex);
@@ -203,6 +212,7 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_subscriptions_version", CallingConvention = CallingConvention.Cdecl)]
             public static extern Int64 get_subscriptions_version(SharedRealmHandle realm, out NativeException ex);
+
 
 #pragma warning restore SA1121 // Use built-in type alias
 #pragma warning restore IDE0049 // Use built-in type alias
@@ -461,6 +471,21 @@ namespace Realms
         public bool HasChanged()
         {
             return NativeMethods.has_changed(this);
+        }
+
+        public Native.Version GetLatestVersion()
+        {
+            return new Native.Version(NativeMethods.get_latest_version(this));
+        }
+
+        public Native.Version GetCurrentVersion()
+        {
+            return new Native.Version(NativeMethods.get_current_version(this));
+        }
+
+        public void Notify()
+        {
+            NativeMethods.notify(this);
         }
 
         public SharedRealmHandle Freeze()

--- a/Realm/Realm/Native/Version.cs
+++ b/Realm/Realm/Native/Version.cs
@@ -1,0 +1,54 @@
+﻿// ////////////////////////////////////////////////////////////////////////////
+// //
+// // Copyright 2021 Realm Inc.
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License")
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+// //
+// ////////////////////////////////////////////////////////////////////////////
+
+using System;
+
+namespace Realms.Native
+{
+#pragma warning disable IDE0049 // Use built-in type alias
+
+    internal struct Version : IEquatable<Version>
+    {
+        public readonly UInt64 Value;
+
+        public Version(UInt64 value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(Version other) => Value.Equals(other.Value);
+
+        public override bool Equals(object obj) => obj is Version other && Equals(other);
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(Version left, Version right) => left.Value == right.Value;
+
+        public static bool operator !=(Version left, Version right) => left.Value != right.Value;
+
+        public static bool operator <(Version left, Version right) => left.Value < right.Value;
+
+        public static bool operator >(Version left, Version right) => left.Value > right.Value;
+
+        public static bool operator <=(Version left, Version right) => left.Value <= right.Value;
+
+        public static bool operator >=(Version left, Version right) => left.Value >= right.Value;
+    }
+
+#pragma warning restore IDE0049 // Use built-in type alias
+}

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -94,6 +94,25 @@ public:
         auto transaction = Realm::Internal::get_transaction_ref(*realm);
         return Realm::Internal::get_db(*realm)->has_changed(transaction);
     }
+
+    static DB::version_type get_latest_version(const SharedRealm& realm)
+    {
+        auto transaction = Realm::Internal::get_transaction_ref(*realm);
+        return transaction->get_version_of_latest_snapshot();
+    }
+
+    static DB::version_type get_current_version(const SharedRealm& realm)
+    {
+        auto transaction = Realm::Internal::get_transaction_ref(*realm);
+        return transaction->get_version();
+    }
+
+    static void notify_realm(const SharedRealm& realm)
+    {
+        auto& cord = Realm::Internal::get_coordinator(*realm);
+        cord.on_change();
+    }
+
 };
 
 Realm::Config get_shared_realm_config(Configuration configuration, SyncConfiguration sync_configuration, SchemaObject* objects, int objects_length, SchemaProperty* properties, uint8_t* encryption_key)
@@ -521,6 +540,21 @@ REALM_EXPORT void shared_realm_get_schema(const SharedRealm& realm, void* manage
 REALM_EXPORT bool shared_realm_has_changed(const SharedRealm& realm)
 {
     return TestHelper::has_changed(realm);
+}
+
+REALM_EXPORT uint64_t shared_realm_get_latest_version(const SharedRealm& realm)
+{
+    return TestHelper::get_latest_version(realm);
+}
+
+REALM_EXPORT uint64_t shared_realm_get_current_version(const SharedRealm& realm)
+{
+    return TestHelper::get_current_version(realm);
+}
+
+REALM_EXPORT void shared_realm_notify(SharedRealm& shared_realm)
+{
+    TestHelper::notify_realm(shared_realm);
 }
 
 REALM_EXPORT bool shared_realm_get_is_frozen(const SharedRealm& realm, NativeException::Marshallable& ex)


### PR DESCRIPTION
This PR changes the way that RefreshAsync is implemented. After investigating the hang in #2739 @fealebenpae came up with this solution in which we organically elicit a notification that will advance the realm on another thread. 
This is just a draft and something that the whole team should discuss. I've created the PR so that CI can run and at least we can discover if there are issues with this implementation.

Also probably we do not need to keep the `GetLatestVersion`, `GetCurrentVersion` methods that we created for a different implementation but we could keep the `HasChanged` method for simplicity


Fixes #2739