### PR TITLE
Increasing timeouts on Windows/UWP/Android

### DIFF
--- a/.github/actions/run-android-device-farm-test/action.yml
+++ b/.github/actions/run-android-device-farm-test/action.yml
@@ -22,6 +22,7 @@ runs:
       with:
         project_arn: ${{ inputs.project-arn}}
         device_pool_arn: ${{ inputs.device-pool-arn }}
+        timeout: 2700
         app_file: ${{ inputs.apk-path }}
         app_type: ANDROID_APP
         test_type: APPIUM_PYTHON

--- a/.github/actions/run-android-device-farm-test/action.yml
+++ b/.github/actions/run-android-device-farm-test/action.yml
@@ -22,7 +22,7 @@ runs:
       with:
         project_arn: ${{ inputs.project-arn}}
         device_pool_arn: ${{ inputs.device-pool-arn }}
-        timeout: 2700
+        timeout: 3000
         app_file: ${{ inputs.apk-path }}
         app_type: ANDROID_APP
         test_type: APPIUM_PYTHON

--- a/.github/templates/test-net-framework.yml
+++ b/.github/templates/test-net-framework.yml
@@ -9,7 +9,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: .NET Framework
-    timeout-minutes: 45
+    timeout-minutes: 50
     steps:
       - #@ template.replace(prepareTest("net-framework"))
       - #@ template.replace(buildTests("Tests/Realm.Tests", TargetFramework="net461", RealmTestsStandaloneExe="true"))

--- a/.github/templates/test-net-framework.yml
+++ b/.github/templates/test-net-framework.yml
@@ -9,7 +9,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: .NET Framework
-    timeout-minutes: 50
+    timeout-minutes: 60
     steps:
       - #@ template.replace(prepareTest("net-framework"))
       - #@ template.replace(buildTests("Tests/Realm.Tests", TargetFramework="net461", RealmTestsStandaloneExe="true"))

--- a/.github/templates/test-uwp-managed.yml
+++ b/.github/templates/test-uwp-managed.yml
@@ -9,7 +9,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: UWP
-    timeout-minutes: 50
+    timeout-minutes: 60
     steps:
       - #@ template.replace(prepareTest("uwp-managed"))
       - name: Import test certificate

--- a/.github/templates/test-uwp-managed.yml
+++ b/.github/templates/test-uwp-managed.yml
@@ -9,7 +9,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: UWP
-    timeout-minutes: 45
+    timeout-minutes: 50
     steps:
       - #@ template.replace(prepareTest("uwp-managed"))
       - name: Import test certificate

--- a/.github/workflows/test-net-framework.yml
+++ b/.github/workflows/test-net-framework.yml
@@ -15,7 +15,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: .NET Framework
-    timeout-minutes: 45
+    timeout-minutes: 50
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/test-net-framework.yml
+++ b/.github/workflows/test-net-framework.yml
@@ -15,7 +15,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: .NET Framework
-    timeout-minutes: 50
+    timeout-minutes: 60
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/test-uwp-managed.yml
+++ b/.github/workflows/test-uwp-managed.yml
@@ -19,7 +19,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: UWP
-    timeout-minutes: 45
+    timeout-minutes: 50
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/test-uwp-managed.yml
+++ b/.github/workflows/test-uwp-managed.yml
@@ -19,7 +19,7 @@ jobs:
   run-tests:
     runs-on: windows-latest
     name: UWP
-    timeout-minutes: 50
+    timeout-minutes: 60
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
Tests on CI are timing out since we added new sync tests, so for now we're increasing the timeouts. 