### PR TITLE
Bump System.Net.Security to 4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@
 * If the very first open of a flexible sync Realm triggered a client reset, the configuration had an initial subscriptions callback, both before and after reset callbacks, and the initial subscription callback began a read transaction without ending it (which is normally going to be the case), opening the frozen Realm for the after reset callback would trigger a BadVersion exception. (Core 13.24.1)
 * Automatic client reset recovery on flexible sync Realms would apply recovered changes in multiple write transactions, releasing the write lock in between. (Core 13.24.1)
 * Having a class name of length 57 would make client reset crash as a limit of 56 was wrongly enforced. (Core 13.24.1)
-* Fixed several causes of "decryption failed" exceptions that could happen when opening multiple encrypted Realm files in the same process while using Apple/linux and storing the Realms on an exFAT file system. (Core 13.24.1) 
+* Fixed several causes of "decryption failed" exceptions that could happen when opening multiple encrypted Realm files in the same process while using Apple/linux and storing the Realms on an exFAT file system. (Core 13.24.1)
 * Fixed several errors that could cause a crash of the sync client. (Core 13.25.0)
 * Bad performance of initial Sync download involving many backlinks. (Core 13.25.1)
+* Explicitly bumped the minimum version of System.Net.Security to 4.3.2 as 4.3.0 has been marked as vulnerable (more details can be found in the deprecation notice on the [NuGet page](https://www.nuget.org/packages/System.Net.Security/4.3.0)).
 
 ### Compatibility
 * Realm Studio: 13.0.0 or later.

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -33,6 +33,7 @@
     </PackageReference>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6" />

--- a/Tools/SetupUnityPackage/CommandLineOptions/RealmOptions.cs
+++ b/Tools/SetupUnityPackage/CommandLineOptions/RealmOptions.cs
@@ -42,7 +42,8 @@ namespace SetupUnityPackage
             "Fody",
             "System.Dynamic.Runtime",
             "Realm.PlatformHelpers",
-            "System.Net.WebSockets.Client"
+            "System.Net.WebSockets.Client",
+            "System.Net.Security"
         };
 
         private static readonly IEnumerable<DependencyInfo> _realmDependencies = new[]


### PR DESCRIPTION
<!--
Assign reviewers if ready for review.
 -->

## Description

4.3.0 has been marked as vulnerable. While users can manually upgrade to 4.3.1, it's easy to miss, so it's better to just pull in the latest non-vulnerable version. This is a transitive dependency we take on through System.Net.WebSockets.Client, but unfortunately the latest version of that package is 4.3.2 and it still depends on Security 4.3.0.