### PR TITLE
Fix an NRE in session property changed callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 * None
 
 ### Fixed
-* None
+* Fixed a NullReferenceException being thrown when subscribing to `PropertyChanged` notifications on a `Session` instance that is then garbage collected prior to unsubscribing. (PR [#3061](https://github.com/realm/realm-dotnet/pull/3061))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.
 
 ### Internal
-* Using Core x.y.z.
+* Using Core 12.9.0.
 
 ## 10.17.0 (2022-10-06)
 

--- a/Realm/Realm/Handles/SessionHandle.cs
+++ b/Realm/Realm/Handles/SessionHandle.cs
@@ -455,6 +455,11 @@ namespace Realms.Sync
                     _ => throw new NotSupportedException($"Unexpected notifiable property value: {property}")
                 };
                 var session = (Session)GCHandle.FromIntPtr(managedSessionHandle).Target;
+                if (session == null)
+                {
+                    // We're taking a weak handle to the session, so it's possible that it's been collected
+                    return;
+                }
 
                 System.Threading.ThreadPool.QueueUserWorkItem(_ =>
                 {


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Reported on the forums: https://www.mongodb.com/community/forums/t/flexible-sync-when-offline/194370/2

##  TODO

* [ ] Changelog entry
* [ ] Tests (if applicable)
