### PR TITLE
Fix crash in RealmObject finalizer due to null _accessor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 * If you set a subscription on a link in flexible sync, the server would not know how to handle it ([#5409](https://github.com/realm/realm-core/issues/5409), since v11.6.1)
 * If a case insensitive query searched for a string including an 4-byte UTF8 character, the program would crash. (Core upgrade)
 * Added validation to prevent adding a removed object using Realm.Add. (Issue [#3020](https://github.com/realm/realm-dotnet/issues/3020))
+* Fixed a NullReferenceException occurring in RealmObject's finalizer whenever an exception is thrown before the object gets initialized. (Issue [#3045](https://github.com/realm/realm-dotnet/issues/3045))
 
 ### Compatibility
 * Realm Studio: 12.0.0 or later.

--- a/Realm/Realm/DatabaseTypes/Accessors/ManagedAccessor.cs
+++ b/Realm/Realm/DatabaseTypes/Accessors/ManagedAccessor.cs
@@ -71,6 +71,11 @@ namespace Realms
             _hashCode = new Lazy<int>(() => _objectHandle.GetObjHash());
         }
 
+        ~ManagedAccessor()
+        {
+            UnsubscribeFromNotifications();
+        }
+
         public RealmValue GetValue(string propertyName)
         {
             return _objectHandle.GetValue(propertyName, _metadata, _realm);

--- a/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmObjectBase.cs
@@ -145,14 +145,6 @@ namespace Realms
         }
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="RealmObjectBase"/> class.
-        /// </summary>
-        ~RealmObjectBase()
-        {
-            UnsubscribeFromNotifications();
-        }
-
-        /// <summary>
         /// Sets the accessor for the newly managed object and possibly adds the object to the realm.
         /// </summary>
         /// <param name="accessor">The accessor to set.</param>

--- a/Tests/Realm.Tests/Database/RealmObjectTests.cs
+++ b/Tests/Realm.Tests/Database/RealmObjectTests.cs
@@ -716,6 +716,27 @@ namespace Realms.Tests.Database
             Assert.That(obj.ToString(), Is.EqualTo($"PrimaryKeyStringObject (removed)"));
         }
 
+        [Test]
+        public void RealmObject_WhenThrowsBeforeInitializer_DoesNotCrash()
+        {
+            // This tests that a RealmObject without an accessor (due to an exception thrown
+            // before being initialized) does not cause a crash (NullReferenceException) once
+            // the object gets GCed. (Simulate a crash by adding a destructor in RealmObject
+            // that tries to access a member on "_accessor".)
+            for (var i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    _ = new ThrowsBeforeInitializer();
+                }
+                catch
+                {
+                }
+
+                GC.Collect();
+            }
+        }
+
         [Serializable]
         public class SerializedObject : RealmObject
         {
@@ -745,6 +766,22 @@ namespace Realms.Tests.Database
             protected internal override void OnManaged()
             {
                 OnManagedCalled++;
+            }
+        }
+
+        private class ThrowsBeforeInitializer : RealmObject
+        {
+            [PrimaryKey]
+            public int Id { get; set; }
+
+            public object WillThrow = new Thrower();
+
+            internal class Thrower
+            {
+                public Thrower()
+                {
+                    throw new Exception("Exception thrown before initializer.");
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes #3045.

When creating a `RealmObject` that throws before being initialized, `_accessor` will be `null`. When the object was garbage collected, `RealmObject`'s destructor would call `_accessor.UnsubscribeFromNotifications()` causing a crash due to `NullReferenceException`.

Solution:
`RealmObject`'s destructor was removed and instead added the call to `UnsubscribeFromNotifications()` in `ManagedAccessor`'s destructor. (For an `UnmanagedAccessor`, a call to `UnsubscribeFromNotifications()` does nothing.)

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
