### PR TITLE
Add VSCode settings for running .NET tests

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "formulahendry.dotnet-test-explorer"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "omnisharp.defaultLaunchSolution": "Realm.sln"
+    "omnisharp.defaultLaunchSolution": "Realm.sln",
+    "dotnet-test-explorer.testProjectPath": "Tests/Realm.Tests/Realm.Tests.csproj"
 }


### PR DESCRIPTION
## Description

Allows to run .NET tests in VSCode by first installing extension **.NET Core Test Explorer**.

##  TODO

* [ ] Changelog entry
* [ ] Tests (if applicable)
