### PR TITLE
Don't access Applciation.dataPath from a background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* [Unity] Fixed an issue that caused the weaver to fail when invoked via the `Tools->Realm->Weave Assemblies` editor menu with the error `UnityEngine.UnityException: get_dataPath can only be called from the main thread`. (Issue [#2836](https://github.com/realm/realm-dotnet/issues/2836))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm.UnityWeaver/UnityWeaver.cs
+++ b/Realm/Realm.UnityWeaver/UnityWeaver.cs
@@ -76,6 +76,7 @@ namespace RealmWeaver
             {
                 AnalyticsEnabled = EditorPrefs.GetBool(EnableAnalyticsPref, defaultValue: true);
                 WeaveEditorAssemblies = EditorPrefs.GetBool(WeaveEditorAssembliesPref, defaultValue: false);
+                WeaverAssemblyResolver.ApplicationDataPath = Application.dataPath;
                 WeaveAssembliesOnEditorLaunch();
             };
 

--- a/Realm/Realm.UnityWeaver/WeaverAssemblyResolver.cs
+++ b/Realm/Realm.UnityWeaver/WeaverAssemblyResolver.cs
@@ -22,7 +22,6 @@ using System.IO;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Pdb;
-using UnityEngine;
 
 namespace RealmWeaver
 {
@@ -63,6 +62,8 @@ namespace RealmWeaver
     public class WeaverAssemblyResolver : BaseAssemblyResolver
     {
         private readonly IDictionary<string, AssemblyDefinition> _cache = new Dictionary<string, AssemblyDefinition>();
+
+        public static string ApplicationDataPath { get; set; }
 
         private WeaverAssemblyResolver(IEnumerable<string> references)
         {
@@ -116,7 +117,7 @@ namespace RealmWeaver
                 return assemblyPath;
             }
 
-            return Path.Combine(Application.dataPath, "..", assemblyPath);
+            return Path.Combine(ApplicationDataPath, "..", assemblyPath);
         }
 
         public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)


### PR DESCRIPTION
…the Unity weaver

<!--
Assign reviewers if ready for review.
 -->

## Description

Fixes https://github.com/realm/realm-dotnet/issues/2836

##  TODO

* [x] Changelog entry
* [ ] Tests (if applicable)
