### PR TITLE
Strip [UsedImplicitly] from the Remotion assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fixed an issue with xUnit tests that would cause `System.Runtime.InteropServices.SEHException` to be thrown whenever Realm was accessed in a non-async test. (Issue [#1865](https://github.com/realm/realm-dotnet/issues/1865))
 * Fixed a bug that would lead to unnecessary metadata allocation when freezing a realm. (Issue [#2789](https://github.com/realm/realm-dotnet/issues/2789))
 * Fixed an issue that would cause Realm-managed objects (e.g. `RealmObject`, list, results, and so on) allocated during a migration block to keep the Realm open until they are garbage collected. This had subtle implications, such as being unable to delete the Realm shortly after a migration or being unable to open the Realm with a different configuration. (PR [#2795](https://github.com/realm/realm-dotnet/pull/2795))
+* Fixed an issue that prevented Unity3D's IL2CPP compiler to correctly process one of Realm's dependencies. (Issue [#2666](https://github.com/realm/realm-dotnet/issues/2666))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Tools/SetupUnityPackage/Program.cs
+++ b/Tools/SetupUnityPackage/Program.cs
@@ -176,6 +176,21 @@ namespace SetupUnityPackage
                 }
             }
 
+            var relinq = Path.Combine(tempPath, "Remotion.Linq.dll");
+            if (File.Exists(relinq))
+            {
+                const string UsedImplicitlyAttribute = "JetBrains.Annotations.UsedImplicitlyAttribute";
+                Console.WriteLine($"Found Remotion.Linq dependency, stripping {UsedImplicitlyAttribute}");
+                using var stream = File.Open(relinq, FileMode.Open, FileAccess.ReadWrite);
+                using var assembly = Mono.Cecil.AssemblyDefinition.ReadAssembly(stream);
+                var module = assembly.MainModule;
+
+                var usedImplicitly = module.Types.Single(t => t.FullName == UsedImplicitlyAttribute);
+                module.Types.Remove(usedImplicitly);
+
+                assembly.Write();
+            }
+
             var mainPackagePath = Path.Combine(opts.PackageBasePath, info.MainPackagePath);
             if (opts.NoRepack)
             {

--- a/Tools/SetupUnityPackage/SetupUnityPackage.csproj
+++ b/Tools/SetupUnityPackage/SetupUnityPackage.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">


### PR DESCRIPTION
## Description

Fixes #2666 

##  TODO

* [x] Changelog entry
* [x] Tests (manually tested by @DominicFrei)
