### PR TITLE
Optimize callAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## vNext (TBD)
 
 ### Enhancements
+* Removed redundant serialization/deserialization of arguments in CallAsync. (Issue [#3079](https://github.com/realm/realm-dotnet/issues/3079))
 * Added a field `Transaction.State` which describes the current state of the transaction. (Issue [#2551](https://github.com/realm/realm-dotnet/issues/2551))
 * Improved error message when null is passed as argument to params for EmailPasswordAuth.CallResetPasswordFunctionAsync. (Issue [#3011](https://github.com/realm/realm-dotnet/issues/3011))
 * Removed backing fields of generated classes' properties which should provide minor improvements to memory used by Realm Objects (Issue [#2647](https://github.com/realm/realm-dotnet/issues/2994))

--- a/wrappers/src/app_cs.cpp
+++ b/wrappers/src/app_cs.cpp
@@ -87,7 +87,7 @@ namespace realm {
             void* managed_http_client;
         };
 
-        class SyncLogger : public util::RootLogger {
+        class SyncLogger : public util::Logger {
         public:
             SyncLogger(void* delegate)
                 : managed_logger(delegate)

--- a/wrappers/src/app_cs.hpp
+++ b/wrappers/src/app_cs.hpp
@@ -126,13 +126,11 @@ namespace binding {
     using UserCallbackT = void(void* tcs_ptr, SharedSyncUser* user, MarshaledAppError err);
     using VoidCallbackT = void(void* tcs_ptr, MarshaledAppError err);
     using BsonCallbackT = void(void* tcs_ptr, realm_value_t response, MarshaledAppError err);
-    using StringCallbackT = void(void* tcs_ptr, const std::string response, MarshaledAppError err);
     using ApiKeysCallbackT = void(void* tcs_ptr, UserApiKey* api_keys, size_t api_keys_len, MarshaledAppError err);
 
     extern std::function<VoidCallbackT> s_void_callback;
     extern std::function<UserCallbackT> s_user_callback;
     extern std::function<BsonCallbackT> s_bson_callback;
-    extern std::function<StringCallbackT> s_string_callback;
     extern std::function<ApiKeysCallbackT> s_api_keys_callback;
 
     inline auto get_string_callback_handler(void* tcs_ptr) {
@@ -141,10 +139,10 @@ namespace binding {
                 std::string error_category = err->error_code.message();
                 MarshaledAppError app_error(err->message, error_category, err->link_to_server_logs, err->http_status_code);
 
-                s_string_callback(tcs_ptr, "", app_error);
+                s_bson_callback(tcs_ptr, realm_value_t{}, app_error);
             }
             else {
-                s_string_callback(tcs_ptr, *response, MarshaledAppError());
+                s_bson_callback(tcs_ptr, to_capi_value(*response), MarshaledAppError());
             }
         };
     }

--- a/wrappers/src/app_cs.hpp
+++ b/wrappers/src/app_cs.hpp
@@ -140,9 +140,11 @@ namespace binding {
                 MarshaledAppError app_error(err->message, error_category, err->link_to_server_logs, err->http_status_code);
 
                 s_bson_callback(tcs_ptr, realm_value_t{}, app_error);
+            } else if (response) {
+                s_bson_callback(tcs_ptr, to_capi_value(*response), MarshaledAppError());
             }
             else {
-                s_bson_callback(tcs_ptr, to_capi_value(*response), MarshaledAppError());
+                s_bson_callback(tcs_ptr, realm_value_t{}, MarshaledAppError());
             }
         };
     }

--- a/wrappers/src/app_cs.hpp
+++ b/wrappers/src/app_cs.hpp
@@ -126,12 +126,28 @@ namespace binding {
     using UserCallbackT = void(void* tcs_ptr, SharedSyncUser* user, MarshaledAppError err);
     using VoidCallbackT = void(void* tcs_ptr, MarshaledAppError err);
     using BsonCallbackT = void(void* tcs_ptr, realm_value_t response, MarshaledAppError err);
+    using StringCallbackT = void(void* tcs_ptr, const std::string response, MarshaledAppError err);
     using ApiKeysCallbackT = void(void* tcs_ptr, UserApiKey* api_keys, size_t api_keys_len, MarshaledAppError err);
 
     extern std::function<VoidCallbackT> s_void_callback;
     extern std::function<UserCallbackT> s_user_callback;
     extern std::function<BsonCallbackT> s_bson_callback;
+    extern std::function<StringCallbackT> s_string_callback;
     extern std::function<ApiKeysCallbackT> s_api_keys_callback;
+
+    inline auto get_string_callback_handler(void* tcs_ptr) {
+        return [tcs_ptr](const std::string* response, util::Optional<AppError> err) {
+            if (err) {
+                std::string error_category = err->error_code.message();
+                MarshaledAppError app_error(err->message, error_category, err->link_to_server_logs, err->http_status_code);
+
+                s_string_callback(tcs_ptr, "", app_error);
+            }
+            else {
+                s_string_callback(tcs_ptr, *response, MarshaledAppError());
+            }
+        };
+    }
 
     inline auto get_user_callback_handler(void* tcs_ptr) {
         return [tcs_ptr](std::shared_ptr<SyncUser> user, util::Optional<AppError> err) {

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -523,6 +523,11 @@ public:
     {
         return std::string(m_data.get(), m_size);
     }
+    
+    std::string_view to_string_view() const
+    {
+        return std::string_view(m_data.get(), m_size);
+    }
 
     operator std::string() const noexcept
     {

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -246,9 +246,10 @@ extern "C" {
     {
         handle_errors(ex, [&] {
             Utf16StringAccessor function_name(function_name_buf, function_name_len);
-
-            auto args = to_array(args_buf, args_len);
-            app->call_function(user, function_name, args, get_bson_callback_handler(tcs_ptr));
+            Utf16StringAccessor args_string(function_name_buf, function_name_len);
+            //auto args = to_array(args_buf, args_len);
+            std::string_view args = std::string_view(std::move(args_string.to_string()));
+            app->call_function(user, function_name, args, nullptr, get_string_callback_handler(tcs_ptr));
         });
     }
 

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -246,10 +246,8 @@ extern "C" {
     {
         handle_errors(ex, [&] {
             Utf16StringAccessor function_name(function_name_buf, function_name_len);
-            Utf16StringAccessor args_string(function_name_buf, function_name_len);
-            //auto args = to_array(args_buf, args_len);
-            std::string_view args = std::string_view(std::move(args_string.to_string()));
-            app->call_function(user, function_name, args, nullptr, get_string_callback_handler(tcs_ptr));
+            Utf16StringAccessor args_accessor(args_buf, args_len);
+            app->call_function(user, function_name, args_accessor.to_string_view(), nullptr, get_string_callback_handler(tcs_ptr));
         });
     }
 

--- a/wrappers/src/sync_user_cs.cpp
+++ b/wrappers/src/sync_user_cs.cpp
@@ -247,7 +247,7 @@ extern "C" {
         handle_errors(ex, [&] {
             Utf16StringAccessor function_name(function_name_buf, function_name_len);
             Utf16StringAccessor args_accessor(args_buf, args_len);
-            app->call_function(user, function_name, args_accessor.to_string_view(), nullptr, get_string_callback_handler(tcs_ptr));
+            app->call_function(user, function_name, args_accessor.to_string_view(), std::nullopt, get_string_callback_handler(tcs_ptr));
         });
     }
 


### PR DESCRIPTION
Removes unnecessary serialisation/deserialisation of args parameter passed to CallAsync

Fixes #3079