### PR TITLE
Add validation and tests when adding invalid (removed) object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
   * Fix one cause of QoS inversion warnings when performing writes on the main thread on Apple platforms. Waiting for async notifications to be ready is now done in a QoS-aware ways.
 * If you set a subscription on a link in flexible sync, the server would not know how to handle it ([#5409](https://github.com/realm/realm-core/issues/5409), since v11.6.1)
 * If a case insensitive query searched for a string including an 4-byte UTF8 character, the program would crash. (Core upgrade)
+* Added validation to prevent adding a removed object using Realm.Add. (Issue [#3020](https://github.com/realm/realm-dotnet/issues/3020))
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -561,6 +561,7 @@ namespace Realms
         {
             ThrowIfDisposed();
             Argument.NotNull(obj, nameof(obj));
+            Argument.Ensure(obj.IsValid, "Cannot add the object to the realm because it has been removed.", nameof(obj));
 
             // This is not obsoleted because the compiler will always pick it for specific types, generating a bunch of warnings
             AddInternal(obj, obj.GetType(), update);
@@ -591,7 +592,12 @@ namespace Realms
         {
             ThrowIfDisposed();
             Argument.NotNull(objs, nameof(objs));
-            Argument.Ensure(objs.All(o => o != null), $"{nameof(objs)} must not contain null values.", nameof(objs));
+
+            foreach (var obj in objs)
+            {
+                Argument.Ensure(obj != null, $"{nameof(objs)} must not contain null objects.", nameof(objs));
+                Argument.Ensure(obj.IsValid, $"{nameof(objs)} must not contain removed objects.", nameof(objs));
+            }
 
             foreach (var obj in objs)
             {

--- a/Tests/Realm.Tests/Database/AddOrUpdateTests.cs
+++ b/Tests/Realm.Tests/Database/AddOrUpdateTests.cs
@@ -1055,6 +1055,57 @@ namespace Realms.Tests.Database
             Assert.That(first.MappedLink.StringValue, Is.EqualTo("Updated"));
         }
 
+        [Test]
+        public void Add_WhenSameRefWasDeleted_ShouldThrow()
+        {
+            var first = new PrimaryKeyObject
+            {
+                Id = 1
+            };
+
+            Assert.That(() =>
+            {
+                _realm.Write(() => _realm.Add(first));
+                _realm.Write(() => _realm.Remove(first));
+                _realm.Write(() => _realm.Add(first));
+            }, Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void AddToList_WhenSameRefWasDeleted_ShouldThrow()
+        {
+            var first = new PrimaryKeyObject
+            {
+                Id = 1
+            };
+
+            Assert.That(() =>
+            {
+                _realm.Write(() => _realm.Add(first));
+                _realm.Write(() => _realm.Remove(first));
+                _realm.Write(() => _realm.Add(new PrimaryKeyWithPKList
+                {
+                    ListValue = { first }
+                }));
+            }, Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void AddMany_WhenSameRefWasDeleted_ShouldThrow()
+        {
+            var first = new PrimaryKeyObject
+            {
+                Id = 1
+            };
+
+            Assert.That(() =>
+            {
+                _realm.Write(() => _realm.Add(first));
+                _realm.Write(() => _realm.Remove(first));
+                _realm.Write(() => _realm.Add(new[] { first }));
+            }, Throws.TypeOf<ArgumentException>());
+        }
+
         private class Parent : RealmObject
         {
             [PrimaryKey]


### PR DESCRIPTION
## Description

Fixes #3020 by validating that objects added via Realm.Add have not been removed prior.

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
