### PR TITLE
Avoid calling setter for bound properties for same value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fixed an issue where sets would consider string and binary data equivalent. This could cause the client to be inconsistent with the server if a string and some binary data with equivalent content was inserted from Atlas. (Core upgrade)
 * Fixed wrong assertion on query error that could result in a crash. (Core upgrade)
 * Fixed a crash that would occur if you close a synchronized Realm while waiting for `SubscriptionSet.WaitForSynchronizationAsync`. (Issue [#2952](https://github.com/realm/realm-dotnet/issues/2952))
+* Avoid calling the setter on UI-bound properties in case the new value of the property is the same as the current one. This avoids some issue with MAUI, that seems to be calling the setter of bound properties unnecessarily when CollectionView/ListView are shown on screen. This is problematic if the object does not belong to the current user's permissions, as it will cause a compensanting write. In some limited cases this could cause an error loop (verified on iOS) when recycling of cells is involved. (Issue [#3128](https://github.com/realm/realm-dotnet/issues/3128))   
 
 ### Compatibility
 * Realm Studio: 13.1.0 or later.

--- a/Realm/Realm/DataBinding/WovenPropertyInfo.cs
+++ b/Realm/Realm/DataBinding/WovenPropertyInfo.cs
@@ -142,7 +142,7 @@ namespace Realms.DataBinding
             return new Lazy<MethodInfo>(() =>
             {
                 var mi = _pi.GetSetMethod(nonPublic);
-                return new WovenSetterMethodInfo(mi);
+                return new WovenSetterMethodInfo(mi, _pi.GetMethod);
             });
         }
     }

--- a/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
+++ b/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
@@ -25,54 +25,69 @@ namespace Realms.DataBinding
 {
     internal class WovenSetterMethodInfo : MethodInfo
     {
-        private readonly MethodInfo _mi;
+        private readonly MethodInfo _getterMi;
 
-        public override MethodAttributes Attributes => _mi.Attributes;
+        private readonly MethodInfo _setterMi;
 
-        public override Type DeclaringType => _mi.DeclaringType;
+        public override MethodAttributes Attributes => _setterMi.Attributes;
 
-        public override RuntimeMethodHandle MethodHandle => _mi.MethodHandle;
+        public override Type DeclaringType => _setterMi.DeclaringType;
 
-        public override string Name => _mi.Name;
+        public override RuntimeMethodHandle MethodHandle => _setterMi.MethodHandle;
 
-        public override Type ReflectedType => _mi.ReflectedType;
+        public override string Name => _setterMi.Name;
 
-        public override ICustomAttributeProvider ReturnTypeCustomAttributes => _mi.ReturnTypeCustomAttributes;
+        public override Type ReflectedType => _setterMi.ReflectedType;
 
-        public override Type ReturnType => _mi.ReturnType;
+        public override ICustomAttributeProvider ReturnTypeCustomAttributes => _setterMi.ReturnTypeCustomAttributes;
 
-        public WovenSetterMethodInfo(MethodInfo mi)
+        public override Type ReturnType => _setterMi.ReturnType;
+
+        public WovenSetterMethodInfo(MethodInfo setterMi, MethodInfo getterMi)
         {
-            Argument.NotNull(mi, nameof(mi));
-            _mi = mi;
+            Argument.NotNull(setterMi, nameof(setterMi));
+            Argument.NotNull(getterMi, nameof(getterMi));
+
+            _setterMi = setterMi;
+            _getterMi = getterMi;
         }
 
-        public override MethodInfo GetBaseDefinition() => _mi.GetBaseDefinition();
+        public override MethodInfo GetBaseDefinition() => _setterMi.GetBaseDefinition();
 
-        public override object[] GetCustomAttributes(bool inherit) => _mi.GetCustomAttributes(inherit);
+        public override object[] GetCustomAttributes(bool inherit) => _setterMi.GetCustomAttributes(inherit);
 
-        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => _mi.GetCustomAttributes(attributeType, inherit);
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => _setterMi.GetCustomAttributes(attributeType, inherit);
 
-        public override MethodImplAttributes GetMethodImplementationFlags() => _mi.GetMethodImplementationFlags();
+        public override MethodImplAttributes GetMethodImplementationFlags() => _setterMi.GetMethodImplementationFlags();
 
-        public override ParameterInfo[] GetParameters() => _mi.GetParameters();
+        public override ParameterInfo[] GetParameters() => _setterMi.GetParameters();
 
         public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
         {
-            var managingRealm = (obj as IRealmObjectBase)?.Realm;
+            var realmObject = obj as IRealmObjectBase;
 
-            // If managingRealm is not null and not currently in transaction, wrap setting the property in a realm.Write(...)
-            if (managingRealm?.IsInTransaction == false)
+            if (realmObject?.IsManaged == true)
             {
-                return managingRealm.Write(() =>
+                if (_getterMi.Invoke(realmObject, null).Equals(parameters[0]))
                 {
-                    return _mi.Invoke(obj, invokeAttr, binder, parameters, culture);
-                });
+                    return null;
+                }
+
+                var managingRealm = (obj as IRealmObjectBase)?.Realm;
+
+                // If managingRealm is not null and not currently in transaction, wrap setting the property in a realm.Write(...)
+                if (managingRealm?.IsInTransaction == false)
+                {
+                    return managingRealm.Write(() =>
+                    {
+                        return _setterMi.Invoke(obj, invokeAttr, binder, parameters, culture);
+                    });
+                }
             }
 
-            return _mi.Invoke(obj, invokeAttr, binder, parameters, culture);
+            return _setterMi.Invoke(obj, invokeAttr, binder, parameters, culture);
         }
 
-        public override bool IsDefined(Type attributeType, bool inherit) => _mi.IsDefined(attributeType, inherit);
+        public override bool IsDefined(Type attributeType, bool inherit) => _setterMi.IsDefined(attributeType, inherit);
     }
 }

--- a/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
+++ b/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
@@ -64,7 +64,7 @@ namespace Realms.DataBinding
 
         public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
         {
-            if (obj is IRealmObjectBase realmObject && realmObject.IsManaged == true)
+            if (obj is IRealmObjectBase realmObject && realmObject.IsManaged)
             {
                 var currentValue = _getterMi.Invoke(realmObject, null);
                 var newValue = parameters[0];

--- a/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
+++ b/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
@@ -68,15 +68,19 @@ namespace Realms.DataBinding
 
             if (realmObject?.IsManaged == true)
             {
-                if (_getterMi.Invoke(realmObject, null).Equals(parameters[0]))
+                var currentValue = _getterMi.Invoke(realmObject, null);
+                var newValue = parameters[0];
+
+                // We don't call the setter if the current value is equal to the new value due to a bug in MAUI (https://github.com/realm/realm-dotnet/issues/3128)
+                if (currentValue?.Equals(newValue) == true || (currentValue == null && newValue == null) )
                 {
                     return null;
                 }
 
-                var managingRealm = (obj as IRealmObjectBase)?.Realm;
+                var managingRealm = realmObject.Realm;
 
                 // If managingRealm is not null and not currently in transaction, wrap setting the property in a realm.Write(...)
-                if (managingRealm?.IsInTransaction == false)
+                if (realmObject.Realm?.IsInTransaction == false)
                 {
                     return managingRealm.Write(() =>
                     {

--- a/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
+++ b/Realm/Realm/DataBinding/WovenSetterMethodInfo.cs
@@ -64,15 +64,13 @@ namespace Realms.DataBinding
 
         public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
         {
-            var realmObject = obj as IRealmObjectBase;
-
-            if (realmObject?.IsManaged == true)
+            if (obj is IRealmObjectBase realmObject && realmObject.IsManaged == true)
             {
                 var currentValue = _getterMi.Invoke(realmObject, null);
                 var newValue = parameters[0];
 
                 // We don't call the setter if the current value is equal to the new value due to a bug in MAUI (https://github.com/realm/realm-dotnet/issues/3128)
-                if (currentValue?.Equals(newValue) == true || (currentValue == null && newValue == null) )
+                if (currentValue?.Equals(newValue) == true || (currentValue == null && newValue == null))
                 {
                     return null;
                 }
@@ -80,7 +78,7 @@ namespace Realms.DataBinding
                 var managingRealm = realmObject.Realm;
 
                 // If managingRealm is not null and not currently in transaction, wrap setting the property in a realm.Write(...)
-                if (realmObject.Realm?.IsInTransaction == false)
+                if (managingRealm?.IsInTransaction == false)
                 {
                     return managingRealm.Write(() =>
                     {

--- a/Tests/Realm.Tests/Database/ReflectableTypeTests.cs
+++ b/Tests/Realm.Tests/Database/ReflectableTypeTests.cs
@@ -246,6 +246,38 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void ReflectableSetValue_IfSameNullValue_ShouldDoNothing()
+        {
+            var owner = new Owner();
+
+            _realm.Write(() =>
+            {
+                _realm.Add(owner);
+            });
+
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
+
+            string propertyChanged = null;
+
+            owner.PropertyChanged += (sender, e) =>
+            {
+                propertyChanged = e.PropertyName;
+            };
+
+            var namePi = typeInfo.GetProperty(nameof(Owner.Name));
+            namePi.SetValue(owner, null);
+            _realm.Refresh();
+
+            Assert.That(propertyChanged, Is.Null);
+
+            var dogPi = typeInfo.GetProperty(nameof(Owner.TopDog));
+            dogPi.SetValue(owner, null);
+            _realm.Refresh();
+
+            Assert.That(propertyChanged, Is.Null);
+        }
+
+        [Test]
         public void Setter_WhenNotInTransaction_ShouldThrow()
         {
             var owner = AddDogAndOwner();

--- a/Tests/Realm.Tests/Database/ReflectableTypeTests.cs
+++ b/Tests/Realm.Tests/Database/ReflectableTypeTests.cs
@@ -219,6 +219,33 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void ReflectableSetValue_IfSameValue_ShouldDoNothing()
+        {
+            var owner = AddDogAndOwner();
+            var dog = owner.TopDog;
+            var typeInfo = ((IReflectableType)owner).GetTypeInfo();
+
+            string propertyChanged = null;
+
+            owner.PropertyChanged += (sender, e) =>
+            {
+                propertyChanged = e.PropertyName;
+            };
+
+            var namePi = typeInfo.GetProperty(nameof(Owner.Name));
+            namePi.SetValue(owner, OwnerName);
+            _realm.Refresh();
+
+            Assert.That(propertyChanged, Is.Null);
+
+            var dogPi = typeInfo.GetProperty(nameof(Owner.TopDog));
+            dogPi.SetValue(owner, dog);
+            _realm.Refresh();
+
+            Assert.That(propertyChanged, Is.Null);
+        }
+
+        [Test]
         public void Setter_WhenNotInTransaction_ShouldThrow()
         {
             var owner = AddDogAndOwner();


### PR DESCRIPTION
Avoids calling the setter for bound properties in case the new value is the same as the old one. This avoids a problem in MAUI in which the UI is calling the setter unnecessarily, and causing an issue in case objects outside of the user's write permissions are modified

Fixes #3128

##  TODO

* [x] Changelog entry
* [x] Tests
