### PR TITLE
Relax IndexOf conditions to handle null and unmanaged objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Enhancements
 * Added validation checks to the geospatial type constructors. This means that an exception will now be thrown when constructing an invalid geospatial shape rather than when using it in a query. (PR [#3362](https://github.com/realm/realm-dotnet/pull/3362)) 
+* Relaxed some validations when invoking `IndexOf(null)` on a collection of non-nullable types. Previously, this would throw an `ArgumentNullException` whereas now it will return `-1`. This is particularly useful for data-binding scenarios where the binding engine might invoke it as `IndexOf(SelectedItem)` which would throw an exception when `SelectedItem` is `null`. (PR [#3369](https://github.com/realm/realm-dotnet/pull/3369))
+* Changed `RealmSet.IndexOf` implementation to return the actual result rather than throw a `NotSupportedException`. The order of persisted sets is still non-deterministic, but is stable between write transactions. Again, this is mostly useful for data-binding scenarios where the set is passed as a binding context to a collection control. (PR [#3369](https://github.com/realm/realm-dotnet/pull/3369))
 
 ### Fixed
 * None

--- a/Realm/Realm/DatabaseTypes/RealmList.cs
+++ b/Realm/Realm/DatabaseTypes/RealmList.cs
@@ -109,7 +109,7 @@ namespace Realms
 
             if (realmValue.Type == RealmValueType.Object && !realmValue.AsIRealmObject().IsManaged)
             {
-                throw new ArgumentException("Value does not belong to a realm", nameof(value));
+                return -1;
             }
 
             return _listHandle.Find(realmValue);

--- a/Realm/Realm/DatabaseTypes/RealmSet.cs
+++ b/Realm/Realm/DatabaseTypes/RealmSet.cs
@@ -89,7 +89,7 @@ namespace Realms
             return _setHandle.Remove(realmValue);
         }
 
-        public override int IndexOf([AllowNull] T value) => throw new NotSupportedException();
+        public override int IndexOf([AllowNull] T value) => -1;
 
         public override bool Contains([AllowNull] T value)
         {

--- a/Realm/Realm/DatabaseTypes/RealmSet.cs
+++ b/Realm/Realm/DatabaseTypes/RealmSet.cs
@@ -89,7 +89,21 @@ namespace Realms
             return _setHandle.Remove(realmValue);
         }
 
-        public override int IndexOf([AllowNull] T value) => -1;
+        // IndexOf is not available on ISet<T>, but is available on IList and IRealmCollection.
+        // We provide an implementation here because in data-binding scenarios, the binding engine
+        // may cast the collection to IList and attempt to invoke IndexOf on it - most notably when
+        // binding to a ListView and changing the SelectedItem.
+        public override int IndexOf([AllowNull] T value)
+        {
+            var realmValue = Operator.Convert<T?, RealmValue>(value);
+
+            if (realmValue.Type == RealmValueType.Object && !realmValue.AsIRealmObject().IsManaged)
+            {
+                return -1;
+            }
+
+            return _setHandle.Find(realmValue);
+        }
 
         public override bool Contains([AllowNull] T value)
         {

--- a/Realm/Realm/Handles/SetHandle.cs
+++ b/Realm/Realm/Handles/SetHandle.cs
@@ -102,6 +102,9 @@ namespace Realms
                 [MarshalAs(UnmanagedType.LPWStr)] string query_buf, IntPtr query_len,
                 [MarshalAs(UnmanagedType.LPArray), In] NativeQueryArgument[] arguments, IntPtr args_count,
                 out NativeException ex);
+
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "set_find_value", CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr find_value(SetHandle setHandle, PrimitiveValue value, out NativeException ex);
         }
 
         public override bool IsValid
@@ -224,6 +227,17 @@ namespace Realms
         }
 
         public override void Unbind() => NativeMethods.destroy(handle);
+
+        public int Find(in RealmValue value)
+        {
+            EnsureIsOpen();
+
+            var (primitive, handles) = value.ToNative();
+            var result = NativeMethods.find_value(this, primitive, out var nativeException);
+            handles?.Dispose();
+            nativeException.ThrowIfNecessary();
+            return (int)result;
+        }
 
         protected override IntPtr SnapshotCore(out NativeException ex) => NativeMethods.snapshot(this, out ex);
 

--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -80,12 +80,7 @@ namespace Realms
 
         public override int IndexOf(T? value)
         {
-            if (value == null)
-            {
-                return -1;
-            }
-
-            var realmValue = Operator.Convert<T, RealmValue>(value!);
+            var realmValue = Operator.Convert<T?, RealmValue>(value!);
 
             if (realmValue.Type == RealmValueType.Object && !realmValue.AsIRealmObject().IsManaged)
             {

--- a/Realm/Realm/Linq/RealmResults.cs
+++ b/Realm/Realm/Linq/RealmResults.cs
@@ -80,13 +80,16 @@ namespace Realms
 
         public override int IndexOf(T? value)
         {
-            Argument.NotNull(value, nameof(value));
+            if (value == null)
+            {
+                return -1;
+            }
 
             var realmValue = Operator.Convert<T, RealmValue>(value!);
 
             if (realmValue.Type == RealmValueType.Object && !realmValue.AsIRealmObject().IsManaged)
             {
-                throw new ArgumentException("Value does not belong to a realm", nameof(value));
+                return -1;
             }
 
             return ResultsHandle.Find(realmValue);

--- a/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
+++ b/Tests/Realm.Tests/Database/RealmResults/SimpleLINQtests.cs
@@ -1312,7 +1312,7 @@ namespace Realms.Tests.Database
         {
             var query = _realm.All<IntPrimaryKeyWithValueObject>().AsRealmCollection();
             var nonManagedItem = new IntPrimaryKeyWithValueObject();
-            Assert.That(() => query.IndexOf(nonManagedItem), Throws.InstanceOf<ArgumentException>());
+            Assert.That(query.IndexOf(nonManagedItem), Is.EqualTo(-1));
         }
 
         [Test]
@@ -1331,10 +1331,10 @@ namespace Realms.Tests.Database
         }
 
         [Test]
-        public void Queryable_IndexOf_WhenNull_ShouldThrow()
+        public void Queryable_IndexOf_WhenNull_ShouldNotThrow()
         {
             var query = _realm.All<IntPrimaryKeyWithValueObject>().AsRealmCollection();
-            Assert.That(() => query.IndexOf(null), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(query.IndexOf(null), Is.EqualTo(-1));
         }
 
         [Test]

--- a/Tests/Realm.Tests/Database/RealmSetTests.cs
+++ b/Tests/Realm.Tests/Database/RealmSetTests.cs
@@ -1227,6 +1227,14 @@ namespace Realms.Tests.Database
             var managedSet = accessor(testObject);
             Assert.That(set, Is.Not.SameAs(managedSet));
 
+            // Assert RealmCollection.IndexOf
+            var managedCollection = managedSet.AsRealmCollection();
+            for (var i = 0; i < managedCollection.Count; i++)
+            {
+                var element = managedCollection[i];
+                Assert.That(managedCollection.IndexOf(element), Is.EqualTo(i));
+            }
+
             // Now we're testing set operations on RealmSet/HashSet
             testData.AssertCount(managedSet);
             testData.AssertExceptWith(managedSet);

--- a/wrappers/src/results_cs.cpp
+++ b/wrappers/src/results_cs.cpp
@@ -154,6 +154,11 @@ REALM_EXPORT Results* results_snapshot(const Results& results, NativeException::
 REALM_EXPORT size_t results_find_value(Results& results, realm_value_t value, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {
+        auto results_type = results.get_type();
+        if (value.is_null() && !is_nullable(results_type)) {
+            return (size_t)-1;
+        }
+
         if (value.type == realm_value_type::RLM_TYPE_LINK) {
             if (results.get_realm() != value.link.object->realm()) {
                 throw ObjectManagedByAnotherRealmException("Can't look up index of an object that belongs to a different Realm.");


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

Looks like MAUI really wants to use indexof and our validations are making it quite hard to data bind to realm collections directly. Not sure if this is the best approach here, but need something hacky for a demo.

##  TODO

* [x] Changelog entry
* [ ] Tests (if applicable)
