### PR TITLE
Stop snapshotting during iteration on frozen collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 * Fixed a NullReferenceException being thrown when subscribing to `PropertyChanged` notifications on a `Session` instance that is then garbage collected prior to unsubscribing. (PR [#3061](https://github.com/realm/realm-dotnet/pull/3061))
 * Removed bitcode support from the iOS binary as it's no longer accepted for App Store submissions. (Issue [#3059](https://github.com/realm/realm-dotnet/issues/3059))
-* Slightly increased performance and reduced allocations when creating an enumerator for frozen collections (PR [#3067](https://github.com/realm/realm-dotnet/pull/3067)).
+* Slightly increased performance and reduced allocations when creating an enumerator for frozen collections (Issue [#2815](https://github.com/realm/realm-dotnet/issues/2815)).
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * Fixed a NullReferenceException being thrown when subscribing to `PropertyChanged` notifications on a `Session` instance that is then garbage collected prior to unsubscribing. (PR [#3061](https://github.com/realm/realm-dotnet/pull/3061))
 * Removed bitcode support from the iOS binary as it's no longer accepted for App Store submissions. (Issue [#3059](https://github.com/realm/realm-dotnet/issues/3059))
+* Slightly increased performance and reduced allocations when creating an enumerator for frozen collections (PR [#3067](https://github.com/realm/realm-dotnet/pull/3067)).
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -487,17 +487,10 @@ namespace Realms
                 _index = -1;
 
                 // If we didn't snapshot the parent, we should not dispose the results handle, otherwise we'll invalidate the
-                // parent collection after iterating it. Only collections of objects support snapshotting.
+                // parent collection after iterating it. Only collections of objects support snapshotting and we do not need to
+                // snapshot if the collection is frozen.
                 _shouldDisposeHandle = parent.IsValid && !parent.IsFrozen && parent.Handle.Value.CanSnapshot && parent.Metadata != null;
-
-                if (parent.IsFrozen)
-                {
-                    _enumerating = parent;
-                }
-                else
-                {
-                    _enumerating = _shouldDisposeHandle ? new RealmResults<T>(parent.Realm, parent.Handle.Value.Snapshot(), parent.Metadata) : parent;
-                }
+                _enumerating = _shouldDisposeHandle ? new RealmResults<T>(parent.Realm, parent.Handle.Value.Snapshot(), parent.Metadata) : parent;
             }
 
             public T Current => _enumerating[_index];

--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -488,8 +488,16 @@ namespace Realms
 
                 // If we didn't snapshot the parent, we should not dispose the results handle, otherwise we'll invalidate the
                 // parent collection after iterating it. Only collections of objects support snapshotting.
-                _shouldDisposeHandle = parent.IsValid && parent.Handle.Value.CanSnapshot && parent.Metadata != null;
-                _enumerating = _shouldDisposeHandle ? new RealmResults<T>(parent.Realm, parent.Handle.Value.Snapshot(), parent.Metadata) : parent;
+                _shouldDisposeHandle = parent.IsValid && !parent.IsFrozen && parent.Handle.Value.CanSnapshot && parent.Metadata != null;
+
+                if (parent.IsFrozen)
+                {
+                    _enumerating = parent;
+                }
+                else
+                {
+                    _enumerating = _shouldDisposeHandle ? new RealmResults<T>(parent.Realm, parent.Handle.Value.Snapshot(), parent.Metadata) : parent;
+                }
             }
 
             public T Current => _enumerating[_index];

--- a/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
+++ b/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
@@ -341,8 +341,7 @@ namespace Realms.Tests.Sync
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
                 var flxConfig = await GetFLXIntegrationConfigAsync();
-                flxConfig.Schema = new[]
-                {
+                flxConfig.Schema = new[] {
                     typeof(AsymmetricObjectWithEmbeddedRecursiveObject),
                     typeof(EmbeddedLevel1),
                     typeof(EmbeddedLevel2),

--- a/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
+++ b/Tests/Realm.Tests/Sync/AsymmetricObjectTests.cs
@@ -341,7 +341,8 @@ namespace Realms.Tests.Sync
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
                 var flxConfig = await GetFLXIntegrationConfigAsync();
-                flxConfig.Schema = new[] {
+                flxConfig.Schema = new[]
+                {
                     typeof(AsymmetricObjectWithEmbeddedRecursiveObject),
                     typeof(EmbeddedLevel1),
                     typeof(EmbeddedLevel2),


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description
Removes the snapshotting step if the collection is frozen and adds a basic test for that.
Fixes https://github.com/realm/realm-dotnet/issues/2815

##  TODO

* [X] Changelog entry
* [X] Tests (if applicable)
