### PR TITLE
Validate that deleting an in-memory realm does not throw if properly disposed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * If you set a subscription on a link in flexible sync, the server would not know how to handle it ([#5409](https://github.com/realm/realm-core/issues/5409), since v11.6.1)
 * If a case insensitive query searched for a string including an 4-byte UTF8 character, the program would crash. (Core upgrade)
 * Added validation to prevent adding a removed object using Realm.Add. (Issue [#3020](https://github.com/realm/realm-dotnet/issues/3020))
+* Added test to validate that deleting a realm containing frozen objects does not throw if the frozen object's realm and the live realm have been disposed. (Issue [#2808](https://github.com/realm/realm-dotnet/issues/2808))
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/Tests/Realm.Tests/Database/InMemoryTests.cs
+++ b/Tests/Realm.Tests/Database/InMemoryTests.cs
@@ -161,5 +161,25 @@ namespace Realms.Tests.Database
                 EncryptionKey = TestHelpers.GetEncryptionKey(23)
             });
         }
+
+        [Test]
+        public void InMemoryRealmWithFrozenObjects_WhenDeleted_DoesNotThrow()
+        {
+            var realm = GetRealm(_config);
+            var frozenObj = realm.Write(() =>
+            {
+                return realm.Add(new IntPropertyObject
+                {
+                    Int = 1
+                }).Freeze();
+            });
+
+            frozenObj.Realm.Dispose();
+            realm.Dispose();
+
+            Assert.That(frozenObj.Realm.IsClosed);
+            Assert.That(realm.IsClosed);
+            Assert.DoesNotThrow(() => Realm.DeleteRealm(_config));
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes #2808 but is likely not a bug; but rather, incorrect usage by the user. The user (see [conversation](https://www.mongodb.com/community/forums/t/frozen-objects-unit-testing/146442)) could not delete a realm containing frozen objects because the realm was still opened.

It is unclear how the user was using the realm but it seems like the user was either (a) disposing of the object's frozen realm or (b) disposing of the live realm before deleting the realm. The user should instead dispose of **both** prior to deleting.

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
