### PR TITLE
Avoid possible loop / error with client reset

### DIFF
--- a/Realm/Realm/Handles/SessionHandle.cs
+++ b/Realm/Realm/Handles/SessionHandle.cs
@@ -203,7 +203,7 @@ namespace Realms.Sync
         {
             try
             {
-                using var handle = new SessionHandle(null, sessionHandlePtr);
+                var handle = new SessionHandle(null, sessionHandlePtr);
                 var session = new Session(handle);
                 var messageString = message.AsString();
 
@@ -224,7 +224,18 @@ namespace Realms.Sync
                     exception = new SessionException(messageString, errorCode);
                 }
 
-                Session.RaiseError(session, exception);
+                System.Threading.ThreadPool.QueueUserWorkItem(_ =>
+                {
+                    try
+                    {
+                        Session.RaiseError(session, exception);
+                    }
+                    catch { }
+                    finally
+                    {
+                        handle.Dispose();
+                    }
+                });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR fixes a possible client reset error / loop. This would happen in a situation like:

```csharp
public MainPage()
{
    InitializeRealm();
}

private async void InitializeRealm()
{
    Session.Error += SessionOnError;
    await LoadDataAsync();
}

public Task LoadDataAsync()
{
	_realm = Realm.GetInstance(new SyncConfiguration(partitionKey, _user, realmName));
	await _realm.SyncSession.WaitForDownloadAsync();
    //.... load stuff in the UI
}

private void SessionOnError(object sender, ErrorEventArgs e)
{
    if (e.Exception is ClientResetException clientResetException)
    {
        _realm?.Dispose();
        var didSucceed = clientResetException.InitiateClientReset();

        if (didSucceed)
        {
            LoadDataAsync();
        }
    }
}

```

In this case if there is a client reset then the `SessionOnError` handler will be called. Then the client reset will be initiated and if `didSucceed` will be true, then `LoadDataAsync` is called again, and then we get yet again a new client reset when we reach `WaitForDownloadAsync`. This creates a loop, and is what happens on iOS. 
On Windows, at the moment there is no loop, because correctly `didSucceed` is false as the realm file is in use and can't be removed. This will make it impossible to make a client reset. 

Internally, the reason why this is happening in both cases is because the `SessionOnError` handler is being called in the same thread where the core sync client operates, and thus there are several shared pointers still referencing the sync session here. When we call `InitiateClientReset`, because the sync session is kept alive by those pointers, then there is a problem in correctly executing the client reset itself. 
In order to solve this, we are calling the error event handler on another thread in the thread loop, in order for the shared pointer in the original thread to be freed. The only thing left to do is to free the managed `SessionHandle` after the event handler has been executed. Because we need to do so, we need to instruct the developers that `InitiateClientReset` need to happen on a different thread than the one where the session error is being run. For instance:

```csharp
private void SessionOnError(object sender, ErrorEventArgs e)
{
    if (e.Exception is ClientResetException clientResetException)
    {
        _realm?.Dispose();
            MainThread.BeginInvokeOnMainThread(async () =>
            {
		            var didSucceed = clientResetException.InitiateClientReset();
		    
		            if (didSucceed)
		            {
		                LoadDataAsync();
		            }
			});
    }
}
```
In this case it's being run on the main thread, but it's just a possibility, and it just needs to be run on a different thread. The reason why we need to do so, is to have the possibility of disposing of the last handle, the managed one. (This means that in the thread where the `InitiateClientReset` is called the session is disposed, and can't be used anymore).

All of this needs to be in the docs.

Additionally, and that's something to be addressed in other PRs:
- The progress observables need to be taken care of, as they have a strong reference to the session handle
- At the moment, if a developer-driven action causes a client reset exception (like calling `WaitForDownloadAsync` above), then the exception is not a `ClientResetException`, but a generic error. We should probably change that. 


##  TODO
* [ ] Changelog entry
* [ ] Docs
