### PR TITLE
Enable nuget cache for unity build

### DIFF
--- a/.github/templates/build-unity.yml
+++ b/.github/templates/build-unity.yml
@@ -1,5 +1,5 @@
 #@ load("@ytt:template", "template")
-#@ load("common.lib.yml", "checkoutCode", "uploadArtifacts", "nugetPackages")
+#@ load("common.lib.yml", "checkoutCode", "uploadArtifacts", "nugetPackages", "setupNugetCache")
 #@ load("test.lib.yml", "fetchPackageArtifacts")
 
 #@ unityPkgName = "io.realm.unity-${{ inputs.version }}.tgz"
@@ -23,6 +23,7 @@ jobs:
     steps:
       - #@ template.replace(checkoutCode())
       - #@ template.replace(fetchPackageArtifacts(packages = nugetPackages))
+      - #@ setupNugetCache([ "Tools/SetupUnityPackage" ])
       - name: Build Unity
         run: dotnet run --project Tools/SetupUnityPackage/ -- realm --packages-path Realm/packages --pack
       - #@ uploadArtifacts(unityPkgName, "Realm/Realm.Unity/" + unityPkgName)

--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -43,6 +43,10 @@ jobs:
       with:
         name: Realm.UnityWeaver.${{ inputs.version }}
         path: ${{ github.workspace }}/Realm/packages/
+    - uses: actions/cache@v2
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('Tools/SetupUnityPackage/*.csproj') }}
     - name: Build Unity
       run: dotnet run --project Tools/SetupUnityPackage/ -- realm --packages-path Realm/packages --pack
     - name: Store artifacts for io.realm.unity-${{ inputs.version }}.tgz


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

https://github.com/realm/realm-dotnet/pull/2860 enabled nuget caching for most builds but I forgot to do it for the Unity package step.

Fixes https://github.com/realm/realm-dotnet/issues/2643.
