### PR TITLE
disambiguate error message when getting a defaultStorageFolder for realm or app-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Improve performance of client reset with automatic recovery and converting top-level tables into embedded tables. (Core upgrade)
 * Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. (Core upgrade)
 * Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
-* Improve error messages when setting a BaseFilePath for realm or app configuration
+* Improve error messages when not setting a BaseFilePath for realm or app configuration (Issue [2863](https://github.com/realm/realm-dotnet/issues/2863))
 
 ### Fixed
 * Fixed issue where Realm parameters' initialization would get run twice, resulting in unexpected behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Improve performance of client reset with automatic recovery and converting top-level tables into embedded tables. (Core upgrade)
 * Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. (Core upgrade)
 * Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
+* Improve error messages when setting a BaseFilePath for realm or app configuration
 
 ### Fixed
 * Fixed issue where Realm parameters' initialization would get run twice, resulting in unexpected behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Improve performance of client reset with automatic recovery and converting top-level tables into embedded tables. (Core upgrade)
 * Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. (Core upgrade)
 * Slightly improve performance of `Realm.RemoveAll()` which removes all objects from an open Realm database. (Issue [#2233](https://github.com/realm/realm-dotnet/issues/2194))
-* Improve error messages when not setting a BaseFilePath for realm or app configuration (Issue [2863](https://github.com/realm/realm-dotnet/issues/2863))
+* Improve error messages when not setting a BaseFilePath for realm or app configuration. (Issue [2863](https://github.com/realm/realm-dotnet/issues/2863))
 
 ### Fixed
 * Fixed issue where Realm parameters' initialization would get run twice, resulting in unexpected behavior.

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -137,12 +137,12 @@ namespace Realms
         {
             if (string.IsNullOrEmpty(optionalPath))
             {
-                return Path.Combine(InteropConfig.TryDefaultStorageFolder("realm"), DefaultRealmName);
+                return Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), DefaultRealmName);
             }
 
             if (!Path.IsPathRooted(optionalPath))
             {
-                optionalPath = Path.Combine(InteropConfig.TryDefaultStorageFolder("realm"), optionalPath);
+                optionalPath = Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), optionalPath);
             }
 
             if (optionalPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.OrdinalIgnoreCase))

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -137,12 +137,12 @@ namespace Realms
         {
             if (string.IsNullOrEmpty(optionalPath))
             {
-                return Path.Combine(InteropConfig.DefaultStorageFolder, DefaultRealmName);
+                return Path.Combine(InteropConfig.TryDefaultStorageFolder("realm"), DefaultRealmName);
             }
 
             if (!Path.IsPathRooted(optionalPath))
             {
-                optionalPath = Path.Combine(InteropConfig.DefaultStorageFolder, optionalPath);
+                optionalPath = Path.Combine(InteropConfig.TryDefaultStorageFolder("realm"), optionalPath);
             }
 
             if (optionalPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.OrdinalIgnoreCase))

--- a/Realm/Realm/Configurations/RealmConfigurationBase.cs
+++ b/Realm/Realm/Configurations/RealmConfigurationBase.cs
@@ -135,14 +135,15 @@ namespace Realms
         /// <returns>A full path including name of Realm file.</returns>
         public static string GetPathToRealm(string optionalPath = null)
         {
+            const string errorMessage = "Could not determine a writable folder to store the Realm file. When constructing the RealmConfiguration, provide an absolute optionalPath where writes are allowed.";
             if (string.IsNullOrEmpty(optionalPath))
             {
-                return Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), DefaultRealmName);
+                return Path.Combine(InteropConfig.GetDefaultStorageFolder(errorMessage), DefaultRealmName);
             }
 
             if (!Path.IsPathRooted(optionalPath))
             {
-                optionalPath = Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), optionalPath);
+                optionalPath = Path.Combine(InteropConfig.GetDefaultStorageFolder(errorMessage), optionalPath);
             }
 
             if (optionalPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.OrdinalIgnoreCase))

--- a/Realm/Realm/InteropConfig.cs
+++ b/Realm/Realm/InteropConfig.cs
@@ -59,27 +59,19 @@ namespace Realms
                 }
             }
 
-            throw new InvalidOperationException("Couldn't determine a writable folder where to store realm file. Specify absolute path manually.");
+            return null;
         });
 
         private static string _customStorageFolder;
 
-        public static string DefaultStorageFolder
-        {
-            get => _customStorageFolder ?? _defaultStorageFolder.Value;
-            set => _customStorageFolder = value;
-        }
+        public static string GetDefaultStorageFolder(string type) =>
+            _customStorageFolder ??
+            _defaultStorageFolder.Value ??
+            throw new InvalidOperationException($"Couldn't determine a writable folder where to store {type} file. Specify absolute path manually.");
 
-        public static string TryDefaultStorageFolder(string type)
+        public static void SetDefaultStorageFolder(string value)
         {
-            try
-            {
-                return DefaultStorageFolder;
-            }
-            catch (InvalidOperationException e)
-            {
-                throw new InvalidOperationException($"Couldn't determine a writable folder where to store {type} file. Specify absolute path manually.");
-            }
+            _customStorageFolder = value;
         }
 
         public static void AddPotentialStorageFolder(string folder)

--- a/Realm/Realm/InteropConfig.cs
+++ b/Realm/Realm/InteropConfig.cs
@@ -70,6 +70,18 @@ namespace Realms
             set => _customStorageFolder = value;
         }
 
+        public static string TryDefaultStorageFolder(string type)
+        {
+            try
+            {
+                return DefaultStorageFolder;
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException($"Couldn't determine a writable folder where to store {type} file. Specify absolute path manually.");
+            }
+        }
+
         public static void AddPotentialStorageFolder(string folder)
         {
 #if DEBUG

--- a/Realm/Realm/InteropConfig.cs
+++ b/Realm/Realm/InteropConfig.cs
@@ -64,10 +64,10 @@ namespace Realms
 
         private static string _customStorageFolder;
 
-        public static string GetDefaultStorageFolder(string type) =>
+        public static string GetDefaultStorageFolder(string errorMessage) =>
             _customStorageFolder ??
             _defaultStorageFolder.Value ??
-            throw new InvalidOperationException($"Couldn't determine a writable folder where to store {type} file. Specify absolute path manually.");
+            throw new InvalidOperationException(errorMessage);
 
         public static void SetDefaultStorageFolder(string value)
         {

--- a/Realm/Realm/Sync/App.cs
+++ b/Realm/Realm/Sync/App.cs
@@ -158,7 +158,7 @@ namespace Realms.Sync
             var nativeConfig = new Native.AppConfiguration
             {
                 AppId = config.AppId,
-                BaseFilePath = config.BaseFilePath ?? InteropConfig.DefaultStorageFolder,
+                BaseFilePath = config.BaseFilePath ?? InteropConfig.TryDefaultStorageFolder("app configuration"),
                 BaseUrl = config.BaseUri?.ToString().TrimEnd('/'),
                 LocalAppName = config.LocalAppName,
                 LocalAppVersion = config.LocalAppVersion,

--- a/Realm/Realm/Sync/App.cs
+++ b/Realm/Realm/Sync/App.cs
@@ -158,7 +158,7 @@ namespace Realms.Sync
             var nativeConfig = new Native.AppConfiguration
             {
                 AppId = config.AppId,
-                BaseFilePath = config.BaseFilePath ?? InteropConfig.GetDefaultStorageFolder("app configuration"),
+                BaseFilePath = config.BaseFilePath ?? InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store app files (such as metadata and Realm files). When constructing the app, set AppConfiguration.BaseFilePath to an absolute path where the app is allowed to write."),
                 BaseUrl = config.BaseUri?.ToString().TrimEnd('/'),
                 LocalAppName = config.LocalAppName,
                 LocalAppVersion = config.LocalAppVersion,

--- a/Realm/Realm/Sync/App.cs
+++ b/Realm/Realm/Sync/App.cs
@@ -152,6 +152,7 @@ namespace Realms.Sync
                     throw new ArgumentException($"{nameof(AppConfiguration.MetadataPersistenceMode)} must be set to {nameof(MetadataPersistenceMode.Encrypted)} when {nameof(AppConfiguration.MetadataEncryptionKey)} is set.");
                 }
             }
+
             var httpClient = config.HttpClientHandler == null ? new HttpClient() : new HttpClient(config.HttpClientHandler);
             var clientHandle = GCHandle.Alloc(httpClient);
             var nativeConfig = new Native.AppConfiguration

--- a/Realm/Realm/Sync/App.cs
+++ b/Realm/Realm/Sync/App.cs
@@ -152,13 +152,12 @@ namespace Realms.Sync
                     throw new ArgumentException($"{nameof(AppConfiguration.MetadataPersistenceMode)} must be set to {nameof(MetadataPersistenceMode.Encrypted)} when {nameof(AppConfiguration.MetadataEncryptionKey)} is set.");
                 }
             }
-
             var httpClient = config.HttpClientHandler == null ? new HttpClient() : new HttpClient(config.HttpClientHandler);
             var clientHandle = GCHandle.Alloc(httpClient);
             var nativeConfig = new Native.AppConfiguration
             {
                 AppId = config.AppId,
-                BaseFilePath = config.BaseFilePath ?? InteropConfig.TryDefaultStorageFolder("app configuration"),
+                BaseFilePath = config.BaseFilePath ?? InteropConfig.GetDefaultStorageFolder("app configuration"),
                 BaseUrl = config.BaseUri?.ToString().TrimEnd('/'),
                 LocalAppName = config.LocalAppName,
                 LocalAppVersion = config.LocalAppVersion,

--- a/Tests/Realm.Tests/App.Local.config
+++ b/Tests/Realm.Tests/App.Local.config
@@ -1,0 +1,9 @@
+<appSettings>
+    <add key="BaasUrl" value="http://your-local-ip:9090" />
+    <add key="BaasUrl" value="http://your-local-ip:9090" />
+    <add key="BaasUrl" value="http://your-local-ip:9090" />
+    <add key="BaasUrl" value="http://your-local-ip:9090" />
+    <add key="BaasUrl" value="http://your-local-ip:9090" />
+    <add key="BaasUrl" value="http://your-local-ip:9090" />
+    <add key="BaasUrl" value="http://your-local-ip:9090" />
+</appSettings>

--- a/Tests/Realm.Tests/App.Local.config
+++ b/Tests/Realm.Tests/App.Local.config
@@ -1,9 +1,0 @@
-<appSettings>
-    <add key="BaasUrl" value="http://your-local-ip:9090" />
-    <add key="BaasUrl" value="http://your-local-ip:9090" />
-    <add key="BaasUrl" value="http://your-local-ip:9090" />
-    <add key="BaasUrl" value="http://your-local-ip:9090" />
-    <add key="BaasUrl" value="http://your-local-ip:9090" />
-    <add key="BaasUrl" value="http://your-local-ip:9090" />
-    <add key="BaasUrl" value="http://your-local-ip:9090" />
-</appSettings>

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -763,7 +763,7 @@ namespace Realms.Tests.Database
         [TestCase("søren")]
         public void GetInstance_WhenPathContainsNonASCIICharacters_ShouldWork(string path)
         {
-            var folder = Path.Combine(InteropConfig.DefaultStorageFolder, path);
+            var folder = Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), path);
             Directory.CreateDirectory(folder);
             var realmPath = Path.Combine(folder, "my.realm");
             var config = new RealmConfiguration(realmPath);

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -763,7 +763,7 @@ namespace Realms.Tests.Database
         [TestCase("søren")]
         public void GetInstance_WhenPathContainsNonASCIICharacters_ShouldWork(string path)
         {
-            var folder = Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), path);
+            var folder = Path.Combine(InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store the Realm file. When constructing the RealmConfiguration, provide an absolute optionalPath where writes are allowed."), path);
             Directory.CreateDirectory(folder);
             var realmPath = Path.Combine(folder, "my.realm");
             var config = new RealmConfiguration(realmPath);

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -763,7 +763,7 @@ namespace Realms.Tests.Database
         [TestCase("søren")]
         public void GetInstance_WhenPathContainsNonASCIICharacters_ShouldWork(string path)
         {
-            var folder = Path.Combine(InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store the Realm file. When constructing the RealmConfiguration, provide an absolute optionalPath where writes are allowed."), path);
+            var folder = Path.Combine(InteropConfig.GetDefaultStorageFolder("No error expected here"), path);
             Directory.CreateDirectory(folder);
             var realmPath = Path.Combine(folder, "my.realm");
             var config = new RealmConfiguration(realmPath);

--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -43,7 +43,7 @@ namespace Realms.Tests
 #pragma warning disable CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
             InteropConfig.SetDefaultStorageFolder(Path.Combine(Path.GetTempPath(), $"rt-{System.Diagnostics.Process.GetCurrentProcess().Id}"));
 #pragma warning restore CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
-            Directory.CreateDirectory(InteropConfig.GetDefaultStorageFolder("realm"));
+            Directory.CreateDirectory(InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store the Realm file. When constructing the RealmConfiguration, provide an absolute optionalPath where writes are allowed."));
 #endif
         }
 

--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -41,9 +41,9 @@ namespace Realms.Tests
         {
 #if !UNITY
 #pragma warning disable CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
-            InteropConfig.DefaultStorageFolder = Path.Combine(Path.GetTempPath(), $"rt-{System.Diagnostics.Process.GetCurrentProcess().Id}");
+            InteropConfig.SetDefaultStorageFolder(Path.Combine(Path.GetTempPath(), $"rt-{System.Diagnostics.Process.GetCurrentProcess().Id}"));
 #pragma warning restore CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
-            Directory.CreateDirectory(InteropConfig.DefaultStorageFolder);
+            Directory.CreateDirectory(InteropConfig.GetDefaultStorageFolder("realm"));
 #endif
         }
 

--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -43,7 +43,7 @@ namespace Realms.Tests
 #pragma warning disable CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
             InteropConfig.SetDefaultStorageFolder(Path.Combine(Path.GetTempPath(), $"rt-{System.Diagnostics.Process.GetCurrentProcess().Id}"));
 #pragma warning restore CA1837 // Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
-            Directory.CreateDirectory(InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store the Realm file. When constructing the RealmConfiguration, provide an absolute optionalPath where writes are allowed."));
+            Directory.CreateDirectory(InteropConfig.GetDefaultStorageFolder("No error expected here"));
 #endif
         }
 

--- a/Tests/Realm.Tests/Sync/AppTests.cs
+++ b/Tests/Realm.Tests/Sync/AppTests.cs
@@ -47,7 +47,7 @@ namespace Realms.Tests.Sync
                 LogLevel = LogLevel.All,
                 MetadataEncryptionKey = new byte[64],
                 MetadataPersistenceMode = MetadataPersistenceMode.Encrypted,
-                BaseFilePath = InteropConfig.DefaultStorageFolder,
+                BaseFilePath = InteropConfig.GetDefaultStorageFolder("app configuration"),
                 CustomLogger = (message, level) => { },
                 DefaultRequestTimeout = TimeSpan.FromSeconds(123)
             };

--- a/Tests/Realm.Tests/Sync/AppTests.cs
+++ b/Tests/Realm.Tests/Sync/AppTests.cs
@@ -47,7 +47,7 @@ namespace Realms.Tests.Sync
                 LogLevel = LogLevel.All,
                 MetadataEncryptionKey = new byte[64],
                 MetadataPersistenceMode = MetadataPersistenceMode.Encrypted,
-                BaseFilePath = InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store app files (such as metadata and Realm files). When constructing the app, set AppConfiguration.BaseFilePath to an absolute path where the app is allowed to write."),
+                BaseFilePath = InteropConfig.GetDefaultStorageFolder("No error expected here"),
                 CustomLogger = (message, level) => { },
                 DefaultRequestTimeout = TimeSpan.FromSeconds(123)
             };

--- a/Tests/Realm.Tests/Sync/AppTests.cs
+++ b/Tests/Realm.Tests/Sync/AppTests.cs
@@ -47,7 +47,7 @@ namespace Realms.Tests.Sync
                 LogLevel = LogLevel.All,
                 MetadataEncryptionKey = new byte[64],
                 MetadataPersistenceMode = MetadataPersistenceMode.Encrypted,
-                BaseFilePath = InteropConfig.GetDefaultStorageFolder("app configuration"),
+                BaseFilePath = InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store app files (such as metadata and Realm files). When constructing the app, set AppConfiguration.BaseFilePath to an absolute path where the app is allowed to write."),
                 CustomLogger = (message, level) => { },
                 DefaultRequestTimeout = TimeSpan.FromSeconds(123)
             };

--- a/Tests/Realm.Tests/Sync/SyncConfigurationTests.cs
+++ b/Tests/Realm.Tests/Sync/SyncConfigurationTests.cs
@@ -65,7 +65,7 @@ namespace Realms.Tests.Sync
         [Test]
         public void SyncConfiguration_WithAbsolutePath()
         {
-            var path = Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), Guid.NewGuid().ToString());
+            var path = Path.Combine(InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store the Realm file. When constructing the RealmConfiguration, provide an absolute optionalPath where writes are allowed."), Guid.NewGuid().ToString());
             var config = GetFakeConfig(optionalPath: path);
 
             Realm.DeleteRealm(config);

--- a/Tests/Realm.Tests/Sync/SyncConfigurationTests.cs
+++ b/Tests/Realm.Tests/Sync/SyncConfigurationTests.cs
@@ -65,7 +65,7 @@ namespace Realms.Tests.Sync
         [Test]
         public void SyncConfiguration_WithAbsolutePath()
         {
-            var path = Path.Combine(InteropConfig.GetDefaultStorageFolder("Could not determine a writable folder to store the Realm file. When constructing the RealmConfiguration, provide an absolute optionalPath where writes are allowed."), Guid.NewGuid().ToString());
+            var path = Path.Combine(InteropConfig.GetDefaultStorageFolder("No error expected here"), Guid.NewGuid().ToString());
             var config = GetFakeConfig(optionalPath: path);
 
             Realm.DeleteRealm(config);

--- a/Tests/Realm.Tests/Sync/SyncConfigurationTests.cs
+++ b/Tests/Realm.Tests/Sync/SyncConfigurationTests.cs
@@ -65,7 +65,7 @@ namespace Realms.Tests.Sync
         [Test]
         public void SyncConfiguration_WithAbsolutePath()
         {
-            var path = Path.Combine(InteropConfig.DefaultStorageFolder, Guid.NewGuid().ToString());
+            var path = Path.Combine(InteropConfig.GetDefaultStorageFolder("realm"), Guid.NewGuid().ToString());
             var config = GetFakeConfig(optionalPath: path);
 
             Realm.DeleteRealm(config);


### PR DESCRIPTION
## Description
Added helper method to allow us to tell whether we try to get a defaultStorageFolder for a realm or app-config 

Fixes #2863
