### PR TITLE
Get parent of embedded object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 * Fix a use-after-free when a sync session is closed and the app is destroyed at the same time. (Core upgrade)
+* Fixed returning the parent when accessing it on an `IEmbeddedObject`. (Issue [#2742](https://github.com/realm/realm-dotnet/issues/2742))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm/DatabaseTypes/Accessors/IRealmAccessor.cs
+++ b/Realm/Realm/DatabaseTypes/Accessors/IRealmAccessor.cs
@@ -143,7 +143,8 @@ namespace Realms
 
         /// <summary>
         /// Gets the parent of the <see cref="IEmbeddedObject">embedded object</see>. It can be either another
-        /// <see cref="IEmbeddedObject">embedded object</see> or a standalone <see cref="IRealmObject">realm object</see>.
+        /// <see cref="IEmbeddedObject">embedded object</see>, a standalone <see cref="IRealmObject">realm object</see>,
+        /// or an <see cref="IAsymmetricObject">asymmetric object</see>.
         /// </summary>
         /// <returns>The parent of the embedded object.</returns>
         IRealmObjectBase GetParent();

--- a/Realm/Realm/DatabaseTypes/Accessors/IRealmAccessor.cs
+++ b/Realm/Realm/DatabaseTypes/Accessors/IRealmAccessor.cs
@@ -142,6 +142,13 @@ namespace Realms
             where T : IRealmObjectBase;
 
         /// <summary>
+        /// Gets the parent of the <see cref="IEmbeddedObject">embedded object</see>. It can be either another
+        /// <see cref="IEmbeddedObject">embedded object</see> or a standalone <see cref="IRealmObject">realm object</see>.
+        /// </summary>
+        /// <returns>The parent of the embedded object.</returns>
+        IRealmObjectBase GetParent();
+
+        /// <summary>
         /// A method called internally to subscribe to the notifications for the associated object.
         /// </summary>
         /// <param name="notifyPropertyChangedDelegate">The delegate invoked when a notification is raised.</param>

--- a/Realm/Realm/DatabaseTypes/Accessors/ManagedAccessor.cs
+++ b/Realm/Realm/DatabaseTypes/Accessors/ManagedAccessor.cs
@@ -132,6 +132,19 @@ namespace Realms
             return new RealmResults<T>(_realm, resultsHandle, relatedMeta);
         }
 
+        public IRealmObjectBase GetParent()
+        {
+            if (_metadata.Schema.BaseType != ObjectSchema.ObjectType.EmbeddedObject)
+            {
+                throw new InvalidOperationException("It is not possible to access a parent of an object that is not embedded.");
+            }
+
+            var parentHandle = _objectHandle.GetParent(out var tableKey);
+            var parentMetadata = _realm.Metadata[tableKey];
+
+            return _realm.MakeObject(parentMetadata, parentHandle);
+        }
+
         public void SubscribeForNotifications(Action<string> notifyPropertyChangedDelegate)
         {
             Debug.Assert(_notificationToken == null, "_notificationToken must be null before subscribing.");

--- a/Realm/Realm/DatabaseTypes/Accessors/UnmanagedAccessor.cs
+++ b/Realm/Realm/DatabaseTypes/Accessors/UnmanagedAccessor.cs
@@ -93,10 +93,7 @@ namespace Realms
             throw new NotImplementedException("This should not be used for now");
         }
 
-        public IRealmObjectBase GetParent()
-        {
-            return null;
-        }
+        public IRealmObjectBase GetParent() => null;
 
         public void SubscribeForNotifications(Action<string> notifyPropertyChangedDelegate)
         {

--- a/Realm/Realm/DatabaseTypes/Accessors/UnmanagedAccessor.cs
+++ b/Realm/Realm/DatabaseTypes/Accessors/UnmanagedAccessor.cs
@@ -93,6 +93,11 @@ namespace Realms
             throw new NotImplementedException("This should not be used for now");
         }
 
+        public IRealmObjectBase GetParent()
+        {
+            return null;
+        }
+
         public void SubscribeForNotifications(Action<string> notifyPropertyChangedDelegate)
         {
         }

--- a/Realm/Realm/DatabaseTypes/EmbeddedObject.cs
+++ b/Realm/Realm/DatabaseTypes/EmbeddedObject.cs
@@ -23,10 +23,7 @@ namespace Realms
     /// </summary>
     public class EmbeddedObject : RealmObjectBase, IEmbeddedObject
     {
-        /// <summary>
-        /// Gets the parent of this <see cref="EmbeddedObject"/>. It can be either another
-        /// <see cref="EmbeddedObject"/> or a standalone <see cref="RealmObject"/>.
-        /// </summary>
-        public RealmObjectBase Parent { get; }
+        /// <inheritdoc/>
+        public IRealmObjectBase Parent => ((IRealmObjectBase)this).Accessor.GetParent();
     }
 }

--- a/Realm/Realm/DatabaseTypes/IRealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/IRealmObjectBase.cs
@@ -96,6 +96,11 @@ namespace Realms
     /// </summary>
     public interface IEmbeddedObject : IRealmObjectBase
     {
+        /// <summary>
+        /// Gets the parent of the <see cref="IEmbeddedObject">embedded object</see>. It can be either another
+        /// <see cref="IEmbeddedObject">embedded object</see> or a standalone <see cref="IRealmObject">realm object</see>.
+        /// </summary>
+        public IRealmObjectBase Parent { get; }
     }
 
     /// <summary>

--- a/Realm/Realm/DatabaseTypes/IRealmObjectBase.cs
+++ b/Realm/Realm/DatabaseTypes/IRealmObjectBase.cs
@@ -98,7 +98,8 @@ namespace Realms
     {
         /// <summary>
         /// Gets the parent of the <see cref="IEmbeddedObject">embedded object</see>. It can be either another
-        /// <see cref="IEmbeddedObject">embedded object</see> or a standalone <see cref="IRealmObject">realm object</see>.
+        /// <see cref="IEmbeddedObject">embedded object</see>, a standalone <see cref="IRealmObject">realm object</see>,
+        /// or an <see cref="IAsymmetricObject">asymmetric object</see>.
         /// </summary>
         public IRealmObjectBase Parent { get; }
     }

--- a/Realm/Realm/Handles/ObjectHandle.cs
+++ b/Realm/Realm/Handles/ObjectHandle.cs
@@ -47,6 +47,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_create_embedded", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr create_embedded_link(ObjectHandle handle, IntPtr propertyIndex, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_parent", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr get_parent(ObjectHandle handle, out TableKey tableKey, out NativeException ex);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "object_get_list", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_list(ObjectHandle handle, IntPtr propertyIndex, out NativeException ex);
 
@@ -282,6 +285,16 @@ namespace Realms
             var objPtr = NativeMethods.create_embedded_link(this, propertyIndex, out var ex);
             ex.ThrowIfNecessary();
             return new ObjectHandle(Root, objPtr);
+        }
+
+        public ObjectHandle GetParent(out TableKey tableKey)
+        {
+            EnsureIsOpen();
+
+            var parentObjPtr = NativeMethods.get_parent(this, out tableKey, out var nativeException);
+            nativeException.ThrowIfNecessary();
+
+            return new ObjectHandle(Root, parentObjPtr);
         }
 
         public ResultsHandle GetBacklinks(string propertyName, Metadata metadata)

--- a/Realm/Realm/Schema/ObjectSchema.cs
+++ b/Realm/Realm/Schema/ObjectSchema.cs
@@ -80,7 +80,7 @@ namespace Realms.Schema
         /// Gets a value indicating whether this <see cref="ObjectSchema"/> describes an embedded object.
         /// </summary>
         /// <value><c>true</c> if the schema pertains to an <see cref="EmbeddedObject"/> instance; <c>false</c> otherwise.</value>
-        [Obsolete("Check against RealmSchemaType instead.")]
+        [Obsolete("Check against BaseType instead.")]
         public bool IsEmbedded => BaseType == ObjectType.EmbeddedObject;
 
         /// <summary>

--- a/Tests/Realm.Tests/Database/EmbeddedObjectsTests.cs
+++ b/Tests/Realm.Tests/Database/EmbeddedObjectsTests.cs
@@ -731,6 +731,104 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void EmbeddedObject_WhenParentAccessed_ReturnsParent()
+        {
+            var parent = new ObjectWithEmbeddedProperties
+            {
+                RecursiveObject = new EmbeddedLevel1
+                {
+                    Child = new EmbeddedLevel2
+                    {
+                        Child = new EmbeddedLevel3()
+                    }
+                }
+            };
+
+            _realm.Write(() =>
+            {
+                _realm.Add(parent);
+            });
+
+            Assert.That(parent, Is.EqualTo(parent.RecursiveObject.Parent));
+
+            var firstChild = parent.RecursiveObject;
+            Assert.That(firstChild, Is.EqualTo(firstChild.Child.Parent));
+
+            var secondChild = firstChild.Child;
+            Assert.That(secondChild, Is.EqualTo(secondChild.Child.Parent));
+        }
+
+        [Test]
+        public void EmbeddedObject_WhenParentAccessedInList_ReturnsParent()
+        {
+            var parent = new ObjectWithEmbeddedProperties();
+            parent.ListOfAllTypesObjects.Add(new EmbeddedAllTypesObject());
+
+            _realm.Write(() =>
+            {
+                _realm.Add(parent);
+            });
+
+            Assert.That(parent, Is.EqualTo(parent.ListOfAllTypesObjects.Single().Parent));
+        }
+
+        [Test]
+        public void EmbeddedObject_WhenParentAccessedInDictionary_ReturnsParent()
+        {
+            var parent = new ObjectWithEmbeddedProperties();
+            parent.DictionaryOfAllTypesObjects.Add("child", new EmbeddedAllTypesObject());
+
+            _realm.Write(() =>
+            {
+                _realm.Add(parent);
+            });
+
+            Assert.That(parent, Is.EqualTo(parent.DictionaryOfAllTypesObjects["child"].Parent));
+        }
+
+        [Test]
+        public void EmbeddedObjectUnmanaged_WhenParentAccessed_ReturnsNull()
+        {
+            var parent = new ObjectWithEmbeddedProperties
+            {
+                RecursiveObject = new EmbeddedLevel1
+                {
+                    Child = new EmbeddedLevel2
+                    {
+                        Child = new EmbeddedLevel3()
+                    }
+                }
+            };
+
+            Assert.That(parent.RecursiveObject.Parent, Is.Null);
+
+            var firstChild = parent.RecursiveObject;
+            Assert.That(firstChild.Child.Parent, Is.Null);
+
+            var secondChild = firstChild.Child;
+            Assert.That(secondChild.Child.Parent, Is.Null);
+        }
+
+        [Test]
+        public void NonEmbeddedObject_WhenParentAccessed_Throws()
+        {
+            var topLevel = new IntPropertyObject
+            {
+                Int = 1
+            };
+
+            _realm.Write(() =>
+            {
+                _realm.Add(topLevel);
+            });
+
+            // Objects not implementing IEmbeddedObject will not have the "Parent" field,
+            // but the "GetParent" method is still accessible on its accessor. It should
+            // throw as it should not be used for such objects.
+            Assert.Throws<InvalidOperationException>(() => ((IRealmObjectBase)topLevel).Accessor.GetParent());
+        }
+
+        [Test]
         public void StaticBacklinks()
         {
             var parent = new ObjectWithEmbeddedProperties

--- a/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
+++ b/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
@@ -345,7 +345,7 @@ namespace Realms.Tests.Sync
                     typeof(AsymmetricObjectWithEmbeddedRecursiveObject),
                     typeof(EmbeddedLevel1),
                     typeof(EmbeddedLevel2),
-                    typeof(EmbeddedLevel2)
+                    typeof(EmbeddedLevel3)
                 };
                 using var realm = await GetRealmAsync(flxConfig);
 

--- a/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
+++ b/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
@@ -406,7 +406,6 @@ namespace Realms.Tests.Sync
 
                     Assert.That(parent, Is.EqualTo(parent.ListOfAllTypesObjects.Single().Parent));
                 });
-
             });
         }
 

--- a/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
+++ b/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
@@ -432,6 +432,29 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
+        public void EmbeddedObjectUnmanaged_WhenParentAccessed_ReturnsNull()
+        {
+            var parent = new AsymmetricObjectWithEmbeddedProperties
+            {
+                RecursiveObject = new EmbeddedLevel1
+                {
+                    Child = new EmbeddedLevel2
+                    {
+                        Child = new EmbeddedLevel3()
+                    }
+                }
+            };
+
+            Assert.That(parent.RecursiveObject.Parent, Is.Null);
+
+            var firstChild = parent.RecursiveObject;
+            Assert.That(firstChild.Child.Parent, Is.Null);
+
+            var secondChild = firstChild.Child;
+            Assert.That(secondChild.Child.Parent, Is.Null);
+        }
+
+        [Test]
         public void NonEmbeddedObject_WhenParentAccessed_Throws()
         {
             SyncTestHelpers.RunBaasTestAsync(async () =>

--- a/wrappers/src/object_cs.cpp
+++ b/wrappers/src/object_cs.cpp
@@ -205,6 +205,16 @@ extern "C" {
         });
     }
 
+    REALM_EXPORT Object* object_get_parent(Object& child, TableKey& table_key, NativeException::Marshallable& ex)
+    {
+        return handle_errors(ex, [&]() {
+            Obj parent = child.obj().get_parent_object();
+            table_key = parent.get_table()->get_key();
+
+            return new Object(child.realm(), std::move(parent));
+        });
+    }
+
     REALM_EXPORT void object_set_null(Object& object, size_t property_ndx, NativeException::Marshallable& ex)
     {
         return handle_errors(ex, [&]() {


### PR DESCRIPTION
## Description

Fixes #2742.

Makes `Parent` accessible on `IEmbeddedObject`s and returns `null` for unmanaged embedded objects.

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
