### PR TITLE
Fix unmanaged schema for bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,30 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Added two extension methods on `IDictionary` to get an `IQueryable` collection wrapping the dictionary's values:
+  * `dictionary.AsRealmQueryable()` allows you to get a `IQueryable<T>` from `IDictionary<string, T>` that can be then treated as a regular queryable collection and filtered/ordered with LINQ or `Filter(string)`.
+  * `dictionary.Filter(query, arguments)` will filter the list and return a filtered collection of dictionary's values. It is roughly equivalent to `dictionary.AsRealmQueryable().Filter(query, arguments)`.
+
+  The resulting queryable collection will behave identically to the results obtained by calling `realm.All<T>()`, i.e. it will emit notifications when it changes and automatically update itself. (Issue [#2647](https://github.com/realm/realm-dotnet/issues/2647))
+* Improve performance of client reset with automatic recovery and converting top-level tables into embedded tables. (Core upgrade)
+* Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. (Core upgrade)
 
 ### Fixed
 * Prevented `IEmbeddedObject`s and `IAsymmetricObject`s from being used as `RealmValue`s when added to a realm, and displaying more meaningful error messages.
+* Fix a use-after-free if the last external reference to an encrypted Realm was closed between when a client reset error was received and when the download of the new Realm began. (Core upgrade)
+* Fixed an assertion failure during client reset with recovery when recovering a list operation on an embedded object that has a link column in the path prefix to the list from the top level object. (Core upgrade)
+* Opening an unencrypted file with an encryption key would sometimes report a misleading error message that indicated that the problem was something other than a decryption failure. (Core upgrade)
+* Fix a rare deadlock which could occur when closing a synchronized Realm immediately after committing a write transaction when the sync worker thread has also just finished processing a changeset from the server. (Core upgrade)
+* Fix a race condition which could result in "operation cancelled" errors being delivered to async open callbacks rather than the actual sync error which caused things to fail. (Core upgrade)
+* Bootstraps will not be applied in a single write transaction - they will be applied 1MB of changesets at a time, or as configured by the SDK. (Core upgrade)
+* Fix database corruption and encryption issues on apple platforms. (Core upgrade)
 * Fixed an issue that would cause an exception when using unmanaged objects in bindings (Issue [#3094](https://github.com/realm/realm-dotnet/issues/3094))
 
 ### Compatibility
-* Realm Studio: 11.0.0 or later.
+* Realm Studio: 12.0.0 or later.
 
 ### Internal
-* Using Core x.y.z.
+* Using Core 12.12.0.
 
 ## 10.18.0 (2022-11-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Prevented `IEmbeddedObject`s and `IAsymmetricObject`s from being used as `RealmValue`s when added to a realm, and displaying more meaningful error messages.
+* Fixed an issue that would cause an exception when using unmanaged objects in bindings (Issue [#3094](https://github.com/realm/realm-dotnet/issues/3094))
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.

--- a/Realm/Realm.SourceGenerator/ClassCodeBuilder.cs
+++ b/Realm/Realm.SourceGenerator/ClassCodeBuilder.cs
@@ -691,6 +691,8 @@ return;".Indent());
 
             return $@"internal class {_unmanagedAccessorClassName} : UnmanagedAccessor, {_accessorInterfaceName}
 {{
+    public override ObjectSchema ObjectSchema => {_classInfo.Name}.RealmSchema;
+
 {propertiesString.Indent(trimNewLines: true)}
 
     public {_unmanagedAccessorClassName}(Type objectType) : base(objectType)

--- a/Realm/Realm/DataBinding/RealmObjectTypeDelegator.cs
+++ b/Realm/Realm/DataBinding/RealmObjectTypeDelegator.cs
@@ -45,7 +45,18 @@ namespace Realms.DataBinding
                 return null;
             }
 
-            if (_schema.Any(p => p.ManagedName == name))
+            if (_schema != null)
+            {
+                if (_schema.Any(p => p.ManagedName == name))
+                {
+                    return _propertyCache.GetOrAdd(name, n => new WovenPropertyInfo(result));
+                }
+
+                return result;
+            }
+
+            // Schema is null only for woven unmanaged objects
+            if (result?.GetCustomAttribute<WovenPropertyAttribute>() != null)
             {
                 return _propertyCache.GetOrAdd(name, n => new WovenPropertyInfo(result));
             }

--- a/Realm/Realm/DataBinding/RealmObjectTypeDelegator.cs
+++ b/Realm/Realm/DataBinding/RealmObjectTypeDelegator.cs
@@ -45,18 +45,8 @@ namespace Realms.DataBinding
                 return null;
             }
 
-            if (_schema != null)
-            {
-                if (_schema.Any(p => p.ManagedName == name))
-                {
-                    return _propertyCache.GetOrAdd(name, n => new WovenPropertyInfo(result));
-                }
-
-                return result;
-            }
-
             // Schema is null only for woven unmanaged objects
-            if (result?.GetCustomAttribute<WovenPropertyAttribute>() != null)
+            if (_schema?.Any(p => p.ManagedName == name) ?? result.GetCustomAttribute<WovenPropertyAttribute>() != null)
             {
                 return _propertyCache.GetOrAdd(name, n => new WovenPropertyInfo(result));
             }

--- a/Realm/Realm/DatabaseTypes/Accessors/UnmanagedAccessor.cs
+++ b/Realm/Realm/DatabaseTypes/Accessors/UnmanagedAccessor.cs
@@ -50,7 +50,7 @@ namespace Realms
         public Realm Realm => null;
 
         /// <inheritdoc/>
-        public ObjectSchema ObjectSchema => null;
+        public virtual ObjectSchema ObjectSchema => null;
 
         /// <inheritdoc/>
         public int BacklinksCount => 0;

--- a/Tests/Realm.Tests/Database/ObjectSchemaTests.cs
+++ b/Tests/Realm.Tests/Database/ObjectSchemaTests.cs
@@ -1533,17 +1533,6 @@ namespace Realms.Tests.Database
             Assert.That(builder["Bar"], Is.EqualTo(bar));
         }
 
-#if !TEST_WEAVER
-        [Test]
-        public void UnmanagedObject_ShouldHaveSchema()
-        {
-            var person = new Person();
-
-            Assert.That(person.ObjectSchema, Is.Not.Null);
-            Assert.That(person.ObjectSchema.Count, Is.AtLeast(1));
-        }
-#endif
-
         private static void ValidateBuiltSchema(ObjectSchema.Builder builder, params Property[] expectedProperties)
         {
             var schema = builder.Build();

--- a/Tests/Realm.Tests/Database/ObjectSchemaTests.cs
+++ b/Tests/Realm.Tests/Database/ObjectSchemaTests.cs
@@ -1533,6 +1533,17 @@ namespace Realms.Tests.Database
             Assert.That(builder["Bar"], Is.EqualTo(bar));
         }
 
+#if !TEST_WEAVER
+        [Test]
+        public void UnmanagedObject_ShouldHaveSchema()
+        {
+            var person = new Person();
+
+            Assert.That(person.ObjectSchema, Is.Not.Null);
+            Assert.That(person.ObjectSchema.Count, Is.AtLeast(1));
+        }
+#endif
+
         private static void ValidateBuiltSchema(ObjectSchema.Builder builder, params Property[] expectedProperties)
         {
             var schema = builder.Build();

--- a/Tests/Realm.Tests/Database/RealmObjectTests.cs
+++ b/Tests/Realm.Tests/Database/RealmObjectTests.cs
@@ -133,12 +133,15 @@ namespace Realms.Tests.Database
         }
 
         [Test]
-        public void RealmObject_ObjectSchema_ReturnsValueWhenManaged()
+        public void RealmObject_ObjectSchema_ReturnsValueWhenManagedAndUnmanaged()
         {
             var person = new Person();
 
+#if TEST_WEAVER
             Assert.That(person.ObjectSchema, Is.Null);
-
+#else
+            Assert.That(person.ObjectSchema, Is.Not.Null);
+#endif
             _realm.Write(() =>
             {
                 _realm.Add(person);

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/A_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/A_generated.cs
@@ -248,6 +248,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class AUnmanagedAccessor : UnmanagedAccessor, IAAccessor
     {
+        public override ObjectSchema ObjectSchema => A.RealmSchema;
+
         private bool _value;
         public bool Value
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AgedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AgedObject_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class AgedObjectUnmanagedAccessor : UnmanagedAccessor, IAgedObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => AgedObject.RealmSchema;
+
         private DateTimeOffset _birthday;
         public DateTimeOffset Birthday
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesObject_generated.cs
@@ -592,6 +592,8 @@ namespace Realms.Tests.Generated
 
     internal class AllTypesObjectUnmanagedAccessor : UnmanagedAccessor, IAllTypesObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => AllTypesObject.RealmSchema;
+
         private char _charProperty;
         public char CharProperty
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithAllTypes_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithAllTypes_generated.cs
@@ -542,6 +542,8 @@ namespace Realms.Tests.Sync.Generated
 
     internal class AsymmetricObjectWithAllTypesUnmanagedAccessor : UnmanagedAccessor, IAsymmetricObjectWithAllTypesAccessor
     {
+        public override ObjectSchema ObjectSchema => AsymmetricObjectWithAllTypes.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedDictionaryObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedDictionaryObject_generated.cs
@@ -256,6 +256,8 @@ namespace Realms.Tests.Sync.Generated
 
     internal class AsymmetricObjectWithEmbeddedDictionaryObjectUnmanagedAccessor : UnmanagedAccessor, IAsymmetricObjectWithEmbeddedDictionaryObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => AsymmetricObjectWithEmbeddedDictionaryObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedListObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedListObject_generated.cs
@@ -256,6 +256,8 @@ namespace Realms.Tests.Sync.Generated
 
     internal class AsymmetricObjectWithEmbeddedListObjectUnmanagedAccessor : UnmanagedAccessor, IAsymmetricObjectWithEmbeddedListObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => AsymmetricObjectWithEmbeddedListObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedRecursiveObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedRecursiveObject_generated.cs
@@ -243,6 +243,8 @@ namespace Realms.Tests.Sync.Generated
 
     internal class AsymmetricObjectWithEmbeddedRecursiveObjectUnmanagedAccessor : UnmanagedAccessor, IAsymmetricObjectWithEmbeddedRecursiveObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => AsymmetricObjectWithEmbeddedRecursiveObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/B_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/B_generated.cs
@@ -236,6 +236,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class BUnmanagedAccessor : UnmanagedAccessor, IBAccessor
     {
+        public override ObjectSchema ObjectSchema => B.RealmSchema;
+
         private IntPropertyObject _c;
         public IntPropertyObject C
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BacklinkObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BacklinkObject_generated.cs
@@ -264,6 +264,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class BacklinkObjectUnmanagedAccessor : UnmanagedAccessor, IBacklinkObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => BacklinkObject.RealmSchema;
+
         private string _beforeBacklinks;
         public string BeforeBacklinks
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Bar_DuplicateClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Bar_DuplicateClass_generated.cs
@@ -234,6 +234,8 @@ namespace Bar.Generated
 
     internal class DuplicateClassUnmanagedAccessor : UnmanagedAccessor, IDuplicateClassAccessor
     {
+        public override ObjectSchema ObjectSchema => DuplicateClass.RealmSchema;
+
         private string _stringValue;
         public string StringValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BasicAsymmetricObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BasicAsymmetricObject_generated.cs
@@ -245,6 +245,8 @@ namespace Realms.Tests.Sync.Generated
 
     internal class BasicAsymmetricObjectUnmanagedAccessor : UnmanagedAccessor, IBasicAsymmetricObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => BasicAsymmetricObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Child_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Child_generated.cs
@@ -261,6 +261,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ChildUnmanagedAccessor : UnmanagedAccessor, IChildAccessor
     {
+        public override ObjectSchema ObjectSchema => Child.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Cities_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Cities_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class CitiesUnmanagedAccessor : UnmanagedAccessor, ICitiesAccessor
     {
+        public override ObjectSchema ObjectSchema => Cities.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithUnqueryableMembers_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithUnqueryableMembers_generated.cs
@@ -302,6 +302,8 @@ namespace Realms.Tests.Generated
 
     internal class ClassWithUnqueryableMembersUnmanagedAccessor : UnmanagedAccessor, IClassWithUnqueryableMembersAccessor
     {
+        public override ObjectSchema ObjectSchema => ClassWithUnqueryableMembers.RealmSchema;
+
         private string _realPropertyToSatisfyWeaver;
         public string RealPropertyToSatisfyWeaver
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CollectionsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CollectionsObject_generated.cs
@@ -1955,6 +1955,8 @@ namespace Realms.Tests.Generated
 
     internal class CollectionsObjectUnmanagedAccessor : UnmanagedAccessor, ICollectionsObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => CollectionsObject.RealmSchema;
+
         public ISet<char> CharSet { get; } = new HashSet<char>(RealmSet<char>.Comparer);
 
         public ISet<byte> ByteSet { get; } = new HashSet<byte>(RealmSet<byte>.Comparer);

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CompletionReport_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CompletionReport_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class CompletionReportUnmanagedAccessor : UnmanagedAccessor, ICompletionReportAccessor
     {
+        public override ObjectSchema ObjectSchema => CompletionReport.RealmSchema;
+
         private DateTimeOffset _completionDate;
         public DateTimeOffset CompletionDate
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ContainerObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ContainerObject_generated.cs
@@ -244,6 +244,8 @@ namespace Realms.Tests.Generated
 
     internal class ContainerObjectUnmanagedAccessor : UnmanagedAccessor, IContainerObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => ContainerObject.RealmSchema;
+
         public IList<IntPropertyObject> Items { get; } = new List<IntPropertyObject>();
 
         public ContainerObjectUnmanagedAccessor(Type objectType) : base(objectType)

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CounterObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CounterObject_generated.cs
@@ -312,6 +312,8 @@ namespace Realms.Tests.Generated
 
     internal class CounterObjectUnmanagedAccessor : UnmanagedAccessor, ICounterObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => CounterObject.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DecimalsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DecimalsObject_generated.cs
@@ -242,6 +242,8 @@ namespace Realms.Tests.Generated
 
     internal class DecimalsObjectUnmanagedAccessor : UnmanagedAccessor, IDecimalsObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => DecimalsObject.RealmSchema;
+
         private decimal _decimalValue;
         public decimal DecimalValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DictionariesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DictionariesObject_generated.cs
@@ -834,6 +834,8 @@ namespace Realms.Tests.Generated
 
     internal class DictionariesObjectUnmanagedAccessor : UnmanagedAccessor, IDictionariesObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => DictionariesObject.RealmSchema;
+
         public IDictionary<string, char> CharDictionary { get; } = new Dictionary<string, char>();
 
         public IDictionary<string, byte> ByteDictionary { get; } = new Dictionary<string, byte>();

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
@@ -290,6 +290,8 @@ namespace Realms.Tests.Generated
 
     internal class DogUnmanagedAccessor : UnmanagedAccessor, IDogAccessor
     {
+        public override ObjectSchema ObjectSchema => Dog.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicDog_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicDog_generated.cs
@@ -277,6 +277,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class DynamicDogUnmanagedAccessor : UnmanagedAccessor, IDynamicDogAccessor
     {
+        public override ObjectSchema ObjectSchema => DynamicDog.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicOwner_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicOwner_generated.cs
@@ -366,6 +366,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class DynamicOwnerUnmanagedAccessor : UnmanagedAccessor, IDynamicOwnerAccessor
     {
+        public override ObjectSchema ObjectSchema => DynamicOwner.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubSubTask_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubSubTask_generated.cs
@@ -271,6 +271,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class DynamicSubSubTaskUnmanagedAccessor : UnmanagedAccessor, IDynamicSubSubTaskAccessor
     {
+        public override ObjectSchema ObjectSchema => DynamicSubSubTask.RealmSchema;
+
         private string _summary;
         public string Summary
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubTask_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubTask_generated.cs
@@ -270,6 +270,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class DynamicSubTaskUnmanagedAccessor : UnmanagedAccessor, IDynamicSubTaskAccessor
     {
+        public override ObjectSchema ObjectSchema => DynamicSubTask.RealmSchema;
+
         private string _summary;
         public string Summary
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicTask_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicTask_generated.cs
@@ -318,6 +318,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class DynamicTaskUnmanagedAccessor : UnmanagedAccessor, IDynamicTaskAccessor
     {
+        public override ObjectSchema ObjectSchema => DynamicTask.RealmSchema;
+
         private string _id;
         public string Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedAllTypesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedAllTypesObject_generated.cs
@@ -612,6 +612,8 @@ namespace Realms.Tests.Generated
 
     internal class EmbeddedAllTypesObjectUnmanagedAccessor : UnmanagedAccessor, IEmbeddedAllTypesObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => EmbeddedAllTypesObject.RealmSchema;
+
         private char _charProperty;
         public char CharProperty
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedGuidType_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedGuidType_generated.cs
@@ -443,6 +443,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class EmbeddedGuidTypeUnmanagedAccessor : UnmanagedAccessor, IEmbeddedGuidTypeAccessor
     {
+        public override ObjectSchema ObjectSchema => EmbeddedGuidType.RealmSchema;
+
         private Guid _regularProperty;
         public Guid RegularProperty
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedIntPropertyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedIntPropertyObject_generated.cs
@@ -235,6 +235,8 @@ namespace Realms.Tests.Generated
 
     internal class EmbeddedIntPropertyObjectUnmanagedAccessor : UnmanagedAccessor, IEmbeddedIntPropertyObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => EmbeddedIntPropertyObject.RealmSchema;
+
         private int _int;
         public int Int
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel1_generated.cs
@@ -270,6 +270,8 @@ namespace Realms.Tests.Generated
 
     internal class EmbeddedLevel1UnmanagedAccessor : UnmanagedAccessor, IEmbeddedLevel1Accessor
     {
+        public override ObjectSchema ObjectSchema => EmbeddedLevel1.RealmSchema;
+
         private string _string;
         public string String
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel2_generated.cs
@@ -270,6 +270,8 @@ namespace Realms.Tests.Generated
 
     internal class EmbeddedLevel2UnmanagedAccessor : UnmanagedAccessor, IEmbeddedLevel2Accessor
     {
+        public override ObjectSchema ObjectSchema => EmbeddedLevel2.RealmSchema;
+
         private string _string;
         public string String
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel3_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel3_generated.cs
@@ -237,6 +237,8 @@ namespace Realms.Tests.Generated
 
     internal class EmbeddedLevel3UnmanagedAccessor : UnmanagedAccessor, IEmbeddedLevel3Accessor
     {
+        public override ObjectSchema ObjectSchema => EmbeddedLevel3.RealmSchema;
+
         private string _string;
         public string String
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ExplicitClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ExplicitClass_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ExplicitClassUnmanagedAccessor : UnmanagedAccessor, IExplicitClassAccessor
     {
+        public override ObjectSchema ObjectSchema => ExplicitClass.RealmSchema;
+
         private int _foo;
         public int Foo
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Foo_DuplicateClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Foo_DuplicateClass_generated.cs
@@ -234,6 +234,8 @@ namespace Foo.Generated
 
     internal class DuplicateClassUnmanagedAccessor : UnmanagedAccessor, IDuplicateClassAccessor
     {
+        public override ObjectSchema ObjectSchema => DuplicateClass.RealmSchema;
+
         private int _intValue;
         public int IntValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/GuidType_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/GuidType_generated.cs
@@ -460,6 +460,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class GuidTypeUnmanagedAccessor : UnmanagedAccessor, IGuidTypeAccessor
     {
+        public override ObjectSchema ObjectSchema => GuidType.RealmSchema;
+
         private Guid _id;
         public Guid Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/HugeSyncObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/HugeSyncObject_generated.cs
@@ -245,6 +245,8 @@ namespace Realms.Tests.Generated
 
     internal class HugeSyncObjectUnmanagedAccessor : UnmanagedAccessor, IHugeSyncObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => HugeSyncObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexedDateTimeOffsetObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexedDateTimeOffsetObject_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class IndexedDateTimeOffsetObjectUnmanagedAccessor : UnmanagedAccessor, IIndexedDateTimeOffsetObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => IndexedDateTimeOffsetObject.RealmSchema;
+
         private DateTimeOffset _dateTimeOffset;
         public DateTimeOffset DateTimeOffset
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPrimaryKeyWithValueObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPrimaryKeyWithValueObject_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Generated
 
     internal class IntPrimaryKeyWithValueObjectUnmanagedAccessor : UnmanagedAccessor, IIntPrimaryKeyWithValueObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => IntPrimaryKeyWithValueObject.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPropertyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPropertyObject_generated.cs
@@ -270,6 +270,8 @@ namespace Realms.Tests.Generated
 
     internal class IntPropertyObjectUnmanagedAccessor : UnmanagedAccessor, IIntPropertyObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => IntPropertyObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/InternalObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/InternalObject_generated.cs
@@ -220,6 +220,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class InternalObjectUnmanagedAccessor : UnmanagedAccessor, IInternalObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => InternalObject.RealmSchema;
+
         private int _intProperty;
         public int IntProperty
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level1_generated.cs
@@ -248,6 +248,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class Level1UnmanagedAccessor : UnmanagedAccessor, ILevel1Accessor
     {
+        public override ObjectSchema ObjectSchema => Level1.RealmSchema;
+
         private string _stringValue;
         public string StringValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level2_generated.cs
@@ -248,6 +248,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class Level2UnmanagedAccessor : UnmanagedAccessor, ILevel2Accessor
     {
+        public override ObjectSchema ObjectSchema => Level2.RealmSchema;
+
         private int _intValue;
         public int IntValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level3_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level3_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class Level3UnmanagedAccessor : UnmanagedAccessor, ILevel3Accessor
     {
+        public override ObjectSchema ObjectSchema => Level3.RealmSchema;
+
         private DateTimeOffset _dateValue;
         public DateTimeOffset DateValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ListsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ListsObject_generated.cs
@@ -815,6 +815,8 @@ namespace Realms.Tests.Generated
 
     internal class ListsObjectUnmanagedAccessor : UnmanagedAccessor, IListsObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => ListsObject.RealmSchema;
+
         public IList<char> CharList { get; } = new List<char>();
 
         public IList<byte> ByteList { get; } = new List<byte>();

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/LoneClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/LoneClass_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class LoneClassUnmanagedAccessor : UnmanagedAccessor, ILoneClassAccessor
     {
+        public override ObjectSchema ObjectSchema => LoneClass.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties1_generated.cs
@@ -289,6 +289,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class MixedProperties1UnmanagedAccessor : UnmanagedAccessor, IMixedProperties1Accessor
     {
+        public override ObjectSchema ObjectSchema => MixedProperties1.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties2_generated.cs
@@ -289,6 +289,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class MixedProperties2UnmanagedAccessor : UnmanagedAccessor, IMixedProperties2Accessor
     {
+        public override ObjectSchema ObjectSchema => MixedProperties2.RealmSchema;
+
         public IList<Person> Friends { get; } = new List<Person>();
 
         private int _age;

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoListProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoListProperties_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class NoListPropertiesUnmanagedAccessor : UnmanagedAccessor, INoListPropertiesAccessor
     {
+        public override ObjectSchema ObjectSchema => NoListProperties.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyObject_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class NonPrimaryKeyObjectUnmanagedAccessor : UnmanagedAccessor, INonPrimaryKeyObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => NonPrimaryKeyObject.RealmSchema;
+
         private string _stringValue;
         public string StringValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithNonPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithNonPKRelation_generated.cs
@@ -248,6 +248,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class NonPrimaryKeyWithNonPKRelationUnmanagedAccessor : UnmanagedAccessor, INonPrimaryKeyWithNonPKRelationAccessor
     {
+        public override ObjectSchema ObjectSchema => NonPrimaryKeyWithNonPKRelation.RealmSchema;
+
         private string _stringValue;
         public string StringValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithPKRelation_generated.cs
@@ -248,6 +248,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class NonPrimaryKeyWithPKRelationUnmanagedAccessor : UnmanagedAccessor, INonPrimaryKeyWithPKRelationAccessor
     {
+        public override ObjectSchema ObjectSchema => NonPrimaryKeyWithPKRelation.RealmSchema;
+
         private string _stringValue;
         public string StringValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NullablePrimaryKeyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NullablePrimaryKeyObject_generated.cs
@@ -244,6 +244,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class NullablePrimaryKeyObjectUnmanagedAccessor : UnmanagedAccessor, INullablePrimaryKeyObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => NullablePrimaryKeyObject.RealmSchema;
+
         private long? _id;
         public long? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectIdPrimaryKeyWithValueObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectIdPrimaryKeyWithValueObject_generated.cs
@@ -245,6 +245,8 @@ namespace Realms.Tests.Generated
 
     internal class ObjectIdPrimaryKeyWithValueObjectUnmanagedAccessor : UnmanagedAccessor, IObjectIdPrimaryKeyWithValueObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => ObjectIdPrimaryKeyWithValueObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV1_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ObjectV1UnmanagedAccessor : UnmanagedAccessor, IObjectV1Accessor
     {
+        public override ObjectSchema ObjectSchema => ObjectV1.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV2_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ObjectV2UnmanagedAccessor : UnmanagedAccessor, IObjectV2Accessor
     {
+        public override ObjectSchema ObjectSchema => ObjectV2.RealmSchema;
+
         private string _id;
         public string Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithEmbeddedProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithEmbeddedProperties_generated.cs
@@ -296,6 +296,8 @@ namespace Realms.Tests.Generated
 
     internal class ObjectWithEmbeddedPropertiesUnmanagedAccessor : UnmanagedAccessor, IObjectWithEmbeddedPropertiesAccessor
     {
+        public override ObjectSchema ObjectSchema => ObjectWithEmbeddedProperties.RealmSchema;
+
         private int _primaryKey;
         public int PrimaryKey
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithObjectProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithObjectProperties_generated.cs
@@ -245,6 +245,8 @@ namespace Realms.Tests.Generated
 
     internal class ObjectWithObjectPropertiesUnmanagedAccessor : UnmanagedAccessor, IObjectWithObjectPropertiesAccessor
     {
+        public override ObjectSchema ObjectSchema => ObjectWithObjectProperties.RealmSchema;
+
         private IntPropertyObject _standaloneObject;
         public IntPropertyObject StandaloneObject
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithPartitionValue_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithPartitionValue_generated.cs
@@ -270,6 +270,8 @@ namespace Realms.Tests.Sync.Generated
 
     internal class ObjectWithPartitionValueUnmanagedAccessor : UnmanagedAccessor, IObjectWithPartitionValueAccessor
     {
+        public override ObjectSchema ObjectSchema => ObjectWithPartitionValue.RealmSchema;
+
         private string _id;
         public string Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithRequiredStringList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithRequiredStringList_generated.cs
@@ -244,6 +244,8 @@ namespace Realms.Tests.Generated
 
     internal class ObjectWithRequiredStringListUnmanagedAccessor : UnmanagedAccessor, IObjectWithRequiredStringListAccessor
     {
+        public override ObjectSchema ObjectSchema => ObjectWithRequiredStringList.RealmSchema;
+
         public IList<string> Strings { get; } = new List<string>();
 
         public ObjectWithRequiredStringListUnmanagedAccessor(Type objectType) : base(objectType)

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnManagedTestClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnManagedTestClass_generated.cs
@@ -271,6 +271,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class OnManagedTestClassUnmanagedAccessor : UnmanagedAccessor, IOnManagedTestClassAccessor
     {
+        public override ObjectSchema ObjectSchema => OnManagedTestClass.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneListProperty_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneListProperty_generated.cs
@@ -244,6 +244,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class OneListPropertyUnmanagedAccessor : UnmanagedAccessor, IOneListPropertyAccessor
     {
+        public override ObjectSchema ObjectSchema => OneListProperty.RealmSchema;
+
         public IList<Person> People { get; } = new List<Person>();
 
         public OneListPropertyUnmanagedAccessor(Type objectType) : base(objectType)

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneNonListProperty_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneNonListProperty_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class OneNonListPropertyUnmanagedAccessor : UnmanagedAccessor, IOneNonListPropertyAccessor
     {
+        public override ObjectSchema ObjectSchema => OneNonListProperty.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnlyListProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnlyListProperties_generated.cs
@@ -263,6 +263,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class OnlyListPropertiesUnmanagedAccessor : UnmanagedAccessor, IOnlyListPropertiesAccessor
     {
+        public override ObjectSchema ObjectSchema => OnlyListProperties.RealmSchema;
+
         public IList<Person> Friends { get; } = new List<Person>();
 
         public IList<Person> Enemies { get; } = new List<Person>();

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedContainer_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedContainer_generated.cs
@@ -263,6 +263,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class OrderedContainerUnmanagedAccessor : UnmanagedAccessor, IOrderedContainerAccessor
     {
+        public override ObjectSchema ObjectSchema => OrderedContainer.RealmSchema;
+
         public IList<OrderedObject> Items { get; } = new List<OrderedObject>();
 
         public IDictionary<string, OrderedObject> ItemsDictionary { get; } = new Dictionary<string, OrderedObject>();

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedObject_generated.cs
@@ -245,6 +245,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class OrderedObjectUnmanagedAccessor : UnmanagedAccessor, IOrderedObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => OrderedObject.RealmSchema;
+
         private int _order;
         public int Order
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Owner_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Owner_generated.cs
@@ -290,6 +290,8 @@ namespace Realms.Tests.Generated
 
     internal class OwnerUnmanagedAccessor : UnmanagedAccessor, IOwnerAccessor
     {
+        public override ObjectSchema ObjectSchema => Owner.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Parent_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Parent_generated.cs
@@ -261,6 +261,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ParentUnmanagedAccessor : UnmanagedAccessor, IParentAccessor
     {
+        public override ObjectSchema ObjectSchema => Parent.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
@@ -392,6 +392,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class PersonUnmanagedAccessor : UnmanagedAccessor, IPersonAccessor
     {
+        public override ObjectSchema ObjectSchema => Person.RealmSchema;
+
         private string _firstName;
         public string FirstName
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyByteObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyByteObject_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyByteObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyByteObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyByteObject.RealmSchema;
+
         private byte _id;
         public byte Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyCharObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyCharObject_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyCharObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyCharObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyCharObject.RealmSchema;
+
         private char _id;
         public char Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyGuidObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyGuidObject_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyGuidObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyGuidObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyGuidObject.RealmSchema;
+
         private Guid _id;
         public Guid Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt16Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt16Object_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyInt16ObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyInt16ObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyInt16Object.RealmSchema;
+
         private short _id;
         public short Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt32Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt32Object_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyInt32ObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyInt32ObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyInt32Object.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt64Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt64Object_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyInt64ObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyInt64ObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyInt64Object.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableByteObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableByteObject_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyNullableByteObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyNullableByteObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyNullableByteObject.RealmSchema;
+
         private byte? _id;
         public byte? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableCharObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableCharObject_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyNullableCharObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyNullableCharObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyNullableCharObject.RealmSchema;
+
         private char? _id;
         public char? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableGuidObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableGuidObject_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyNullableGuidObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyNullableGuidObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyNullableGuidObject.RealmSchema;
+
         private Guid? _id;
         public Guid? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt16Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt16Object_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyNullableInt16ObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyNullableInt16ObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyNullableInt16Object.RealmSchema;
+
         private short? _id;
         public short? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt32Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt32Object_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyNullableInt32ObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyNullableInt32ObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyNullableInt32Object.RealmSchema;
+
         private int? _id;
         public int? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt64Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt64Object_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyNullableInt64ObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyNullableInt64ObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyNullableInt64Object.RealmSchema;
+
         private long? _id;
         public long? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableObjectIdObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableObjectIdObject_generated.cs
@@ -232,6 +232,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyNullableObjectIdObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyNullableObjectIdObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyNullableObjectIdObject.RealmSchema;
+
         private ObjectId? _id;
         public ObjectId? Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObjectIdObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObjectIdObject_generated.cs
@@ -232,6 +232,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyObjectIdObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyObjectIdObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyObjectIdObject.RealmSchema;
+
         private ObjectId _id;
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObject_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class PrimaryKeyObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyObject.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyStringObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyStringObject_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Generated
 
     internal class PrimaryKeyStringObjectUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyStringObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyStringObject.RealmSchema;
+
         private string _id;
         public string Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNoPKList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNoPKList_generated.cs
@@ -270,6 +270,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class PrimaryKeyWithNoPKListUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyWithNoPKListAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyWithNoPKList.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKChildWithPKGrandChild_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKChildWithPKGrandChild_generated.cs
@@ -261,6 +261,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class PrimaryKeyWithNonPKChildWithPKGrandChildUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyWithNonPKChildWithPKGrandChildAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyWithNonPKChildWithPKGrandChild.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKRelation_generated.cs
@@ -261,6 +261,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class PrimaryKeyWithNonPKRelationUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyWithNonPKRelationAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyWithNonPKRelation.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKList_generated.cs
@@ -270,6 +270,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class PrimaryKeyWithPKListUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyWithPKListAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyWithPKList.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKRelation_generated.cs
@@ -261,6 +261,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class PrimaryKeyWithPKRelationUnmanagedAccessor : UnmanagedAccessor, IPrimaryKeyWithPKRelationAccessor
     {
+        public override ObjectSchema ObjectSchema => PrimaryKeyWithPKRelation.RealmSchema;
+
         private long _id;
         public long Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Product_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Product_generated.cs
@@ -283,6 +283,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ProductUnmanagedAccessor : UnmanagedAccessor, IProductAccessor
     {
+        public override ObjectSchema ObjectSchema => Product.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmValueObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmValueObject_generated.cs
@@ -324,6 +324,8 @@ namespace Realms.Tests.Generated
 
     internal class RealmValueObjectUnmanagedAccessor : UnmanagedAccessor, IRealmValueObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => RealmValueObject.RealmSchema;
+
         private int _id = TestHelpers.Random.Next();
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RecursiveBacklinksObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RecursiveBacklinksObject_generated.cs
@@ -265,6 +265,8 @@ namespace Realms.Tests.Generated
 
     internal class RecursiveBacklinksObjectUnmanagedAccessor : UnmanagedAccessor, IRecursiveBacklinksObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => RecursiveBacklinksObject.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedPropertiesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedPropertiesObject_generated.cs
@@ -247,6 +247,8 @@ namespace Realms.Tests.Generated
 
     internal class RemappedPropertiesObjectUnmanagedAccessor : UnmanagedAccessor, IRemappedPropertiesObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => RemappedPropertiesObject.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedTypeObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedTypeObject_generated.cs
@@ -351,6 +351,8 @@ namespace Realms.Tests.Generated
 
     internal class RemappedTypeObjectUnmanagedAccessor : UnmanagedAccessor, IRemappedTypeObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => RemappedTypeObject.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Report_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Report_generated.cs
@@ -274,6 +274,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ReportUnmanagedAccessor : UnmanagedAccessor, IReportAccessor
     {
+        public override ObjectSchema ObjectSchema => Report.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPrimaryKeyStringObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPrimaryKeyStringObject_generated.cs
@@ -244,6 +244,8 @@ namespace Realms.Tests.Generated
 
     internal class RequiredPrimaryKeyStringObjectUnmanagedAccessor : UnmanagedAccessor, IRequiredPrimaryKeyStringObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => RequiredPrimaryKeyStringObject.RealmSchema;
+
         private string _id;
         public string Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPropertyClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPropertyClass_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class RequiredPropertyClassUnmanagedAccessor : UnmanagedAccessor, IRequiredPropertyClassAccessor
     {
+        public override ObjectSchema ObjectSchema => RequiredPropertyClass.RealmSchema;
+
         private string _fooRequired;
         public string FooRequired
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredStringObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredStringObject_generated.cs
@@ -231,6 +231,8 @@ namespace Realms.Tests.Generated
 
     internal class RequiredStringObjectUnmanagedAccessor : UnmanagedAccessor, IRequiredStringObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => RequiredStringObject.RealmSchema;
+
         private string _string;
         public string String
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SerializedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SerializedObject_generated.cs
@@ -308,6 +308,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class SerializedObjectUnmanagedAccessor : UnmanagedAccessor, ISerializedObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => SerializedObject.RealmSchema;
+
         private int _intValue;
         public int IntValue
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SomeClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SomeClass_generated.cs
@@ -235,6 +235,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class SomeClassUnmanagedAccessor : UnmanagedAccessor, ISomeClassAccessor
     {
+        public override ObjectSchema ObjectSchema => SomeClass.RealmSchema;
+
         private BacklinkObject _backlinkObject;
         public BacklinkObject BacklinkObject
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncAllTypesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncAllTypesObject_generated.cs
@@ -446,6 +446,8 @@ namespace Realms.Tests.Generated
 
     internal class SyncAllTypesObjectUnmanagedAccessor : UnmanagedAccessor, ISyncAllTypesObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => SyncAllTypesObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncCollectionsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncCollectionsObject_generated.cs
@@ -1196,6 +1196,8 @@ namespace Realms.Tests.Generated
 
     internal class SyncCollectionsObjectUnmanagedAccessor : UnmanagedAccessor, ISyncCollectionsObjectAccessor
     {
+        public override ObjectSchema ObjectSchema => SyncCollectionsObject.RealmSchema;
+
         private ObjectId _id = ObjectId.GenerateNewId();
         public ObjectId Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncObjectWithRequiredStringList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncObjectWithRequiredStringList_generated.cs
@@ -257,6 +257,8 @@ namespace Realms.Tests.Sync.Generated
 
     internal class SyncObjectWithRequiredStringListUnmanagedAccessor : UnmanagedAccessor, ISyncObjectWithRequiredStringListAccessor
     {
+        public override ObjectSchema ObjectSchema => SyncObjectWithRequiredStringList.RealmSchema;
+
         private string _id;
         public string Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ThrowsBeforeInitializer_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ThrowsBeforeInitializer_generated.cs
@@ -234,6 +234,8 @@ namespace Realms.Tests.Database.Generated
 
     internal class ThrowsBeforeInitializerUnmanagedAccessor : UnmanagedAccessor, IThrowsBeforeInitializerAccessor
     {
+        public override ObjectSchema ObjectSchema => ThrowsBeforeInitializer.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/UnqueryableBacklinks_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/UnqueryableBacklinks_generated.cs
@@ -235,6 +235,8 @@ namespace Realms.Tests.Generated
 
     internal class UnqueryableBacklinksUnmanagedAccessor : UnmanagedAccessor, IUnqueryableBacklinksAccessor
     {
+        public override ObjectSchema ObjectSchema => UnqueryableBacklinks.RealmSchema;
+
         private ClassWithUnqueryableMembers _parent;
         public ClassWithUnqueryableMembers Parent
         {

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Walker_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Walker_generated.cs
@@ -290,6 +290,8 @@ namespace Realms.Tests.Generated
 
     internal class WalkerUnmanagedAccessor : UnmanagedAccessor, IWalkerAccessor
     {
+        public override ObjectSchema ObjectSchema => Walker.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesClass_generated.cs
@@ -592,6 +592,8 @@ namespace SourceGeneratorAssemblyToProcess.Generated
 
     internal class AllTypesClassUnmanagedAccessor : UnmanagedAccessor, IAllTypesClassAccessor
     {
+        public override ObjectSchema ObjectSchema => AllTypesClass.RealmSchema;
+
         private char _charProperty;
         public char CharProperty
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AutomaticPropertiesClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AutomaticPropertiesClass_generated.cs
@@ -234,6 +234,8 @@ namespace SourceGeneratorAssemblyToProcess.Generated
 
     internal class AutomaticPropertiesClassUnmanagedAccessor : UnmanagedAccessor, IAutomaticPropertiesClassAccessor
     {
+        public override ObjectSchema ObjectSchema => AutomaticPropertiesClass.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithoutParameterlessConstructor_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithoutParameterlessConstructor_generated.cs
@@ -236,6 +236,8 @@ namespace SourceGeneratorAssemblyToProcess.Generated
 
     internal class ClassWithoutParameterlessConstructorUnmanagedAccessor : UnmanagedAccessor, IClassWithoutParameterlessConstructorAccessor
     {
+        public override ObjectSchema ObjectSchema => ClassWithoutParameterlessConstructor.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
@@ -248,6 +248,8 @@ namespace SourceGeneratorPlayground.Generated
 
     internal class DogUnmanagedAccessor : UnmanagedAccessor, IDogAccessor
     {
+        public override ObjectSchema ObjectSchema => Dog.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedObj_generated.cs
@@ -237,6 +237,8 @@ namespace SourceGeneratorPlayground.Generated
 
     internal class EmbeddedObjUnmanagedAccessor : UnmanagedAccessor, IEmbeddedObjAccessor
     {
+        public override ObjectSchema ObjectSchema => EmbeddedObj.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NamespaceObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NamespaceObj_generated.cs
@@ -249,6 +249,8 @@ namespace SourceGeneratorAssemblyToProcess.Generated
 
     internal class NamespaceObjUnmanagedAccessor : UnmanagedAccessor, INamespaceObjAccessor
     {
+        public override ObjectSchema ObjectSchema => NamespaceObj.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoNamespaceClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoNamespaceClass_generated.cs
@@ -230,6 +230,8 @@ namespace Global.Generated
 
     internal class NoNamespaceClassUnmanagedAccessor : UnmanagedAccessor, INoNamespaceClassAccessor
     {
+        public override ObjectSchema ObjectSchema => NoNamespaceClass.RealmSchema;
+
         private string _name;
         public string Name
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OtherNamespaceObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OtherNamespaceObj_generated.cs
@@ -234,6 +234,8 @@ namespace OtherNamespace.Generated
 
     internal class OtherNamespaceObjUnmanagedAccessor : UnmanagedAccessor, IOtherNamespaceObjAccessor
     {
+        public override ObjectSchema ObjectSchema => OtherNamespaceObj.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PartialClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PartialClass_generated.cs
@@ -247,6 +247,8 @@ namespace SourceGeneratorAssemblyToProcess.Generated
 
     internal class PartialClassUnmanagedAccessor : UnmanagedAccessor, IPartialClassAccessor
     {
+        public override ObjectSchema ObjectSchema => PartialClass.RealmSchema;
+
         private int _id;
         public int Id
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
@@ -261,6 +261,8 @@ namespace SourceGeneratorPlayground.Generated
 
     internal class PersonUnmanagedAccessor : UnmanagedAccessor, IPersonAccessor
     {
+        public override ObjectSchema ObjectSchema => Person.RealmSchema;
+
         private Guid _id = Guid.NewGuid();
         public Guid Id
         {

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmObj_generated.cs
@@ -234,6 +234,8 @@ namespace SourceGeneratorPlayground.Generated
 
     internal class RealmObjUnmanagedAccessor : UnmanagedAccessor, IRealmObjAccessor
     {
+        public override ObjectSchema ObjectSchema => RealmObj.RealmSchema;
+
         private int _id;
         public int Id
         {


### PR DESCRIPTION
Added schema for unmanaged generated objects and fixed `RealmObjectTypeDelegator` when used with unmanaged objects


## Description

Fixes #3094 and #3086

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
