### PR TITLE
Copy parent metadata when freezing realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Fixed an issue with xUnit tests that would cause `System.Runtime.InteropServices.SEHException` to be thrown whenever Realm was accessed in a non-async test. (Issue [#1865](https://github.com/realm/realm-dotnet/issues/1865))
+* Fixed a bug that would lead to unnecessary metadata allocation when freezing a realm. (Issue [#2789](https://github.com/realm/realm-dotnet/issues/2789))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -283,7 +283,7 @@ namespace Realms
             }
         }
 
-        internal Realm(SharedRealmHandle sharedRealmHandle, RealmConfigurationBase config, RealmSchema schema)
+        internal Realm(SharedRealmHandle sharedRealmHandle, RealmConfigurationBase config, RealmSchema schema, RealmMetadata metadata = null)
         {
             Config = config;
 
@@ -305,7 +305,7 @@ namespace Realms
             _state.AddRealm(this);
 
             SharedRealmHandle = sharedRealmHandle;
-            Metadata = new RealmMetadata(schema.Select(CreateRealmObjectMetadata));
+            Metadata = metadata ?? new RealmMetadata(schema.Select(CreateRealmObjectMetadata));
             Schema = schema;
             IsFrozen = SharedRealmHandle.IsFrozen;
             DynamicApi = new Dynamic(this);
@@ -455,7 +455,7 @@ namespace Realms
             }
 
             var handle = SharedRealmHandle.Freeze();
-            return new Realm(handle, Config, Schema);
+            return new Realm(handle, Config, Schema, Metadata);
         }
 
         private void ThrowIfDisposed()

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -901,6 +901,16 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void FrozenRealms_ReuseParentSchemaAndMetadata()
+        {
+            using var realm = GetRealm();
+            using var frozenRealm = realm.Freeze();
+
+            Assert.That(realm.Schema, Is.SameAs(frozenRealm.Schema));
+            Assert.That(realm.Metadata, Is.SameAs(frozenRealm.Metadata));
+        }
+
+        [Test]
         public void FrozenRealms_GetGarbageCollected()
         {
             TestHelpers.RunAsyncTest(async () =>


### PR DESCRIPTION
Avoiding creating metadata again when freezing a realm, passing it from the parent instead. 

Fixes #2789

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
