### PR TITLE
Small fixes to source generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Made WebSocket error logging more verbose when using `AppConfiguration.UseManagedWebSockets = true`. [#3459](https://github.com/realm/realm-dotnet/pull/3459)
 
 ### Fixed
-* None
+* Added an error that is raised when interface based Realm classes are used with a language version lower than 8.0. At the same time, removed the use of `not` in the generated code, so that it's compatible with a minumum C# version of 8.0. (Issue [#3265](https://github.com/realm/realm-dotnet/issues/3265))
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/Realm/Realm.SourceGenerator/ClassCodeBuilder.cs
+++ b/Realm/Realm.SourceGenerator/ClassCodeBuilder.cs
@@ -476,7 +476,7 @@ public override bool Equals(object? obj)
         return !IsValid;
     }
 
-    if (obj is not Realms.IRealmObjectBase iro)
+    if (!(obj is Realms.IRealmObjectBase iro))
     {
         return false;
     }

--- a/Realm/Realm.SourceGenerator/Diagnostics.cs
+++ b/Realm/Realm.SourceGenerator/Diagnostics.cs
@@ -53,6 +53,7 @@ namespace Realms.SourceGenerator
             IndexedPrimaryKey = 28,
             InvalidCollectionInitializer = 29,
             InvalidCollectionInitializerInCtor = 30,
+            OldCSharpVersion = 100,
             InvalidGeneratorConfiguration = 1000,
         }
 
@@ -77,12 +78,21 @@ namespace Realms.SourceGenerator
                 description: $"Exception Message: {message}. \r\nCallstack:\r\n{stackTrace}");
         }
 
+        public static Diagnostic OldCSharpVersion()
+        {
+            return CreateDiagnosticError(
+                Id.OldCSharpVersion,
+                "Unsupported version of C#",
+                $"It is not possible to use the Realm source generator with C# versions older than 8.0.",
+                Location.None);
+        }
+
         public static Diagnostic ClassUnclearDefinition(string className, Location location)
         {
             return CreateDiagnosticError(
                 Id.ClassUnclearDefinition,
                 "Realm classes cannot implement multiple class interfaces",
-                $"Class {className} is declared as implementing multiple class interfaces.A class can implement only one interface between IRealmObject, IEmbeddedObject, IAsymmetricObject.",
+                $"Class {className} is declared as implementing multiple class interfaces. A class can implement only one interface between IRealmObject, IEmbeddedObject, IAsymmetricObject.",
                 location);
         }
 

--- a/Realm/Realm.SourceGenerator/Diagnostics.cs
+++ b/Realm/Realm.SourceGenerator/Diagnostics.cs
@@ -68,6 +68,15 @@ namespace Realms.SourceGenerator
                 Location.None);
         }
 
+        public static Diagnostic OldCSharpVersion()
+        {
+            return CreateDiagnosticError(
+                Id.OldCSharpVersion,
+                "Unsupported version of C#",
+                $"It is not possible to use the Realm source generator with C# versions older than 8.0.",
+                Location.None);
+        }
+
         public static Diagnostic UnexpectedError(string className, string message, string stackTrace)
         {
             return CreateDiagnosticError(
@@ -76,15 +85,6 @@ namespace Realms.SourceGenerator
                 $"There was an unexpected error during source generation of class {className}",
                 Location.None,
                 description: $"Exception Message: {message}. \r\nCallstack:\r\n{stackTrace}");
-        }
-
-        public static Diagnostic OldCSharpVersion()
-        {
-            return CreateDiagnosticError(
-                Id.OldCSharpVersion,
-                "Unsupported version of C#",
-                $"It is not possible to use the Realm source generator with C# versions older than 8.0.",
-                Location.None);
         }
 
         public static Diagnostic ClassUnclearDefinition(string className, Location location)

--- a/Realm/Realm.SourceGenerator/DiagnosticsEmitter.cs
+++ b/Realm/Realm.SourceGenerator/DiagnosticsEmitter.cs
@@ -59,6 +59,8 @@ namespace Realms.SourceGenerator
                     throw;
                 }
             }
+
+            parsingResults.GeneralDiagnostics.ForEach(_context.ReportDiagnostic);
         }
 
         private static void SerializeDiagnostics(GeneratorExecutionContext context, ClassInfo classInfo)

--- a/Realm/Realm.SourceGenerator/Parser.cs
+++ b/Realm/Realm.SourceGenerator/Parser.cs
@@ -51,6 +51,7 @@ namespace Realms.SourceGenerator
                 comp.LanguageVersion < LanguageVersion.CSharp8)
             {
                 result.GeneralDiagnostics.Add(Diagnostics.OldCSharpVersion());
+                return result;
             }
 
             foreach (var rc in realmClasses)

--- a/Realm/Realm.SourceGenerator/Parser.cs
+++ b/Realm/Realm.SourceGenerator/Parser.cs
@@ -46,6 +46,13 @@ namespace Realms.SourceGenerator
             var classNames = new HashSet<string>();
             var duplicateClassNames = new HashSet<string>();
 
+            if (realmClasses.Any() &&
+                _context.Compilation is CSharpCompilation comp &&
+                comp.LanguageVersion < LanguageVersion.CSharp8)
+            {
+                result.GeneralDiagnostics.Add(Diagnostics.OldCSharpVersion());
+            }
+
             foreach (var rc in realmClasses)
             {
                 var classSymbol = rc.ClassSymbol;
@@ -556,5 +563,7 @@ namespace Realms.SourceGenerator
     internal record ParsingResults
     {
         public List<ClassInfo> ClassInfo { get; } = new();
+
+        public List<Diagnostic> GeneralDiagnostics { get; } = new();
     }
 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/A_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/A_generated.cs
@@ -223,7 +223,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AgedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AgedObject_generated.cs
@@ -212,7 +212,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesObject_generated.cs
@@ -370,7 +370,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithAllTypes_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithAllTypes_generated.cs
@@ -354,7 +354,7 @@ namespace Realms.Tests.Sync
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedDictionaryObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedDictionaryObject_generated.cs
@@ -227,7 +227,7 @@ namespace Realms.Tests.Sync
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedListObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedListObject_generated.cs
@@ -227,7 +227,7 @@ namespace Realms.Tests.Sync
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedRecursiveObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AsymmetricObjectWithEmbeddedRecursiveObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests.Sync
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/B_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/B_generated.cs
@@ -218,7 +218,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BacklinkObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BacklinkObject_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Bar_DuplicateClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Bar_DuplicateClass_generated.cs
@@ -217,7 +217,7 @@ namespace Bar
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BasicAsymmetricObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/BasicAsymmetricObject_generated.cs
@@ -225,7 +225,7 @@ namespace Realms.Tests.Sync
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Child_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Child_generated.cs
@@ -228,7 +228,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Cities_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Cities_generated.cs
@@ -215,7 +215,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithUnqueryableMembers_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithUnqueryableMembers_generated.cs
@@ -236,7 +236,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CollectionsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CollectionsObject_generated.cs
@@ -489,7 +489,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Company_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Company_generated.cs
@@ -230,7 +230,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CompletionReport_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CompletionReport_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ContainerObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ContainerObject_generated.cs
@@ -219,7 +219,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CoordinatesEmbeddedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CoordinatesEmbeddedObject_generated.cs
@@ -225,7 +225,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CounterObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CounterObject_generated.cs
@@ -257,7 +257,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CustomGeoPoint_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/CustomGeoPoint_generated.cs
@@ -231,7 +231,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DecimalsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DecimalsObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DictionariesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DictionariesObject_generated.cs
@@ -312,7 +312,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
@@ -233,7 +233,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicDog_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicDog_generated.cs
@@ -225,7 +225,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicOwner_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicOwner_generated.cs
@@ -242,7 +242,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubSubTask_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubSubTask_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubTask_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicSubTask_generated.cs
@@ -228,7 +228,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicTask_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/DynamicTask_generated.cs
@@ -235,7 +235,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedAllTypesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedAllTypesObject_generated.cs
@@ -381,7 +381,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedGuidType_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedGuidType_generated.cs
@@ -266,7 +266,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedIntPropertyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedIntPropertyObject_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel1_generated.cs
@@ -230,7 +230,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel2_generated.cs
@@ -230,7 +230,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel3_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedLevel3_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ExplicitClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ExplicitClass_generated.cs
@@ -215,7 +215,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Foo_DuplicateClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Foo_DuplicateClass_generated.cs
@@ -217,7 +217,7 @@ namespace Foo
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/GuidType_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/GuidType_generated.cs
@@ -269,7 +269,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/HugeSyncObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/HugeSyncObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexedDateTimeOffsetObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexedDateTimeOffsetObject_generated.cs
@@ -213,7 +213,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexesClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexesClass_generated.cs
@@ -250,7 +250,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/InitializedFieldObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/InitializedFieldObject_generated.cs
@@ -212,7 +212,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPrimaryKeyWithValueObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPrimaryKeyWithValueObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPropertyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IntPropertyObject_generated.cs
@@ -228,7 +228,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level1_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level2_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level3_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Level3_generated.cs
@@ -212,7 +212,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ListsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ListsObject_generated.cs
@@ -309,7 +309,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/LoneClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/LoneClass_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties1_generated.cs
@@ -229,7 +229,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/MixedProperties2_generated.cs
@@ -229,7 +229,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoListProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoListProperties_generated.cs
@@ -219,7 +219,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithNonPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithNonPKRelation_generated.cs
@@ -223,7 +223,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NonPrimaryKeyWithPKRelation_generated.cs
@@ -223,7 +223,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NullablePrimaryKeyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NullablePrimaryKeyObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectContainerEmbedded_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectContainerEmbedded_generated.cs
@@ -226,7 +226,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectContainerV1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectContainerV1_generated.cs
@@ -230,7 +230,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectEmbedded_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectEmbedded_generated.cs
@@ -221,7 +221,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectIdPrimaryKeyWithValueObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectIdPrimaryKeyWithValueObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV1_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV1_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV2_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectV2_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithEmbeddedProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithEmbeddedProperties_generated.cs
@@ -231,7 +231,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithFtsIndex_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithFtsIndex_generated.cs
@@ -225,7 +225,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithInvalidGeoPoints_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithInvalidGeoPoints_generated.cs
@@ -224,7 +224,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithObjectProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithObjectProperties_generated.cs
@@ -220,7 +220,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithPartitionValue_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithPartitionValue_generated.cs
@@ -246,7 +246,7 @@ namespace Realms.Tests.Sync
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithRequiredStringList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ObjectWithRequiredStringList_generated.cs
@@ -219,7 +219,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnManagedTestClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnManagedTestClass_generated.cs
@@ -231,7 +231,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneListProperty_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneListProperty_generated.cs
@@ -216,7 +216,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneNonListProperty_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OneNonListProperty_generated.cs
@@ -214,7 +214,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnlyListProperties_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OnlyListProperties_generated.cs
@@ -219,7 +219,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedContainer_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedContainer_generated.cs
@@ -223,7 +223,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OrderedObject_generated.cs
@@ -223,7 +223,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Owner_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Owner_generated.cs
@@ -236,7 +236,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Parent_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Parent_generated.cs
@@ -228,7 +228,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
@@ -272,7 +272,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyByteObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyByteObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyCharObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyCharObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyGuidObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyGuidObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt16Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt16Object_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt32Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt32Object_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt64Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyInt64Object_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableByteObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableByteObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableCharObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableCharObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableGuidObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableGuidObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt16Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt16Object_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt32Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt32Object_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt64Object_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableInt64Object_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableObjectIdObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyNullableObjectIdObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObjectIdObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObjectIdObject_generated.cs
@@ -217,7 +217,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyStringObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyStringObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNoPKList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNoPKList_generated.cs
@@ -229,7 +229,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKChildWithPKGrandChild_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKChildWithPKGrandChild_generated.cs
@@ -228,7 +228,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithNonPKRelation_generated.cs
@@ -228,7 +228,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKList_generated.cs
@@ -229,7 +229,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKRelation_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrimaryKeyWithPKRelation_generated.cs
@@ -228,7 +228,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrivatePrimaryKeyObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PrivatePrimaryKeyObject_generated.cs
@@ -219,7 +219,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Product_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Product_generated.cs
@@ -231,7 +231,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmValueObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmValueObject_generated.cs
@@ -235,7 +235,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RecursiveBacklinksObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RecursiveBacklinksObject_generated.cs
@@ -224,7 +224,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedPropertiesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedPropertiesObject_generated.cs
@@ -222,7 +222,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedTypeObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RemappedTypeObject_generated.cs
@@ -246,7 +246,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Report_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Report_generated.cs
@@ -230,7 +230,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPrimaryKeyStringObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPrimaryKeyStringObject_generated.cs
@@ -219,7 +219,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPropertyClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredPropertyClass_generated.cs
@@ -212,7 +212,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredStringObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RequiredStringObject_generated.cs
@@ -214,7 +214,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SerializedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SerializedObject_generated.cs
@@ -236,7 +236,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SomeClass_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SomeClass_generated.cs
@@ -216,7 +216,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncAllTypesObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncAllTypesObject_generated.cs
@@ -299,7 +299,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncCollectionsObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncCollectionsObject_generated.cs
@@ -376,7 +376,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncObjectWithRequiredStringList_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/SyncObjectWithRequiredStringList_generated.cs
@@ -234,7 +234,7 @@ namespace Realms.Tests.Sync
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/TestNotificationObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/TestNotificationObject_generated.cs
@@ -248,7 +248,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ThrowsBeforeInitializer_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ThrowsBeforeInitializer_generated.cs
@@ -218,7 +218,7 @@ namespace Realms.Tests.Database
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/TopLevelGeoPoint_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/TopLevelGeoPoint_generated.cs
@@ -223,7 +223,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/TypeEmbeddedObject_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/TypeEmbeddedObject_generated.cs
@@ -220,7 +220,7 @@ namespace Realms.Tests.Database
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/UnqueryableBacklinks_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/UnqueryableBacklinks_generated.cs
@@ -218,7 +218,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Walker_generated.cs
+++ b/Tests/Realm.Tests/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Walker_generated.cs
@@ -233,7 +233,7 @@ namespace Realms.Tests
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/Realm.SourceGenerator.Tests/ComparisonTests.cs
+++ b/Tests/SourceGenerators/Realm.SourceGenerator.Tests/ComparisonTests.cs
@@ -17,6 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Realms.SourceGenerator;
 using RealmGeneratorVerifier = SourceGeneratorTests.CSharpSourceGeneratorVerifier<Realms.SourceGenerator.RealmGenerator>;
 
@@ -65,6 +67,22 @@ namespace SourceGeneratorTests
             test.TestState.Sources.Add(source);
             test.TestState.GeneratedSources.Add((typeof(RealmGenerator), generatedFileName, generated));
             test.TestState.AnalyzerConfigFiles.Add(("/.globalConfig", BuildGlobalOptions(options)));
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task OldCSharpVersionTest()
+        {
+            var className = "AllTypesClass";
+            var source = GetSource(className, ClassFolder.Test);
+            var error = new DiagnosticResult("RLM100", DiagnosticSeverity.Error)
+        .WithMessage("It is not possible to use the Realm source generator with C# versions older than 8.0.");
+
+            var test = new RealmGeneratorVerifier.Test();
+            test.LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7;
+            test.TestState.Sources.Add(source);
+            test.TestState.ExpectedDiagnostics.Add(error);
 
             await test.RunAsync();
         }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AllTypesClass_generated.cs
@@ -408,7 +408,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AutomaticPropertiesClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/AutomaticPropertiesClass_generated.cs
@@ -212,7 +212,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithoutParameterlessConstructor_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ClassWithoutParameterlessConstructor_generated.cs
@@ -213,7 +213,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ConfusingNamespaceClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/ConfusingNamespaceClass_generated.cs
@@ -212,7 +212,7 @@ namespace SourceGeneratorAssemblyToProcess.Realm
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Dog_generated.cs
@@ -218,7 +218,7 @@ namespace SourceGeneratorPlayground
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/EmbeddedObj_generated.cs
@@ -216,7 +216,7 @@ namespace SourceGeneratorPlayground
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IgnoreObjectNullabilityClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IgnoreObjectNullabilityClass_generated.cs
@@ -243,7 +243,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexedClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/IndexedClass_generated.cs
@@ -234,7 +234,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/InitializerNamespaceClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/InitializerNamespaceClass_generated.cs
@@ -210,7 +210,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NamespaceObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NamespaceObj_generated.cs
@@ -219,7 +219,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NestedClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NestedClass_generated.cs
@@ -220,7 +220,7 @@ namespace SourceGeneratorPlayground
                     return !IsValid;
                 }
 
-                if (obj is not Realms.IRealmObjectBase iro)
+                if (!(obj is Realms.IRealmObjectBase iro))
                 {
                     return false;
                 }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoNamespaceClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NoNamespaceClass_generated.cs
@@ -206,7 +206,7 @@ public partial class NoNamespaceClass : IRealmObject, INotifyPropertyChanged, IR
             return !IsValid;
         }
 
-        if (obj is not Realms.IRealmObjectBase iro)
+        if (!(obj is Realms.IRealmObjectBase iro))
         {
             return false;
         }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NullableClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/NullableClass_generated.cs
@@ -275,7 +275,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OtherNamespaceObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/OtherNamespaceObj_generated.cs
@@ -212,7 +212,7 @@ namespace OtherNamespace
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PartialClass_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/PartialClass_generated.cs
@@ -214,7 +214,7 @@ namespace SourceGeneratorAssemblyToProcess
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/Person_generated.cs
@@ -218,7 +218,7 @@ namespace SourceGeneratorPlayground
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmObj_generated.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmObj_generated.cs
@@ -212,7 +212,7 @@ namespace SourceGeneratorPlayground
                 return !IsValid;
             }
 
-            if (obj is not Realms.IRealmObjectBase iro)
+            if (!(obj is Realms.IRealmObjectBase iro))
             {
                 return false;
             }

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmObjectAndEmbeddedObjectClass.diagnostics.cs
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/Generated/Realm.SourceGenerator/Realms.SourceGenerator.RealmGenerator/RealmObjectAndEmbeddedObjectClass.diagnostics.cs
@@ -2,7 +2,7 @@
   {
     "Id": "RLM002",
     "Severity": 3,
-    "Message": "Class RealmObjectAndEmbeddedObjectClass is declared as implementing multiple class interfaces.A class can implement only one interface between IRealmObject, IEmbeddedObject, IAsymmetricObject.",
+    "Message": "Class RealmObjectAndEmbeddedObjectClass is declared as implementing multiple class interfaces. A class can implement only one interface between IRealmObject, IEmbeddedObject, IAsymmetricObject.",
     "Location": {
       "StartLine": 23,
       "StartColumn": 26,

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/SourceGeneratorAssemblyToProcess.csproj
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/SourceGeneratorAssemblyToProcess.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>disable</Nullable>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This PR does two things:
- Raises an error when running the source generator against c# code with a version lower than 8.0
- Removes the use of `not` from the generated code, so it should be possible to use c# 8.0 as the minimum supported version. (most of the changes in the PR are due to this)

Fixes #3265

##  TODO

* [x] Changelog entry
