### PR TITLE
Avoiding GC of session when there are subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fixed a rare corruption of files on streaming format (often following compact, convert or copying to a new file). (Core 13.17.1)
 * Trying to search a full-text indexes created as a result of an additive schema change (i.e. applying the differences between the local schema and a synchronized realm's schema) could have resulted in an IllegalOperation error with the error code `Column has no fulltext index`. (Core 13.17.1)
 * Sync progress for DOWNLOAD messages from server state was updated wrongly. This may have resulted in an extra round-trip to the server. (Core 13.17.1)
+* Fixed an issue that would make `realm.SyncSession` garbage collected even when there are subscribers to `realm.SyncSession.PropertyChanged`.
 
 ### Fixed
 * Fixed a race condition between canceling an async write transaction and closing the Realm file, which could result in an `ObjectDisposedException : Safe handle has been closed` being thrown. ([PR #3400](https://github.com/realm/realm-dotnet/pull/3400))

--- a/Realm/Realm/Sync/Session.cs
+++ b/Realm/Realm/Sync/Session.cs
@@ -34,6 +34,10 @@ namespace Realms.Sync
     {
         private readonly SessionHandle _handle;
 
+        internal event EventHandler? Subscribed;
+
+        internal event EventHandler? Unsubscribed;
+
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "This is the private event - the public is uppercased.")]
         private event PropertyChangedEventHandler? _propertyChanged;
 
@@ -64,6 +68,7 @@ namespace Realms.Sync
                 if (_propertyChanged == null)
                 {
                     Handle.SubscribeNotifications(this);
+                    Subscribed?.Invoke(this, EventArgs.Empty);
                 }
 
                 _propertyChanged += value;
@@ -75,6 +80,7 @@ namespace Realms.Sync
 
                 if (_propertyChanged == null)
                 {
+                    Unsubscribed?.Invoke(this, EventArgs.Empty);
                     Handle.UnsubscribeNotifications();
                 }
             }
@@ -209,6 +215,7 @@ namespace Realms.Sync
                 }
 
                 _propertyChanged = null;
+                Unsubscribed?.Invoke(this, EventArgs.Empty);
                 _handle.Close();
             }
         }

--- a/Tests/Realm.Tests/Database/RelationshipTests.cs
+++ b/Tests/Realm.Tests/Database/RelationshipTests.cs
@@ -119,7 +119,7 @@ namespace Realms.Tests.Database
             Assert.That(() => tim.ListOfDogs.CopyTo(null!, 0), Throws.TypeOf<ArgumentNullException>());
             var copiedDogs = new Dog[2];
             Assert.That(() => tim.ListOfDogs.CopyTo(copiedDogs, -1), Throws.TypeOf<ArgumentOutOfRangeException>());
-            Assert.That(() => tim.ListOfDogs.CopyTo(copiedDogs, 1), Throws.TypeOf<ArgumentException>()); // insuffiient room
+            Assert.That(() => tim.ListOfDogs.CopyTo(copiedDogs, 1), Throws.TypeOf<ArgumentException>()); // insufficient room
         }
 
         [Test]

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -1016,9 +1016,85 @@ namespace Realms.Tests.Sync
                 var session = realm.SyncSession;
                 weakSessionRef = new WeakReference(session);
                 Assert.That(weakSessionRef.IsAlive, Is.True);
-                session.PropertyChanged += (sender, e) => { };
+                session.PropertyChanged += HandlePropertyChanged;
             });
 
+            static void HandlePropertyChanged(object sender, EventArgs e)
+            {
+            }
+
+            GC.Collect();
+            Assert.That(weakSessionRef.IsAlive, Is.False);
+        }
+
+        [Test]
+        public void Session_Free2_Instance_Even_With_PropertyChanged_Subscribers()
+        {
+            WeakReference weakSessionRef = null!;
+
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                var config = await GetIntegrationConfigAsync();
+                using var realm = GetRealm(config);
+                var session = realm.SyncSession;
+                weakSessionRef = new WeakReference(session);
+                Assert.That(weakSessionRef.IsAlive, Is.True);
+                session.PropertyChanged += HandlePropertyChanged;
+                session.PropertyChanged -= HandlePropertyChanged;
+            });
+
+            static void HandlePropertyChanged(object sender, EventArgs e)
+            {
+            }
+
+            GC.Collect();
+            Assert.That(weakSessionRef.IsAlive, Is.False);
+        }
+
+        [Test]
+        public async Task Session_AAAAAA()
+        {
+            // SyncTestHelpers.RunBaasTestAsync(async () =>
+            // {
+            //     var config = await GetIntegrationConfigAsync();
+            //     using var realm = GetRealm(config);
+
+            //     Func<WeakReference> ctr = () =>
+            //     {
+            //         return new WeakReference(realm.SyncSession);
+            //     };
+
+            //     WeakReference weakSessionRef = ctr();
+            //     Assert.That(weakSessionRef.IsAlive, Is.True);
+            //     realm.SyncSession.PropertyChanged += (sender, e) => { };
+
+            //     GC.Collect();
+            //     GC.WaitForPendingFinalizers();
+            //     Assert.That(weakSessionRef.IsAlive, Is.True);
+            // });
+
+            WeakReference weakSessionRef = null!;
+
+            var tcs1 = new TaskCompletionSource();
+            var tcs2 = new TaskCompletionSource();
+
+            Task.Run(() =>
+            {
+                SyncTestHelpers.RunBaasTestAsync(async () =>
+                {
+                    var config = await GetIntegrationConfigAsync();
+                    using var realm = GetRealm(config);
+                    var session = realm.SyncSession;
+                    weakSessionRef = new WeakReference(session);
+                    Assert.That(weakSessionRef.IsAlive, Is.True);
+                    session.PropertyChanged += (sender, e) => { };
+                });
+
+                tcs1.TrySetResult();
+
+            });
+
+            await tcs1.Task;
             GC.Collect();
             Assert.That(weakSessionRef.IsAlive, Is.False);
         }

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -1052,6 +1052,38 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
+        public void AnotherTest()
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                WeakReference weakSessionRef = null!;
+
+                var config = await GetIntegrationConfigAsync();
+                using var realm = GetRealm(config);
+
+                weakSessionRef = new Func<WeakReference>(() => {
+                    return new WeakReference(realm.SyncSession);
+                })();
+
+                Assert.That(weakSessionRef.IsAlive, Is.True);
+
+                realm.SyncSession.PropertyChanged += HandlePropertyChanged;
+
+                GC.Collect();
+                Assert.That(weakSessionRef.IsAlive, Is.True);
+
+                realm.SyncSession.PropertyChanged -= HandlePropertyChanged;
+
+                GC.Collect();
+                Assert.That(weakSessionRef.IsAlive, Is.False);  //TODO This fails
+            });
+
+            static void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)
+            {
+            }
+        }
+
+        [Test]
         public void Session_NotificationToken_Freed_When_Close_Realm()
         {
             WeakReference weakNotificationTokenRef = null!;

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -1052,7 +1052,7 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
-        public void AnotherTest()
+        public void Session_Should_Keep_Instance_Until_There_Are_Subscribers()
         {
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
@@ -1069,13 +1069,16 @@ namespace Realms.Tests.Sync
 
                 realm.SyncSession.PropertyChanged += HandlePropertyChanged;
 
+                // We want to have more assurance that the reference is not being collected at a later time
+                await WaitUntilReferencesAreCollected(500, weakSessionRef);
                 GC.Collect();
                 Assert.That(weakSessionRef.IsAlive, Is.True);
 
                 realm.SyncSession.PropertyChanged -= HandlePropertyChanged;
 
+                await WaitUntilReferencesAreCollected(500, weakSessionRef);
                 GC.Collect();
-                Assert.That(weakSessionRef.IsAlive, Is.False);  //TODO This fails
+                Assert.That(weakSessionRef.IsAlive, Is.False);
             });
 
             static void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -1019,12 +1019,12 @@ namespace Realms.Tests.Sync
                 session.PropertyChanged += HandlePropertyChanged;
             });
 
-            static void HandlePropertyChanged(object sender, EventArgs e)
+            static void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)
             {
             }
 
             GC.Collect();
-            Assert.That(weakSessionRef.IsAlive, Is.False);
+            Assert.That(weakSessionRef.IsAlive, Is.True);
         }
 
         [Test]
@@ -1043,7 +1043,7 @@ namespace Realms.Tests.Sync
                 session.PropertyChanged -= HandlePropertyChanged;
             });
 
-            static void HandlePropertyChanged(object sender, EventArgs e)
+            static void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)
             {
             }
 

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -1005,7 +1005,7 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
-        public void Session_Free_Instance_Even_With_PropertyChanged_Subscribers()
+        public void Session_Should_Not_Free_Instance_With_PropertyChanged_Subscribers()
         {
             WeakReference weakSessionRef = null!;
 
@@ -1028,7 +1028,7 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
-        public void Session_Free2_Instance_Even_With_PropertyChanged_Subscribers()
+        public void Session_Should_Free_Instance_With_No_PropertyChanged_Subscribers()
         {
             WeakReference weakSessionRef = null!;
 
@@ -1047,54 +1047,6 @@ namespace Realms.Tests.Sync
             {
             }
 
-            GC.Collect();
-            Assert.That(weakSessionRef.IsAlive, Is.False);
-        }
-
-        [Test]
-        public async Task Session_AAAAAA()
-        {
-            // SyncTestHelpers.RunBaasTestAsync(async () =>
-            // {
-            //     var config = await GetIntegrationConfigAsync();
-            //     using var realm = GetRealm(config);
-
-            //     Func<WeakReference> ctr = () =>
-            //     {
-            //         return new WeakReference(realm.SyncSession);
-            //     };
-
-            //     WeakReference weakSessionRef = ctr();
-            //     Assert.That(weakSessionRef.IsAlive, Is.True);
-            //     realm.SyncSession.PropertyChanged += (sender, e) => { };
-
-            //     GC.Collect();
-            //     GC.WaitForPendingFinalizers();
-            //     Assert.That(weakSessionRef.IsAlive, Is.True);
-            // });
-
-            WeakReference weakSessionRef = null!;
-
-            var tcs1 = new TaskCompletionSource();
-            var tcs2 = new TaskCompletionSource();
-
-            Task.Run(() =>
-            {
-                SyncTestHelpers.RunBaasTestAsync(async () =>
-                {
-                    var config = await GetIntegrationConfigAsync();
-                    using var realm = GetRealm(config);
-                    var session = realm.SyncSession;
-                    weakSessionRef = new WeakReference(session);
-                    Assert.That(weakSessionRef.IsAlive, Is.True);
-                    session.PropertyChanged += (sender, e) => { };
-                });
-
-                tcs1.TrySetResult();
-
-            });
-
-            await tcs1.Task;
             GC.Collect();
             Assert.That(weakSessionRef.IsAlive, Is.False);
         }

--- a/Tests/Realm.Tests/Sync/SessionTests.cs
+++ b/Tests/Realm.Tests/Sync/SessionTests.cs
@@ -1061,7 +1061,8 @@ namespace Realms.Tests.Sync
                 var config = await GetIntegrationConfigAsync();
                 using var realm = GetRealm(config);
 
-                weakSessionRef = new Func<WeakReference>(() => {
+                weakSessionRef = new Func<WeakReference>(() =>
+                {
                     return new WeakReference(realm.SyncSession);
                 })();
 
@@ -1071,13 +1072,11 @@ namespace Realms.Tests.Sync
 
                 // We want to have more assurance that the reference is not being collected at a later time
                 await WaitUntilReferencesAreCollected(500, weakSessionRef);
-                GC.Collect();
                 Assert.That(weakSessionRef.IsAlive, Is.True);
 
                 realm.SyncSession.PropertyChanged -= HandlePropertyChanged;
 
                 await WaitUntilReferencesAreCollected(500, weakSessionRef);
-                GC.Collect();
                 Assert.That(weakSessionRef.IsAlive, Is.False);
             });
 

--- a/Tests/Realm.Tests/TestHelpers.cs
+++ b/Tests/Realm.Tests/TestHelpers.cs
@@ -104,7 +104,7 @@ namespace Realms.Tests
             Assert.That(references.All(r => !r.IsAlive), "Expected all references to be GC-ed within 10 seconds but they weren't");
         }
 
-        private static async Task WaitUntilReferencesAreCollected(int milliseconds, params WeakReference[] references)
+        public static async Task WaitUntilReferencesAreCollected(int milliseconds, params WeakReference[] references)
         {
             IgnoreOnUnity("Waiting on GC seems to lock up on Unity on Linux.", OSPlatform.Linux);
 


### PR DESCRIPTION
We are trying to avoid that `realm.SyncSession` gets garbage collected, at least until there are subscribers to `realm.SyncSession.PropertyChanged`

##  TODO

* [x] Changelog entry
* [x] Tests (if applicable)
