### PR TITLE
Reduce number of reg invocations on Unity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 * None
 
 ### Fixed
-* None
+* Fixed an issue on Unity on Windows when the weaver would trigger excessive terminal windows to open. (Issue [3364]https://github.com/realm/realm-dotnet/issues/3364)
+* Fixed an issue on Unity on CI where weaving would fail with the following error: `Could not analyze the user's assembly. Cannot access a closed Stream.`. (Issue [3364]https://github.com/realm/realm-dotnet/issues/3364)
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.
 
 ### Internal
-* Using Core x.y.z.
+* Using Core 13.15.0
 
 ## 11.1.2 (2023-06-20)
 

--- a/Realm/Realm.Weaver/Analytics/Analytics.cs
+++ b/Realm/Realm.Weaver/Analytics/Analytics.cs
@@ -250,7 +250,7 @@ namespace RealmWeaver
             {
                 // collect environment details
                 _realmEnvMetrics[UserEnvironment.UserId] = AnonymizedUserId;
-                _realmEnvMetrics[UserEnvironment.LegacyUserId] = GetLegacyAnonymizedUserId();
+                _realmEnvMetrics[UserEnvironment.LegacyUserId] = LegacyAnonymizedUserId;
                 _realmEnvMetrics[UserEnvironment.ProjectId] = SHA256Hash(Encoding.UTF8.GetBytes(_config.ProjectId ?? module.Assembly.Name.Name));
                 _realmEnvMetrics[UserEnvironment.RealmSdk] = "dotnet";
                 _realmEnvMetrics[UserEnvironment.RealmSdkVersion] = Assembly.GetExecutingAssembly().GetName().Version.ToString();

--- a/Realm/Realm.Weaver/Analytics/Analytics.cs
+++ b/Realm/Realm.Weaver/Analytics/Analytics.cs
@@ -249,7 +249,7 @@ namespace RealmWeaver
             try
             {
                 // collect environment details
-                _realmEnvMetrics[UserEnvironment.UserId] = GetAnonymizedUserId();
+                _realmEnvMetrics[UserEnvironment.UserId] = AnonymizedUserId;
                 _realmEnvMetrics[UserEnvironment.LegacyUserId] = GetLegacyAnonymizedUserId();
                 _realmEnvMetrics[UserEnvironment.ProjectId] = SHA256Hash(Encoding.UTF8.GetBytes(_config.ProjectId ?? module.Assembly.Name.Name));
                 _realmEnvMetrics[UserEnvironment.RealmSdk] = "dotnet";

--- a/Realm/Realm.Weaver/Analytics/Analytics.cs
+++ b/Realm/Realm.Weaver/Analytics/Analytics.cs
@@ -435,12 +435,12 @@ namespace RealmWeaver
         {
             var payload = "Analytics disabled";
 
+            // this is necessary since when not in the assembly that has the models
+            // AnalyzeRealmClassProperties won't be called
+            _analyzeUserAssemblyTask.Wait();
+
             if (_config.AnalyticsCollection != AnalyticsCollection.Disabled)
             {
-                // this is necessary since when not in the assembly that has the models
-                // AnalyzeRealmClassProperties won't be called
-                _analyzeUserAssemblyTask.Wait();
-
                 try
                 {
                     const string sendAddr = "https://data.mongodb-api.com/app/realmsdkmetrics-zmhtm/endpoint/v2/metric?data=";

--- a/Realm/Realm.Weaver/Analytics/AnalyticsUtils.cs
+++ b/Realm/Realm.Weaver/Analytics/AnalyticsUtils.cs
@@ -84,7 +84,25 @@ namespace RealmWeaver
             }
         });
 
+        private static readonly Lazy<string> _legacyAnonymizedUserId = new(() =>
+        {
+            try
+            {
+                var id = NetworkInterface.GetAllNetworkInterfaces()
+                                   .Where(n => n.Name == "en0" || (n.OperationalStatus == OperationalStatus.Up && n.NetworkInterfaceType != NetworkInterfaceType.Loopback))
+                                   .Select(n => n.GetPhysicalAddress().GetAddressBytes())
+                                   .First();
+                return SHA256Hash(id, useLegacyEncoding: true);
+            }
+            catch
+            {
+                return Unknown();
+            }
+        });
+
         public static string AnonymizedUserId => _anonymizedUserId.Value;
+        
+        public static string LegacyAnonymizedUserId => _legacyAnonymizedUserId.Value;
 
         public static string GetTargetOsName(FrameworkName frameworkName)
         {
@@ -233,22 +251,6 @@ namespace RealmWeaver
             }
 
             return Unknown();
-        }
-
-        public static string GetLegacyAnonymizedUserId()
-        {
-            try
-            {
-                var id = NetworkInterface.GetAllNetworkInterfaces()
-                                   .Where(n => n.Name == "en0" || (n.OperationalStatus == OperationalStatus.Up && n.NetworkInterfaceType != NetworkInterfaceType.Loopback))
-                                   .Select(n => n.GetPhysicalAddress().GetAddressBytes())
-                                   .First();
-                return SHA256Hash(id, useLegacyEncoding: true);
-            }
-            catch
-            {
-                return Unknown();
-            }
         }
 
         private static bool ContainsIgnoreCase(this string @this, string strCompare) =>

--- a/Realm/Realm.Weaver/Analytics/AnalyticsUtils.cs
+++ b/Realm/Realm.Weaver/Analytics/AnalyticsUtils.cs
@@ -101,7 +101,7 @@ namespace RealmWeaver
         });
 
         public static string AnonymizedUserId => _anonymizedUserId.Value;
-        
+
         public static string LegacyAnonymizedUserId => _legacyAnonymizedUserId.Value;
 
         public static string GetTargetOsName(FrameworkName frameworkName)


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

This PR attempts to address the issues highlighted in https://github.com/realm/realm-dotnet/issues/3364 by:
1. Creating a hidden window for the `reg` invocation. This should address the annoyance of a terminal window popping up every time we build the project.
2. Caching the results of the `reg` invocation. Those are unlikely to change, so no need to run it on every build.

Fixes https://github.com/realm/realm-dotnet/issues/3364

##  TODO

* [x] Changelog entry
* [ ] Tests (if applicable)
* [ ] Decide whether we want to keep getting the machine guid from reg or use one of the Unity options for a unique device id.
