### PR TITLE
Added missing docs and tests for `WriteCopy` when using flexible sync

### DIFF
--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -1308,11 +1308,24 @@ namespace Realms
         /// 3. When using Sync, it is required that all local changes are synchronized with the server before the copy can be written.
         ///    This is to be sure that the file can be used as a starting point for a newly installed application.
         ///    The function will throw if there are pending uploads.
+        /// 4. Writing a copy to a flexible sync realm is not supported unless flexible sync is already enabled.
+        /// 5  Changing from flexible sync sync to partition based sync is not supported.
+        /// 6. Changing the partition to synchronize on is not supported.
         /// </remarks>
         /// <param name="config">Configuration, specifying the path and optionally the encryption key for the copy.</param>
         public void WriteCopy(RealmConfigurationBase config)
         {
             Argument.NotNull(config, nameof(config));
+
+            if (config is FlexibleSyncConfiguration && Config is not FlexibleSyncConfiguration)
+            {
+                throw new NotSupportedException("Writing a copy to a flexible sync realm is not supported unless flexible sync is already enabled");
+            }
+
+            if (config is PartitionSyncConfiguration && Config is FlexibleSyncConfiguration)
+            {
+                throw new NotSupportedException("Changing from flexible sync sync to partition based sync is not supported when writing a Realm copy.");
+            }
 
             if (Config is PartitionSyncConfiguration originalConfig && config is PartitionSyncConfiguration copiedConfig && originalConfig.Partition != copiedConfig.Partition)
             {

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -610,6 +610,45 @@ namespace Realms.Tests.Sync
         }
 
         [Test]
+        public void WriteCopy_ThrowsWhenConvertingFromLocalToFLX()
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                using var localRealm = GetRealm();
+                var flexConfig = await GetFLXIntegrationConfigAsync();
+
+                var ex = Assert.Throws<NotSupportedException>(() => localRealm.WriteCopy(flexConfig))!;
+                Assert.That(ex.Message, Does.Contain("Writing a copy to a flexible sync realm is not supported unless flexible sync is already enabled"));
+            });
+        }
+
+        [Test]
+        public void WriteCopy_ThrowsWhenConvertingFromPBSToFLX()
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                using var pbsRealm = await GetIntegrationRealmAsync();
+                var flexConfig = await GetFLXIntegrationConfigAsync();
+
+                var ex = Assert.Throws<NotSupportedException>(() => pbsRealm.WriteCopy(flexConfig))!;
+                Assert.That(ex.Message, Does.Contain("Writing a copy to a flexible sync realm is not supported unless flexible sync is already enabled"));
+            });
+        }
+
+        [Test]
+        public void WriteCopy_ThrowsWhenConvertingFromFLXToPBS()
+        {
+            SyncTestHelpers.RunBaasTestAsync(async () =>
+            {
+                using var flxRealm = await GetFLXIntegrationRealmAsync();
+                var pbsConfig = await GetIntegrationConfigAsync();
+
+                var ex = Assert.Throws<NotSupportedException>(() => flxRealm.WriteCopy(pbsConfig))!;
+                Assert.That(ex.Message, Does.Contain("Changing from flexible sync sync to partition based sync is not supported when writing a Realm copy"));
+            });
+        }
+
+        [Test]
         public void DeleteRealmWorksIfCalledMultipleTimes()
         {
             var config = GetFakeConfig();


### PR DESCRIPTION
Fixes #3195

##  TODO

* [x] Tests (if applicable)
