### PR TITLE
[v11] 12. Raise Replace events for collection notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### Enhancements
 * Added nullability annotations to the Realm assembly. Now methods returning reference types are correctly annotated to indicate whether the returned value may or may not be null. (Issue [#3248](https://github.com/realm/realm-dotnet/issues/3248))
+* Replacing a value at an index (i.e. `myList[1] = someObj`) will now correctly `CollectionChange` notifications with the `Replace` action. (Issue [#2854](https://github.com/realm/realm-dotnet/issues/2854))
 
 ### Fixed
 


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Fixes https://github.com/realm/realm-dotnet/issues/2854

This doesn't technically need v11, but it would have conflicted, so I decided to do it on top of the nullable annotations branch.

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
