### PR TITLE
Remove netcore tests from ci tests

### DIFF
--- a/.github/templates/main.yml
+++ b/.github/templates/main.yml
@@ -54,7 +54,7 @@ jobs:
   _: #@ template.replace(buildUnity())
   _: #@ template.replace(runTests(".NET Framework"))
   _: #@ template.replace(runTests("UWP Managed", additionalSecrets = ["Pfx_Password", "Base64_Encoded_Pfx"]))
-  _: #@ template.replace(runNetCoreTests("[\"netcoreapp3.1\", \"net6.0\"]"))
+  _: #@ template.replace(runNetCoreTests("[\"net6.0\", \"net7.0\"]"))
   _: #@ template.replace(runTests("macOS"))
   _: #@ template.replace(runTests("iOS"))
   _: #@ template.replace(runTests("tvOS", runSyncTests = False))

--- a/.github/templates/test-net-core.yml
+++ b/.github/templates/test-net-core.yml
@@ -33,7 +33,6 @@ jobs:
 
     steps:
       - #@ template.replace(prepareTest(cleanupWorkspace = True))
-      - #@ setupDotnet(ifCondition = "matrix.framework == 'net6.0' && matrix.os.runner != 'macos-arm'")
       - #@ template.replace(dotnetBuildTests("Tests/Realm.Tests", "${{ matrix.framework }}", "${{ matrix.os.runtime }}"))
       - name: Run the tests
         run: #@ "${{ steps.dotnet-publish.outputs.executable-path }}/Realm.Tests --result=TestResults.xml --labels=After" + baasTestArgs("net-core-${{ matrix.runner }}-${{ matrix.runtime }}")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
     uses: ./.github/workflows/test-net-core.yml
     with:
       version: ${{ needs.build-packages.outputs.package_version }}
-      framework: '["netcoreapp3.1", "net6.0"]'
+      framework: '["net6.0", "net7.0"]'
   test-macos:
     uses: ./.github/workflows/test-macos.yml
     name: Test

--- a/.github/workflows/test-net-core.yml
+++ b/.github/workflows/test-net-core.yml
@@ -88,11 +88,6 @@ jobs:
         apiKey: ${{ secrets.AtlasPublicKey}}
         privateApiKey: ${{ secrets.AtlasPrivateKey }}
         clusterSize: M10
-    - name: Configure .NET
-      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a
-      if: matrix.framework == 'net6.0' && matrix.os.runner != 'macos-arm'
-      with:
-        dotnet-version: 6.0.x
     - name: Publish Tests/Realm.Tests
       run: dotnet publish Tests/Realm.Tests -c Release -f ${{ matrix.framework }} -r ${{ matrix.os.runtime }} -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ inputs.version }} -p:RealmTestsStandaloneExe=true --no-self-contained
     - name: Output executable path

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -6,7 +6,7 @@
     in the project file, but the NUnit test adapter doesn't support .NET Standard 2.0, so it should never be
     first in the list.
     -->
-        <TargetFrameworks Condition="'$(MSBuildVersion)' &gt;= '17.0'">$(TargetFrameworks);net6.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(MSBuildVersion)' &gt;= '17.0'">$(TargetFrameworks);net6.0;net7.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(RuntimeIdentifier)' != 'osx-arm64'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
         <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
         <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

.NET Core 3.1 is end of life-d, so we should instead be testing 6.0 and 7.0 instead.

##  TODO

* [ ] Changelog entry
* [ ] Tests (if applicable)
