### PR TITLE
Fix codeql workflow

### DIFF
--- a/.github/templates/codeql.yml
+++ b/.github/templates/codeql.yml
@@ -25,7 +25,7 @@
   - name: Configure .NET 6
     uses: #@ actionSetupDotnet
     with:
-      dotnet-version: '6.0.x'
+      dotnet-version: '6.0.4'
       include-prerelease: true
 #@ for pkgName in nugetPackages:
   - name: #@ "Build " + pkgName

--- a/.github/templates/codeql.yml
+++ b/.github/templates/codeql.yml
@@ -25,7 +25,7 @@
   - name: Configure .NET 6
     uses: #@ actionSetupDotnet
     with:
-      dotnet-version: '6.0.4'
+      dotnet-version: '6.0.202'
       include-prerelease: true
 #@ for pkgName in nugetPackages:
   - name: #@ "Build " + pkgName

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Configure .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 6.0.4
         include-prerelease: true
     - name: Build Realm.Fody
       run: msbuild Realm/Realm.Fody -p:UseSharedCompilation=false -restore -p:Configuration=Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Configure .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.4
+        dotnet-version: 6.0.202
         include-prerelease: true
     - name: Build Realm.Fody
       run: msbuild Realm/Realm.Fody -p:UseSharedCompilation=false -restore -p:Configuration=Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Configure .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.4'
+        dotnet-version: 6.0.4
         include-prerelease: true
     - name: Build Realm.Fody
       run: msbuild Realm/Realm.Fody -p:UseSharedCompilation=false -restore -p:Configuration=Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Configure .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.4
+        dotnet-version: '6.0.4'
         include-prerelease: true
     - name: Build Realm.Fody
       run: msbuild Realm/Realm.Fody -p:UseSharedCompilation=false -restore -p:Configuration=Release

--- a/Tests/Tests.iOS/AppDelegate.cs
+++ b/Tests/Tests.iOS/AppDelegate.cs
@@ -27,6 +27,7 @@ using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 
+
 namespace Realms.Tests.iOS
 {
     [Register("AppDelegate")]

--- a/Tests/Tests.iOS/AppDelegate.cs
+++ b/Tests/Tests.iOS/AppDelegate.cs
@@ -27,7 +27,6 @@ using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 
-
 namespace Realms.Tests.iOS
 {
     [Register("AppDelegate")]


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

CodeQL only works on Windows 2019, but .NET 6.0.5 requires MSBuild 17 which comes with VS 2022. This pins the version used by the workflow to 6.0.4.
