### PR TITLE
Don't throw in GetEnumerator when the collection is not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* Fixed an issue that caused `RealmInvalidObjectException` to be caused when enumerating an invalid Realm collection (e.g. a list belonging to a deleted object). (Issue [#2840](https://github.com/realm/realm-dotnet/issues/2840))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -477,16 +477,11 @@ namespace Realms
 
             internal Enumerator(RealmCollectionBase<T> parent)
             {
-                if (!parent.IsValid)
-                {
-                    throw new RealmInvalidObjectException("Can't enumerate the collection because it was deleted or the Realm it is contained in has been closed.");
-                }
-
                 _index = -1;
 
                 // If we didn't snapshot the parent, we should not dispose the results handle, otherwise we'll invalidate the
                 // parent collection after iterating it. Only collections of objects support snapshotting.
-                _shouldDisposeHandle = parent.Handle.Value.CanSnapshot && parent.Metadata != null;
+                _shouldDisposeHandle = parent.IsValid && parent.Handle.Value.CanSnapshot && parent.Metadata != null;
                 _enumerating = _shouldDisposeHandle ? new RealmResults<T>(parent.Realm, parent.Handle.Value.Snapshot(), parent.Metadata) : parent;
             }
 

--- a/Tests/Realm.Tests/Database/CollectionTests.cs
+++ b/Tests/Realm.Tests/Database/CollectionTests.cs
@@ -277,6 +277,44 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void Collection_GetEnumerator_WhenCollectionDeleted_ReturnsEmpty()
+        {
+            var container = new ContainerObject
+            {
+                Items =
+                {
+                    new IntPropertyObject()
+                }
+            };
+
+            _realm.Write(() => _realm.Add(container));
+
+            var collection = (RealmList<IntPropertyObject>)container.Items;
+
+            Assert.That(collection.IsValid);
+
+            var counter = 0;
+            foreach (var value in collection)
+            {
+                counter++;
+            }
+
+            Assert.That(counter, Is.EqualTo(1));
+
+            _realm.Write(() => _realm.Remove(container));
+
+            Assert.That(collection.IsValid, Is.False);
+
+            counter = 0;
+            foreach (var value in collection)
+            {
+                counter++;
+            }
+
+            Assert.That(counter, Is.EqualTo(0));
+        }
+
+        [Test]
         public void ListAsRealmQueryable_RaisesNotifications()
         {
             var joe = new Owner

--- a/Tests/Scripts/DeployCluster.ps1
+++ b/Tests/Scripts/DeployCluster.ps1
@@ -38,3 +38,5 @@ while ($attempt++ -lt 200) {
 
     Write-Output "Cluster state is $state after $($attempt * 5) seconds. Waiting 5 seconds for IDLE"
 }
+
+Write-Output "Command line: --baasurl=https://realm-dev.mongodb.com --baascluster=$ClusterName --baasapikey=$ApiKey --baasprivateapikey=$PrivateApiKey --baasprojectid=$ProjectId"


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Fixes https://github.com/realm/realm-dotnet/issues/2840

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
