### PR TITLE
Add native removeAll implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,6 @@ In order to use the source generation the model classes need to be declared impl
 * Seamlessly handle migrating an App Services application deployment model. (Core upgrade)
 * Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
 
-
 ### Fixed
 * Fix a use-after-free when a sync session is closed and the app is destroyed at the same time. (Core upgrade)
 * Fixed a `NullReferenceException` occurring in `RealmObjectBase`'s finalizer whenever an exception is thrown before the object gets initialized. (Issue [#3045](https://github.com/realm/realm-dotnet/issues/3045))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## vNext (TBD)
 
 ### Enhancements
-* Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
 * Added two extension methods on `IDictionary` to get an `IQueryable` collection wrapping the dictionary's values:
   * `dictionary.AsRealmQueryable()` allows you to get a `IQueryable<T>` from `IDictionary<string, T>` that can be then treated as a regular queryable collection and filtered/ordered with LINQ or `Filter(string)`.
   * `dictionary.Filter(query, arguments)` will filter the list and return a filtered collection of dictionary's values. It is roughly equivalent to `dictionary.AsRealmQueryable().Filter(query, arguments)`.
@@ -9,6 +8,7 @@
   The resulting queryable collection will behave identically to the results obtained by calling `realm.All<T>()`, i.e. it will emit notifications when it changes and automatically update itself. (Issue [#2647](https://github.com/realm/realm-dotnet/issues/2647))
 * Improve performance of client reset with automatic recovery and converting top-level tables into embedded tables. (Core upgrade)
 * Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. (Core upgrade)
+* Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
 
 ### Fixed
 * Prevented `IEmbeddedObject`s and `IAsymmetricObject`s from being used as `RealmValue`s when added to a realm, and displaying more meaningful error messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
+* Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
 * Added two extension methods on `IDictionary` to get an `IQueryable` collection wrapping the dictionary's values:
   * `dictionary.AsRealmQueryable()` allows you to get a `IQueryable<T>` from `IDictionary<string, T>` that can be then treated as a regular queryable collection and filtered/ordered with LINQ or `Filter(string)`.
   * `dictionary.Filter(query, arguments)` will filter the list and return a filtered collection of dictionary's values. It is roughly equivalent to `dictionary.AsRealmQueryable().Filter(query, arguments)`.
@@ -78,7 +79,6 @@ In order to use the source generation the model classes need to be declared impl
 * Prioritize integration of local changes over remote changes - shorten the time users may have to wait when committing local changes. Stop storing downloaded changesets in history. (Core upgrade)
 * Greatly improve the performance of sorting or distincting a Dictionary's keys or values. The most expensive operation is now performed O(log N) rather than O(N log N) times, and large Dictionaries can see upwards of 99% reduction in time to sort. (Core upgrade)
 * Seamlessly handle migrating an App Services application deployment model. (Core upgrade)
-* Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
 
 ### Fixed
 * Fix a use-after-free when a sync session is closed and the app is destroyed at the same time. (Core upgrade)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ In order to use the source generation the model classes need to be declared impl
 * Prioritize integration of local changes over remote changes - shorten the time users may have to wait when committing local changes. Stop storing downloaded changesets in history. (Core upgrade)
 * Greatly improve the performance of sorting or distincting a Dictionary's keys or values. The most expensive operation is now performed O(log N) rather than O(N log N) times, and large Dictionaries can see upwards of 99% reduction in time to sort. (Core upgrade)
 * Seamlessly handle migrating an App Services application deployment model. (Core upgrade)
+* Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
+
 
 ### Fixed
 * Fix a use-after-free when a sync session is closed and the app is destroyed at the same time. (Core upgrade)

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -225,7 +225,7 @@ namespace Realms
 
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_remove_all", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool remove_all(SharedRealmHandle sharedRealm, out NativeException ex);
-            
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_sync_session", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_session(SharedRealmHandle realm, out NativeException ex);
 

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -223,6 +223,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_remove_type", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool remove_type(SharedRealmHandle sharedRealm, [MarshalAs(UnmanagedType.LPWStr)] string typeName, IntPtr typeLength, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_remove_all", CallingConvention = CallingConvention.Cdecl)]
+            public static extern bool remove_all(SharedRealmHandle sharedRealm, out NativeException ex);
+            
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_sync_session", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_session(SharedRealmHandle realm, out NativeException ex);
 
@@ -688,6 +691,13 @@ namespace Realms
         public bool RemoveType(string typeName)
         {
             var result = NativeMethods.remove_type(this, typeName, (IntPtr)typeName.Length, out var nativeException);
+            nativeException.ThrowIfNecessary();
+            return result;
+        }
+
+        public bool RemoveAll()
+        {
+            var result = NativeMethods.remove_all(this, out var nativeException);
             nativeException.ThrowIfNecessary();
             return result;
         }

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -1575,11 +1575,7 @@ namespace Realms
         {
             ThrowIfDisposed();
 
-            foreach (var metadata in Metadata.Values)
-            {
-                using var resultsHandle = SharedRealmHandle.CreateResults(metadata.TableKey);
-                resultsHandle.Clear(SharedRealmHandle);
-            }
+            this.SharedRealmHandle.RemoveAll();
         }
 
         /// <summary>

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -1575,7 +1575,7 @@ namespace Realms
         {
             ThrowIfDisposed();
 
-            this.SharedRealmHandle.RemoveAll();
+            SharedRealmHandle.RemoveAll();
         }
 
         /// <summary>

--- a/Tests/Realm.Tests/Database/RemoveTests.cs
+++ b/Tests/Realm.Tests/Database/RemoveTests.cs
@@ -182,7 +182,7 @@ namespace Realms.Tests.Database
             // Reopen with the complete schema
             r1 = Realm.GetInstance(c1);
             Assert.That(r1.All<Person>(), Is.Empty);
-            r1.Dispose();
+// 1.Dispose();
         }
 
         [Test]

--- a/Tests/Realm.Tests/Database/RemoveTests.cs
+++ b/Tests/Realm.Tests/Database/RemoveTests.cs
@@ -154,6 +154,38 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void RemoveAllObjectsShouldClearEntireDatabaseWithPartialSchema()
+        {
+            var c1 = new RealmConfiguration
+            {
+                Schema = new[] { typeof(Person), typeof(IntPrimaryKeyWithValueObject) }
+            };
+            var r1 = Realm.GetInstance(c1);
+            r1.Write(() =>
+            {
+                r1.Add(new Person());
+            });
+            r1.Dispose();
+
+            // Open with a subset of the schema
+            var c2 = new RealmConfiguration
+            {
+                Schema = new[] { typeof(IntPrimaryKeyWithValueObject) }
+            };
+            var r2 = Realm.GetInstance(c2);
+            r2.Write(() =>
+            {
+                r2.RemoveAll();
+            });
+            r2.Dispose();
+
+            // Reopen with the complete schema
+            r1 = Realm.GetInstance(c1);
+            Assert.That(r1.All<Person>(), Is.Empty);
+            r1.Dispose();
+        }
+
+        [Test]
         public void RemoveObject_FromAnotherRealm_ShouldThrow()
         {
             PerformWithOtherRealm(null, other =>

--- a/Tests/Realm.Tests/Database/RemoveTests.cs
+++ b/Tests/Realm.Tests/Database/RemoveTests.cs
@@ -177,9 +177,10 @@ namespace Realms.Tests.Database
             {
                 r2.RemoveAll();
             });
+            r2.Dispose();
 
             // Reopen with the complete schema
-            r1 = Realm.GetInstance(c1);
+            r1 = GetRealm(c1);
             Assert.That(r1.All<Person>(), Is.Empty);
         }
 

--- a/Tests/Realm.Tests/Database/RemoveTests.cs
+++ b/Tests/Realm.Tests/Database/RemoveTests.cs
@@ -160,7 +160,7 @@ namespace Realms.Tests.Database
             {
                 Schema = new[] { typeof(Person), typeof(IntPrimaryKeyWithValueObject) }
             };
-            var r1 = Realm.GetInstance(c1);
+            var r1 = GetRealm(c1);
             r1.Write(() =>
             {
                 r1.Add(new Person());
@@ -172,17 +172,15 @@ namespace Realms.Tests.Database
             {
                 Schema = new[] { typeof(IntPrimaryKeyWithValueObject) }
             };
-            var r2 = Realm.GetInstance(c2);
+            var r2 = GetRealm(c2);
             r2.Write(() =>
             {
                 r2.RemoveAll();
             });
-            r2.Dispose();
 
             // Reopen with the complete schema
             r1 = Realm.GetInstance(c1);
             Assert.That(r1.All<Person>(), Is.Empty);
-// 1.Dispose();
         }
 
         [Test]

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -542,8 +542,8 @@ namespace Realms.Tests.Sync
                 await WaitForUploadAsync(realm);
 
                 Assert.That(realm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), Is.EqualTo(DummyDataSize / 2));
-                
-                realm.Write(() => {realm.RemoveAll();});
+
+                realm.Write(() => { realm.RemoveAll(); });
 
                 Assert.That(realm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), Is.EqualTo(0));
                 await WaitForUploadAsync(realm);

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -525,6 +525,40 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
+        public void RemoveAll_RemovesAllElements([Values(true, false)] bool originalEncrypted)
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                var realmConfig = await GetIntegrationConfigAsync(Guid.NewGuid().ToString());
+                if (originalEncrypted)
+                {
+                    realmConfig.EncryptionKey = TestHelpers.GetEncryptionKey(42);
+                }
+
+                using var realm = GetRealm(realmConfig);
+
+                AddDummyData(realm, true);
+
+                await WaitForUploadAsync(realm);
+
+                Assert.That(realm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), Is.EqualTo(DummyDataSize / 2));
+                
+                realm.Write(() => {realm.RemoveAll();});
+
+                Assert.That(realm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), Is.EqualTo(0));
+                await WaitForUploadAsync(realm);
+                realm.Dispose();
+
+                // Ensure that the Realm can be deleted from the filesystem. If the sync
+                // session was still using it, we would get a permission denied error.
+                Assert.That(DeleteRealmWithRetries(realm), Is.True);
+
+                using var asyncRealm = await GetRealmAsync(realmConfig);
+                Assert.That(asyncRealm.All<ObjectIdPrimaryKeyWithValueObject>().Count(), Is.EqualTo(0));
+            });
+        }
+
+        [Test]
         public void WriteCopy_FailsWhenNotFinished([Values(true, false)] bool originalEncrypted,
                                                    [Values(true, false)] bool copyEncrypted)
         {

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -760,8 +760,8 @@ REALM_EXPORT bool shared_realm_remove_all(const SharedRealm& realm, NativeExcept
         realm->verify_in_write();
 
         auto& group = realm->read_group();
-        for (auto table_key : all_tables.get_table_keys()) {
-            auto table = all_tables.get_table(table_key);
+        for (auto table_key : group.get_table_keys()) {
+            auto table = group.get_table(table_key);
             if (table->get_name().begins_with("class_")) {
                 table->clear();
             }

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -760,7 +760,7 @@ REALM_EXPORT bool shared_realm_remove_all(const SharedRealm& realm, NativeExcept
         realm->verify_in_write();
 
         auto& group = realm->read_group();
-        for(realm::TableKey table_key : all_tables.get_table_keys()) {
+        for (auto table_key : all_tables.get_table_keys()) {
             auto table = all_tables.get_table(table_key);
             if (table->get_name().begins_with("class_")) {
                 table->clear();

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -762,7 +762,9 @@ REALM_EXPORT bool shared_realm_remove_all(const SharedRealm& realm, NativeExcept
         realm::Group& all_tables = realm->read_group();
         for(realm::TableKey table_key : all_tables.get_table_keys()) {
             auto table = all_tables.get_table(table_key);
-            table->clear();
+            if (table->get_name().begins_with("class_")) {
+                table->clear();
+            }
         }
         return true;
     });

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -754,6 +754,19 @@ REALM_EXPORT bool shared_realm_remove_type(const SharedRealm& realm, uint16_t* t
     });
 }
 
+REALM_EXPORT bool shared_realm_remove_all(const SharedRealm& realm, NativeException::Marshallable& ex)
+{
+    return handle_errors(ex, [&]() {
+        realm->verify_in_write();
+
+        for(auto object_schema : realm->schema()) {
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
+            table->clear();
+        }
+        return true;
+    });
+}
+
 REALM_EXPORT SharedSyncSession* shared_realm_get_sync_session(SharedRealm& realm, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&] {

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -759,9 +759,9 @@ REALM_EXPORT bool shared_realm_remove_all(const SharedRealm& realm, NativeExcept
     return handle_errors(ex, [&]() {
         realm->verify_in_write();
 
-        auto full_schema = ObjectStore::schema_from_group(realm->read_group());
-        for(auto object_schema : full_schema) {
-            auto table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
+        realm::Group& all_tables = realm->read_group();
+        for(realm::TableKey table_key : all_tables.get_table_keys()) {
+            auto table = all_tables.get_table(table_key);
             table->clear();
         }
         return true;

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -759,7 +759,8 @@ REALM_EXPORT bool shared_realm_remove_all(const SharedRealm& realm, NativeExcept
     return handle_errors(ex, [&]() {
         realm->verify_in_write();
 
-        for(auto object_schema : realm->schema()) {
+        auto full_schema = ObjectStore::schema_from_group(realm->read_group());
+        for(auto object_schema : full_schema) {
             auto table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
             table->clear();
         }

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -759,7 +759,7 @@ REALM_EXPORT bool shared_realm_remove_all(const SharedRealm& realm, NativeExcept
     return handle_errors(ex, [&]() {
         realm->verify_in_write();
 
-        realm::Group& all_tables = realm->read_group();
+        auto& group = realm->read_group();
         for(realm::TableKey table_key : all_tables.get_table_keys()) {
             auto table = all_tables.get_table(table_key);
             if (table->get_name().begins_with("class_")) {


### PR DESCRIPTION
## Description
Uses a single native call to remove all objects from Realm through `Realm.RemoveAll()`
Fixes https://github.com/realm/realm-dotnet/issues/2233

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
