### PR TITLE
Expose options to control sync timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## vNext (TBD)
 
 ### Enhancements
-* None
+* Added `SyncConfiguration.CancelAsyncOperationsOnNonFatalErrors` which controls whether async operations (such as `Realm.GetInstanceAsync`, `Session.WaitForUploadAsync` and so on) should throw an exception whenever a non-fatal session error occurs. (Issue [#3222](https://github.com/realm/realm-dotnet/issues/3222))
+* Added `AppConfiguration.SyncTimeoutOptions` which has a handful of properties that control sync timeouts, such as the connection timeout, ping-pong intervals, and others. (Issue [#3223](https://github.com/realm/realm-dotnet/issues/3223))
 
 ### Fixed
 * None

--- a/Realm/Realm/Configurations/SyncConfigurationBase.cs
+++ b/Realm/Realm/Configurations/SyncConfigurationBase.cs
@@ -81,6 +81,19 @@ namespace Realms.Sync
         /// </remarks>
         public SessionErrorCallback OnSessionError { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether async operations, such as <see cref="Realm.GetInstanceAsync"/>,
+        /// <see cref="Session.WaitForUploadAsync"/>, or <see cref="Session.WaitForDownloadAsync"/> should throw an
+        /// error whenever a non-fatal error, such as timeout occurs.
+        /// </summary>
+        /// <remarks>
+        /// If set to <c>false</c>, non-fatal session errors will be ignored and sync will continue retrying the
+        /// connection under in the background. This means that in cases where the devie is offline, these operations
+        /// may take an indeterminate time to complete.
+        /// </remarks>
+        /// <value><c>true</c> to throw an error if a non-fatal session error occurs, <c>false</c> otherwise.</value>
+        public bool CancelAsyncOperationsOnNonFatalErrors { get; set; }
+
         internal SessionStopPolicy SessionStopPolicy { get; set; } = SessionStopPolicy.AfterChangesUploaded;
 
         /// <summary>
@@ -141,6 +154,7 @@ namespace Realms.Sync
                 session_stop_policy = SessionStopPolicy,
                 schema_mode = Schema == null ? SchemaMode.AdditiveDiscovered : SchemaMode.AdditiveExplicit,
                 client_resync_mode = ClientResetHandler.ClientResetMode,
+                cancel_waits_on_nonfatal_error = CancelAsyncOperationsOnNonFatalErrors,
             };
         }
     }

--- a/Realm/Realm/Native/AppConfiguration.cs
+++ b/Realm/Realm/Native/AppConfiguration.cs
@@ -111,5 +111,15 @@ namespace Realms.Sync.Native
         internal IntPtr managed_logger;
 
         internal IntPtr managed_http_client;
+
+        internal UInt64 sync_connect_timeout_ms;
+
+        internal UInt64 sync_connection_linger_time_ms;
+
+        internal UInt64 sync_ping_keep_alive_period_ms;
+
+        internal UInt64 sync_pong_keep_alive_timeout_ms;
+
+        internal UInt64 sync_fast_reconnect_limit;
     }
 }

--- a/Realm/Realm/Native/SyncConfiguration.cs
+++ b/Realm/Realm/Native/SyncConfiguration.cs
@@ -56,5 +56,8 @@ namespace Realms.Sync.Native
         internal bool is_flexible_sync;
 
         internal ClientResyncMode client_resync_mode;
+
+        [MarshalAs(UnmanagedType.I1)]
+        internal bool cancel_waits_on_nonfatal_error;
     }
 }

--- a/Realm/Realm/Sync/App.cs
+++ b/Realm/Realm/Sync/App.cs
@@ -139,6 +139,7 @@ namespace Realms.Sync
         public static App Create(AppConfiguration config)
         {
             Argument.NotNull(config, nameof(config));
+            var syncTimeouts = config.SyncTimeoutOptions ?? new();
 
             if (config.MetadataPersistenceMode.HasValue)
             {
@@ -167,6 +168,11 @@ namespace Realms.Sync
                 managed_http_client = GCHandle.ToIntPtr(clientHandle),
 #pragma warning disable CS0618 // Type or member is obsolete - We still want to support people using it
                 log_level = config.LogLevel != LogLevel.Info ? config.LogLevel : Logger.LogLevel,
+                sync_connection_linger_time_ms = (ulong)syncTimeouts.ConnectionLingerTime.TotalMilliseconds,
+                sync_connect_timeout_ms = (ulong)syncTimeouts.ConnectTimeout.TotalMilliseconds,
+                sync_fast_reconnect_limit = (ulong)syncTimeouts.FastReconnectLimit.TotalMilliseconds,
+                sync_ping_keep_alive_period_ms = (ulong)syncTimeouts.PingKeepAlivePeriod.TotalMilliseconds,
+                sync_pong_keep_alive_timeout_ms = (ulong)syncTimeouts.PongKeepAliveTimeout.TotalMilliseconds,
             };
 
             if (config.CustomLogger != null)

--- a/Realm/Realm/Sync/AppConfiguration.cs
+++ b/Realm/Realm/Sync/AppConfiguration.cs
@@ -151,6 +151,13 @@ namespace Realms.Sync
         public HttpMessageHandler HttpClientHandler { get; set; }
 
         /// <summary>
+        /// Gets or sets the options for the assorted types of connection timeouts for sync connections
+        /// opened for this app.
+        /// </summary>
+        /// <value>The sync timeout options applied to synchronized Realms.</value>
+        public SyncTimeoutOptions SyncTimeoutOptions { get; set; } = new();
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AppConfiguration"/> class with the specified <paramref name="appId"/>.
         /// </summary>
         /// <param name="appId">The Atlas App Services App id.</param>

--- a/Realm/Realm/Sync/SyncTimeoutOptions.cs
+++ b/Realm/Realm/Sync/SyncTimeoutOptions.cs
@@ -1,0 +1,108 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+
+namespace Realms.Sync
+{
+    /// <summary>
+    /// Options for configuring timeouts and intervals used by the sync client.
+    /// </summary>
+    public class SyncTimeoutOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum amount of time to allow for a connection to
+        /// become fully established.
+        /// </summary>
+        /// <remarks>
+        /// This includes the time to resolve the
+        /// network address, the TCP connect operation, the SSL handshake, and
+        /// the WebSocket handshake.
+        /// <br/>
+        /// Defaults to 2 minutes.
+        /// </remarks>
+        /// <value>The connection timeout.</value>
+        public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// Gets or sets the amount of time to keep a connection open after all
+        /// sessions have been abandoned.
+        /// </summary>
+        /// <remarks>
+        /// After all synchronized Realms have been closed for a given server, the
+        /// connection is kept open until the linger time has expired to avoid the
+        /// overhead of reestablishing the connection when Realms are being closed and
+        /// reopened.
+        /// <br/>
+        /// Defaults to 30 seconds.
+        /// </remarks>
+        /// <value>The time to keep the connection open.</value>
+        public TimeSpan ConnectionLingerTime { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Gets or sets how long to wait between each heartbeat ping message.
+        /// </summary>
+        /// <remarks>
+        /// The client periodically sends ping messages to the server to check if the
+        /// connection is still alive. Shorter periods make connection state change
+        /// notifications more responsive at the cost of battery life (as the antenna
+        /// will have to wake up more often).
+        /// <br/>
+        /// Defaults to 1 minute.
+        /// </remarks>
+        /// <value>The ping interval.</value>
+        public TimeSpan PingKeepAlivePeriod { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Gets or sets how long to wait for a reponse to a heartbeat ping before
+        /// concluding that the connection has dropped.
+        /// </summary>
+        /// <remarks>
+        /// Shorter values will make connection state change notifications more
+        /// responsive as it will only change to `disconnected` after this much time has
+        /// elapsed, but overly short values may result in spurious disconnection
+        /// notifications when the server is simply taking a long time to respond.
+        /// <br/>
+        /// Defaults to 2 minutes.
+        /// </remarks>
+        /// <value>The pong timeout.</value>
+        public TimeSpan PongKeepAliveTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// Gets or sets the maximum amount of time since the loss of a
+        /// prior connection, for a new connection to be considered a "fast
+        /// reconnect".
+        /// </summary>
+        /// <remarks>
+        /// When a client first connects to the server, it defers uploading any local
+        /// changes until it has downloaded all changesets from the server. This
+        /// typically reduces the total amount of merging that has to be done, and is
+        /// particularly beneficial the first time that a specific client ever connects
+        /// to the server.
+        /// <br/>
+        /// When an existing client disconnects and then reconnects within the "fact
+        /// reconnect" time this is skipped and any local changes are uploaded
+        /// immediately without waiting for downloads, just as if the client was online
+        /// the whole time.
+        /// <br/>
+        /// Defaults to 1 minute.
+        /// </remarks>
+        /// <value>The window in which a drop in connectivity is considered transient.</value>
+        public TimeSpan FastReconnectLimit { get; set; } = TimeSpan.FromMinutes(1);
+    }
+}

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -29,6 +29,8 @@ using Realms.Sync;
 using Realms.Sync.ErrorHandling;
 using Realms.Sync.Exceptions;
 
+using NUnitExplicit = NUnit.Framework.ExplicitAttribute;
+
 namespace Realms.Tests.Sync
 {
     [TestFixture, Preserve(AllMembers = true)]
@@ -653,6 +655,76 @@ namespace Realms.Tests.Sync
 
             // Dispose should close the session and allow us to delete the Realm.
             Assert.That(DeleteRealmWithRetries(realm.Config), Is.True);
+        }
+
+        [Test]
+        public void SyncTimeouts_ArePassedCorrectlyToCore()
+        {
+            var logger = new Logger.InMemoryLogger();
+            Logger.Default = logger;
+            Logger.LogLevel = LogLevel.Debug;
+
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                var appConfig = SyncTestHelpers.GetAppConfig();
+                appConfig.SyncTimeoutOptions.ConnectTimeout = TimeSpan.FromMilliseconds(1234);
+                appConfig.SyncTimeoutOptions.ConnectionLingerTime = TimeSpan.FromMilliseconds(3456);
+                appConfig.SyncTimeoutOptions.PingKeepAlivePeriod = TimeSpan.FromMilliseconds(5678);
+                appConfig.SyncTimeoutOptions.PongKeepAliveTimeout = TimeSpan.FromMilliseconds(7890);
+                appConfig.SyncTimeoutOptions.FastReconnectLimit = TimeSpan.FromMilliseconds(9012);
+                var app = CreateApp(appConfig);
+                var config = await GetIntegrationConfigAsync(app: app);
+
+                using var realm = await GetRealmAsync(config);
+
+                var logs = logger.GetLog();
+
+                Assert.That(logs, Does.Contain("Config param: connect_timeout = 1234 ms"));
+                Assert.That(logs, Does.Contain("Config param: connection_linger_time = 3456 ms"));
+                Assert.That(logs, Does.Contain("Config param: ping_keepalive_period = 5678 ms"));
+                Assert.That(logs, Does.Contain("Config param: pong_keepalive_timeout = 7890 ms"));
+                Assert.That(logs, Does.Contain("Config param: fast_reconnect_limit = 9012 ms"));
+            });
+        }
+
+        [Test, NUnitExplicit("Enable when https://github.com/realm/realm-core/issues/6301 is addressed")]
+        public void CancelAsyncOperationsOnNonFatalErrors_WhenTrue_ShouldCancelAsyncOperationsOnTimeout()
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                var appConfig = SyncTestHelpers.GetAppConfig();
+
+                // 1 ms timeout is way too short to establish a connection
+                appConfig.SyncTimeoutOptions.ConnectTimeout = TimeSpan.FromMilliseconds(1);
+
+                var app = CreateApp(appConfig);
+                var config = await GetIntegrationConfigAsync(app: app);
+                config.CancelAsyncOperationsOnNonFatalErrors = true;
+
+                var ex = await TestHelpers.AssertThrows<RealmException>(() => GetRealmAsync(config));
+                Assert.That(ex.InnerException, Is.TypeOf<SessionException>().And.Message.Contains("Sync connection was not fully established in time"));
+            });
+        }
+
+        [Test, NUnitExplicit("Enable when https://github.com/realm/realm-core/issues/6301 is addressed")]
+        public void CancelAsyncOperationsOnNonFatalErrors_WhenFalse_ShouldNotCancelAsyncOperationsOnTimeout()
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                var appConfig = SyncTestHelpers.GetAppConfig();
+
+                // 1 ms timeout is way too short to establish a connection
+                appConfig.SyncTimeoutOptions.ConnectTimeout = TimeSpan.FromMilliseconds(1);
+
+                var app = CreateApp(appConfig);
+                var config = await GetIntegrationConfigAsync(app: app);
+                config.CancelAsyncOperationsOnNonFatalErrors = false;
+
+                // Connection should timeout immediately, but we should continue retrying until we eventually
+                // timeout the GetRealmAsync operation
+                var ex = await TestHelpers.AssertThrows<TimeoutException>(() => GetRealmAsync(config), timeout: 1000);
+                Assert.That(ex.Message, Does.Contain("The operation has timed out after 1000 ms"));
+            });
         }
 
         private const int DummyDataSize = 100;

--- a/Tests/Realm.Tests/TestHelpers.cs
+++ b/Tests/Realm.Tests/TestHelpers.cs
@@ -297,12 +297,12 @@ namespace Realms.Tests
             });
         }
 
-        public static async Task<T> AssertThrows<T>(Func<Task> function)
+        public static async Task<T> AssertThrows<T>(Func<Task> function, int timeout = 5000)
             where T : Exception
         {
             try
             {
-                await function().Timeout(5000);
+                await function().Timeout(timeout);
             }
             catch (T ex)
             {

--- a/wrappers/src/app_cs.cpp
+++ b/wrappers/src/app_cs.cpp
@@ -90,6 +90,16 @@ namespace realm {
             void* managed_logger;
 
             void* managed_http_client;
+
+            uint64_t sync_connect_timeout_ms;
+
+            uint64_t sync_connection_linger_time_ms;
+
+            uint64_t sync_ping_keep_alive_period_ms;
+
+            uint64_t sync_pong_keep_alive_timeout_ms;
+
+            uint64_t sync_fast_reconnect_limit;
         };
 
         class SyncLogger : public util::Logger {
@@ -190,6 +200,11 @@ extern "C" {
             SyncClientConfig sync_client_config;
             sync_client_config.log_level = app_config.log_level;
             sync_client_config.base_file_path = Utf16StringAccessor(app_config.base_file_path, app_config.base_file_path_len);
+            sync_client_config.timeouts.connection_linger_time = app_config.sync_connection_linger_time_ms;
+            sync_client_config.timeouts.connect_timeout = app_config.sync_connect_timeout_ms;
+            sync_client_config.timeouts.fast_reconnect_limit = app_config.sync_fast_reconnect_limit;
+            sync_client_config.timeouts.ping_keepalive_period = app_config.sync_ping_keep_alive_period_ms;
+            sync_client_config.timeouts.pong_keepalive_timeout = app_config.sync_pong_keep_alive_timeout_ms;
 
             if (app_config.metadata_mode_has_value) {
                 sync_client_config.metadata_mode = app_config.metadata_mode;

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -135,6 +135,7 @@ Realm::Config get_shared_realm_config(Configuration configuration, SyncConfigura
 
     config.sync_config->stop_policy = sync_configuration.session_stop_policy;
     config.sync_config->client_resync_mode = sync_configuration.client_resync_mode;
+    config.sync_config->cancel_waits_on_nonfatal_error = sync_configuration.cancel_waits_on_nonfatal_error;
 
     if (sync_configuration.client_resync_mode == ClientResyncMode::DiscardLocal ||
         sync_configuration.client_resync_mode == ClientResyncMode::Recover ||

--- a/wrappers/src/shared_realm_cs.hpp
+++ b/wrappers/src/shared_realm_cs.hpp
@@ -92,6 +92,8 @@ struct SyncConfiguration
     bool is_flexible_sync;
 
     ClientResyncMode client_resync_mode;
+
+    bool cancel_waits_on_nonfatal_error;
 };
 
 inline const TableRef get_table(const SharedRealm& realm, TableKey table_key)


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Adds a few sync timeout options to AppConfiguration as well as an option to cancel async operations on non-fatal session errors.

Fixes https://github.com/realm/realm-dotnet/issues/3222
Fixes https://github.com/realm/realm-dotnet/issues/3223

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
