### PR TITLE
Don’t use KeyValuePair in marshaling because it’s overloaded on UWP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Fixed the message of the `MissingMemberException` being thrown when attempting to access a non-existent property with the dynamic API. (PR [#3432](https://github.com/realm/realm-dotnet/pull/3432))
+* Fixed a `Cannot marshal generic Windows Runtime types with a non Windows Runtime type as a generic type argument` build error when using .NET Native. (Issue [#3434](https://github.com/realm/realm-dotnet/issues/3434), since 11.4.0)
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/Realm/Realm/Native/HttpClientTransport.cs
+++ b/Realm/Realm/Native/HttpClientTransport.cs
@@ -59,7 +59,7 @@ namespace Realms.Native
 
             public readonly UInt64 timeout_ms;
 
-            public readonly MarshaledVector<KeyValuePair<StringValue, StringValue>> headers;
+            public readonly MarshaledVector<MarshaledPair<StringValue, StringValue>> headers;
 
             private readonly StringValue body;
 
@@ -91,7 +91,7 @@ namespace Realms.Native
 
             public CustomErrorCode custom_status_code;
 
-            public MarshaledVector<KeyValuePair<StringValue, StringValue>> headers;
+            public MarshaledVector<MarshaledPair<StringValue, StringValue>> headers;
 
             public StringValue body;
         }
@@ -148,13 +148,13 @@ namespace Realms.Native
                     var response = await httpClient.SendAsync(message, cts.Token).ConfigureAwait(false);
 
                     var headers = response.Headers.Concat(response.Content.Headers)
-                        .Select(h => new KeyValuePair<StringValue, StringValue>(StringValue.AllocateFrom(h.Key, arena), StringValue.AllocateFrom(h.Value.FirstOrDefault(), arena)))
+                        .Select(h => new MarshaledPair<StringValue, StringValue>(StringValue.AllocateFrom(h.Key, arena), StringValue.AllocateFrom(h.Value.FirstOrDefault(), arena)))
                         .ToArray();
 
                     var nativeResponse = new HttpClientResponse
                     {
                         http_status_code = (int)response.StatusCode,
-                        headers = MarshaledVector<KeyValuePair<StringValue, StringValue>>.AllocateFrom(headers, arena),
+                        headers = MarshaledVector<MarshaledPair<StringValue, StringValue>>.AllocateFrom(headers, arena),
                         body = StringValue.AllocateFrom(await response.Content.ReadAsStringAsync().ConfigureAwait(false), arena),
                     };
 

--- a/Realm/Realm/Native/MarshaledPair.cs
+++ b/Realm/Realm/Native/MarshaledPair.cs
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System.Collections.Generic;
+
+namespace Realms.Native
+{
+    internal struct MarshaledPair<TKey, TValue>
+        where TKey : unmanaged
+        where TValue : unmanaged
+    {
+        public TKey Key;
+
+        public TValue Value;
+
+        public MarshaledPair(TKey key, TValue value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public void Deconstruct(out TKey key, out TValue value)
+        {
+            key = Key;
+            value = Value;
+        }
+
+        public static implicit operator KeyValuePair<TKey, TValue>(MarshaledPair<TKey, TValue> pair) => new (pair.Key, pair.Value);
+    }
+}

--- a/Realm/Realm/Native/SyncError.cs
+++ b/Realm/Realm/Native/SyncError.cs
@@ -34,7 +34,7 @@ namespace Realms.Native
         [MarshalAs(UnmanagedType.U1)]
         public bool is_client_reset;
 
-        public MarshaledVector<KeyValuePair<StringValue, StringValue>> user_info_pairs;
+        public MarshaledVector<MarshaledPair<StringValue, StringValue>> user_info_pairs;
 
         public MarshaledVector<CompensatingWriteInfo> compensating_writes;
 


### PR DESCRIPTION
## Description
Use our own struct for marshaling instead of using `System.KeyValuePair<TKey, TValue>`.

Fixes #3434

* [x] Changelog entry
* [ ] Tests (if applicable)
