### PR TITLE
Fixes some annoyances with running tests from VS

### DIFF
--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UnityBuild>false</UnityBuild>
-	<!--
-	The Visual Studio Run Tests context menu command (Ctrl+R, T) always picks the first target framework
-	in the project file, but the NUnit test adapter doesn't support .NET Standard 2.0, so it should never be
-	first in the list.
-	-->
+    <!--
+    The Visual Studio Run Tests context menu command (Ctrl+R, T) always picks the first target framework
+    in the project file, but the NUnit test adapter doesn't support .NET Standard 2.0, so it should never be
+    first in the list.
+    -->
     <TargetFrameworks Condition="'$(MSBuildVersion)' &gt;= '17.0'">$(TargetFrameworks);net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(RuntimeIdentifier)' != 'osx-arm64'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
-	<TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Realms.Tests</RootNamespace>
     <IsTestProject>true</IsTestProject>
@@ -100,19 +100,19 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(UseRealmNupkgsWithVersion)' == ''">
     <None Include="..\..\wrappers\build\Darwin\$(Configuration)\librealm-wrappers.dylib"
-		  Condition="$([MSBuild]::IsOsPlatform('OSX'))">
-		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\wrappers\build\Linux\$(Configuration)\librealm-wrappers.so"
-		  Condition="$([MSBuild]::IsOsPlatform('Linux')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">
+      Condition="$([MSBuild]::IsOsPlatform('Linux')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\wrappers\build\Windows\$(Configuration)-x64\realm-wrappers.dll"
-		  Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">
+      Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\wrappers\build\Windows\$(Configuration)-arm64\realm-wrappers.dll"
-		  Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">
+      Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UnityBuild>false</UnityBuild>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	<!--
+	The Visual Studio Run Tests context menu command (Ctrl+R, T) always picks the first target framework
+	in the project file, but the NUnit test adapter doesn't support .NET Standard 2.0, so it should never be
+	first in the list.
+	-->
     <TargetFrameworks Condition="'$(MSBuildVersion)' &gt;= '17.0'">$(TargetFrameworks);net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(RuntimeIdentifier)' != 'osx-arm64'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+	<TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Realms.Tests</RootNamespace>
     <IsTestProject>true</IsTestProject>
@@ -27,9 +32,10 @@
   <ItemGroup Condition="'$(UnityBuild)' != 'true'">
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnitLite" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" 
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"
       Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UnityBuild)' == 'true'">
@@ -93,16 +99,20 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(UseRealmNupkgsWithVersion)' == ''">
-    <None Include="..\..\wrappers\build\Darwin\$(Configuration)\librealm-wrappers.dylib" Condition="$(RuntimeIdentifier.StartsWith('osx'))">
+    <None Include="..\..\wrappers\build\Darwin\$(Configuration)\librealm-wrappers.dylib"
+		  Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\wrappers\build\Linux\$(Configuration)\librealm-wrappers.so"
+		  Condition="$([MSBuild]::IsOsPlatform('Linux')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\wrappers\build\Linux\$(Configuration)\librealm-wrappers.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+    <None Include="..\..\wrappers\build\Windows\$(Configuration)-x64\realm-wrappers.dll"
+		  Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\wrappers\build\Windows\$(Configuration)-x64\realm-wrappers.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\wrappers\build\Windows\$(Configuration)-arm64\realm-wrappers.dll" Condition="'$(RuntimeIdentifier)' == 'win-arm64'">
+    <None Include="..\..\wrappers\build\Windows\$(Configuration)-arm64\realm-wrappers.dll"
+		  Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description
* Fixes the way wrappers are selected when they are copied over during the compilation of `Realm.Test`
* Adds `Microsoft.NET.Test.Sdk` to satisfy `.netcore3.1` which before was not finding the `testhost`
* Changes the order in which `TargetFrameworks` are inserted in `Realm.Test` since Visual Studio Run Tests context menu just picks up the first in line