### PR TITLE
RNET-1161: Implement support for using a log level for a specific log category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,24 @@
 ## vNext (TBD)
 
+### Deprecations
+* TODO(lj): Add deprecated APIs
+
 ### Enhancements
 * Allow `ShouldCompactOnLaunch` to be set on `SyncConfiguration`, not only `RealmConfiguration`. (Issue [#3617](https://github.com/realm/realm-dotnet/issues/3617))
 * Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions (Core 14.10.0).
 * Performance has been improved for range queries on integers and timestamps. Requires that you use the "BETWEEN" operation in `Realm.All<T>().Filter(...)`. (Core 14.10.1)
+* Allowed `ShouldCompactOnLaunch` to be set on `SyncConfiguration`, not only `RealmConfiguration`. (Issue [#3617](https://github.com/realm/realm-dotnet/issues/3617))
+* Allowed setting and getting a `LogLevel` for a given `LogCategory`, enabling more control over which category of messages should be logged and at what criticality level. The hierarchy of categories starts at `LogCategory.Realm`.
+  ```csharp
+  Logger.SetLogLevel(LogLevel.Warn, LogCategory.Realm.Sync);
+  Logger.GetLogLevel(LogCategory.Realm.Sync.Client.Session); // LogLevel.Warn
+  ```
+  (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
+* Added a function logger that accepts a callback that will receive the `LogLevel`, `LogCategory`, and the message when invoked.
+  ```csharp
+  Logger.Default = Logger.Function((level, category, message) => /* custom implementation */);
+  ```
+  (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
 
 ### Fixed
 * A `ForCurrentlyOutstandingWork` progress notifier would not immediately call its callback after registration. Instead you would have to wait for some data to be received to get your first update - if you were already caught up when you registered the notifier you could end up waiting a long time for the server to deliver a download that would call/expire your notifier. (Core 14.8.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
     ```csharp
     RealmLogger.Default = RealmLogger.Function((level, category, message) => /* custom implementation */);
     ```
-  * Added a `RealmLogger.Log()` overload taking a category. If unset, `LogCategory.Realm.SDK` will be used.
+  * Added a `RealmLogger.Log()` overload taking a category. The pre-existing `Log()` API will implicitly log at `LogCategory.Realm.SDK`.
     ```csharp
     RealmLogger.Default.Log(LogLevel.Warn, LogCategory.Realm, "A warning message");
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,29 @@
 ## vNext (TBD)
 
 ### Deprecations
-* TODO(lj): Add deprecated APIs
+* The `Logger.LogLevel` `set` and `get` accessors have been deprecated. Please use `Logger.SetLogLevel()` and `Logger.GetLogLevel()` (see **Enhancements** below).
+* The `Logger.Function(Action<LogLevel, string> logFunction)` have been deprecated. Please use `Logger.Function(Action<LogLevel, LogCategory, string> logFunction)` (see **Enhancements** below).
 
 ### Enhancements
 * Allow `ShouldCompactOnLaunch` to be set on `SyncConfiguration`, not only `RealmConfiguration`. (Issue [#3617](https://github.com/realm/realm-dotnet/issues/3617))
 * Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions (Core 14.10.0).
 * Performance has been improved for range queries on integers and timestamps. Requires that you use the "BETWEEN" operation in `Realm.All<T>().Filter(...)`. (Core 14.10.1)
 * Allowed `ShouldCompactOnLaunch` to be set on `SyncConfiguration`, not only `RealmConfiguration`. (Issue [#3617](https://github.com/realm/realm-dotnet/issues/3617))
-* Allowed setting and getting a `LogLevel` for a given `LogCategory`, enabling more control over which category of messages should be logged and at what criticality level. The hierarchy of categories starts at `LogCategory.Realm`.
-  ```csharp
-  Logger.SetLogLevel(LogLevel.Warn, LogCategory.Realm.Sync);
-  Logger.GetLogLevel(LogCategory.Realm.Sync.Client.Session); // LogLevel.Warn
-  ```
-  (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
-* Added a function logger that accepts a callback that will receive the `LogLevel`, `LogCategory`, and the message when invoked.
-  ```csharp
-  Logger.Default = Logger.Function((level, category, message) => /* custom implementation */);
-  ```
-  (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
+* Introduced a `LogCategory` and allowed for more control over which category of messages should be logged and at which criticality level:
+  * Allowed setting and getting a `LogLevel` for a given `LogCategory`. The hierarchy of categories starts at `LogCategory.Realm`.
+    ```csharp
+    Logger.SetLogLevel(LogLevel.Warn, LogCategory.Realm.Sync);
+    Logger.GetLogLevel(LogCategory.Realm.Sync.Client.Session); // LogLevel.Warn
+    ```
+  * Added a function logger that accepts a callback that will receive the `LogLevel`, `LogCategory`, and the message when invoked.
+    ```csharp
+    Logger.Default = Logger.Function((level, category, message) => /* custom implementation */);
+    ```
+  * Added an optional category as a last parameter to `Logger.Log()`. If unset, `LogCategory.Realm.SDK` will be used.
+    ```csharp
+    Logger.Default.Log(LogLevel.Warn, "A warning message", LogCategory.Realm);
+    ```
+    (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
 
 ### Fixed
 * A `ForCurrentlyOutstandingWork` progress notifier would not immediately call its callback after registration. Instead you would have to wait for some data to be received to get your first update - if you were already caught up when you registered the notifier you could end up waiting a long time for the server to deliver a download that would call/expire your notifier. (Core 14.8.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
 ## vNext (TBD)
 
 ### Deprecations
-* The `Logger.LogLevel` `set` and `get` accessors have been deprecated. Please use `Logger.SetLogLevel()` and `Logger.GetLogLevel()` (see **Enhancements** below).
-* The `Logger.Function(Action<LogLevel, string> logFunction)` have been deprecated. Please use `Logger.Function(Action<LogLevel, LogCategory, string> logFunction)` (see **Enhancements** below).
+* The `Logger` has been deprecated in favor of `RealmLogger`, which `Logger` currently derives from. (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
+  * The `Logger.LogLevel` `set` and `get` accessors have been deprecated. Please use `RealmLogger.SetLogLevel()` and `RealmLogger.GetLogLevel()` (see **Enhancements** below).
+  * The `Logger.Function(Action<LogLevel, string> logFunction)` have been deprecated. Please use `RealmLogger.Function(Action<LogLevel, LogCategory, string> logFunction)` (see **Enhancements** below).
 
 ### Enhancements
 * Allow `ShouldCompactOnLaunch` to be set on `SyncConfiguration`, not only `RealmConfiguration`. (Issue [#3617](https://github.com/realm/realm-dotnet/issues/3617))
 * Reduce the size of the local transaction log produced by creating objects, improving the performance of insertion-heavy transactions (Core 14.10.0).
 * Performance has been improved for range queries on integers and timestamps. Requires that you use the "BETWEEN" operation in `Realm.All<T>().Filter(...)`. (Core 14.10.1)
 * Allowed `ShouldCompactOnLaunch` to be set on `SyncConfiguration`, not only `RealmConfiguration`. (Issue [#3617](https://github.com/realm/realm-dotnet/issues/3617))
-* Introduced a `LogCategory` and allowed for more control over which category of messages should be logged and at which criticality level:
+* Introduced a `LogCategory` and allowed for more control over which category of messages should be logged and at which criticality level. (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
   * Allowed setting and getting a `LogLevel` for a given `LogCategory`. The hierarchy of categories starts at `LogCategory.Realm`.
     ```csharp
-    Logger.SetLogLevel(LogLevel.Warn, LogCategory.Realm.Sync);
-    Logger.GetLogLevel(LogCategory.Realm.Sync.Client.Session); // LogLevel.Warn
+    RealmLogger.SetLogLevel(LogLevel.Warn, LogCategory.Realm.Sync);
+    RealmLogger.GetLogLevel(LogCategory.Realm.Sync.Client.Session); // LogLevel.Warn
     ```
   * Added a function logger that accepts a callback that will receive the `LogLevel`, `LogCategory`, and the message when invoked.
     ```csharp
-    Logger.Default = Logger.Function((level, category, message) => /* custom implementation */);
+    RealmLogger.Default = RealmLogger.Function((level, category, message) => /* custom implementation */);
     ```
-  * Added an optional category as a last parameter to `Logger.Log()`. If unset, `LogCategory.Realm.SDK` will be used.
+  * Added a `RealmLogger.Log()` overload taking a category. If unset, `LogCategory.Realm.SDK` will be used.
     ```csharp
-    Logger.Default.Log(LogLevel.Warn, "A warning message", LogCategory.Realm);
+    RealmLogger.Default.Log(LogLevel.Warn, LogCategory.Realm, "A warning message");
     ```
-    (PR [#3634](https://github.com/realm/realm-dotnet/pull/3634))
 
 ### Fixed
 * A `ForCurrentlyOutstandingWork` progress notifier would not immediately call its callback after registration. Instead you would have to wait for some data to be received to get your first update - if you were already caught up when you registered the notifier you could end up waiting a long time for the server to deliver a download that would call/expire your notifier. (Core 14.8.0)

--- a/Realm/Realm.UnityUtils/Initializer.cs
+++ b/Realm/Realm.UnityUtils/Initializer.cs
@@ -37,7 +37,7 @@ namespace UnityUtils
                 Platform.DeviceInfo = new UnityDeviceInfo();
                 Platform.BundleId = Application.productName;
                 InteropConfig.AddPotentialStorageFolder(FileHelper.GetStorageFolder());
-                Realms.Logging.Logger.Console = new UnityLogger();
+                Realms.Logging.RealmLogger.Console = new UnityLogger();
                 Application.quitting += () =>
                 {
                     NativeCommon.CleanupNativeResources("Application is exiting");

--- a/Realm/Realm.UnityUtils/UnityLogger.cs
+++ b/Realm/Realm.UnityUtils/UnityLogger.cs
@@ -20,6 +20,9 @@ using Realms.Logging;
 
 namespace UnityUtils
 {
+    /// <summary>
+    /// A <see cref="RealmLogger"/> that outputs messages via UnityEngine.
+    /// </summary>
     public class UnityLogger : RealmLogger
     {
         protected override void LogImpl(LogLevel level, LogCategory category, string message)

--- a/Realm/Realm.UnityUtils/UnityLogger.cs
+++ b/Realm/Realm.UnityUtils/UnityLogger.cs
@@ -22,9 +22,9 @@ namespace UnityUtils
 {
     public class UnityLogger : Logger
     {
-        protected override void LogImpl(LogLevel level, string message)
+        protected override void LogImpl(LogLevel level, LogCategory category, string message)
         {
-            var toLog = FormatLog(level, message);
+            var toLog = FormatLog(level, category, message);
             switch (level)
             {
                 case LogLevel.Fatal:

--- a/Realm/Realm.UnityUtils/UnityLogger.cs
+++ b/Realm/Realm.UnityUtils/UnityLogger.cs
@@ -22,9 +22,9 @@ namespace UnityUtils
 {
     public class UnityLogger : Logger
     {
-        protected override void LogImpl(LogLevel level, LogCategory category, string message)
+        protected override void LogImpl(LogLevel level, string message, LogCategory? category = null)
         {
-            var toLog = FormatLog(level, category, message);
+            var toLog = FormatLog(level, message, category!);
             switch (level)
             {
                 case LogLevel.Fatal:

--- a/Realm/Realm.UnityUtils/UnityLogger.cs
+++ b/Realm/Realm.UnityUtils/UnityLogger.cs
@@ -20,11 +20,11 @@ using Realms.Logging;
 
 namespace UnityUtils
 {
-    public class UnityLogger : Logger
+    public class UnityLogger : RealmLogger
     {
-        protected override void LogImpl(LogLevel level, string message, LogCategory? category = null)
+        protected override void LogImpl(LogLevel level, LogCategory category, string message)
         {
-            var toLog = FormatLog(level, message, category!);
+            var toLog = FormatLog(level, category!, message);
             switch (level)
             {
                 case LogLevel.Fatal:

--- a/Realm/Realm/Handles/RealmHandle.cs
+++ b/Realm/Realm/Handles/RealmHandle.cs
@@ -148,7 +148,7 @@ namespace Realms
             }
             catch(Exception ex)
             {
-                Logger.Default.Log(LogLevel.Error, $"An error occurred while closing native handle. Please file an issue at https://github.com/realm/realm-dotnet/issues. Error: {ex}");
+                RealmLogger.Default.Log(LogLevel.Error, $"An error occurred while closing native handle. Please file an issue at https://github.com/realm/realm-dotnet/issues. Error: {ex}");
                 Debug.Fail($"Failed to close native handle: {ex}");
 
                 // it would be really bad if we got an exception in here. We must not pass it on, but have to return false

--- a/Realm/Realm/Handles/SessionHandle.cs
+++ b/Realm/Realm/Handles/SessionHandle.cs
@@ -325,7 +325,7 @@ namespace Realms.Sync
             }
             catch (Exception ex)
             {
-                Logger.Default.Log(LogLevel.Warn, $"An error has occurred while handling a session error: {ex}");
+                RealmLogger.Default.Log(LogLevel.Warn, $"An error has occurred while handling a session error: {ex}");
             }
         }
 
@@ -359,7 +359,7 @@ namespace Realms.Sync
             catch (Exception ex)
             {
                 var handlerType = syncConfig is null ? "ClientResetHandler" : syncConfig.ClientResetHandler.GetType().Name;
-                Logger.Default.Log(LogLevel.Error, $"An error has occurred while executing {handlerType}.OnBeforeReset during a client reset: {ex}");
+                RealmLogger.Default.Log(LogLevel.Error, $"An error has occurred while executing {handlerType}.OnBeforeReset during a client reset: {ex}");
 
                 var exHandle = GCHandle.Alloc(ex);
                 return GCHandle.ToIntPtr(exHandle);
@@ -397,7 +397,7 @@ namespace Realms.Sync
             catch (Exception ex)
             {
                 var handlerType = syncConfig is null ? "ClientResetHandler" : syncConfig.ClientResetHandler.GetType().Name;
-                Logger.Default.Log(LogLevel.Error, $"An error has occurred while executing {handlerType}.OnAfterReset during a client reset: {ex}");
+                RealmLogger.Default.Log(LogLevel.Error, $"An error has occurred while executing {handlerType}.OnAfterReset during a client reset: {ex}");
 
                 var exHandle = GCHandle.Alloc(ex);
                 return GCHandle.ToIntPtr(exHandle);
@@ -460,7 +460,7 @@ namespace Realms.Sync
             }
             catch (Exception ex)
             {
-                Logger.Default.Log(LogLevel.Error, $"An error has occurred while raising a property changed event: {ex}");
+                RealmLogger.Default.Log(LogLevel.Error, $"An error has occurred while raising a property changed event: {ex}");
             }
         }
 

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -851,7 +851,7 @@ namespace Realms
         [MonoPInvokeCallback(typeof(NativeMethods.LogMessageCallback))]
         private static void LogMessage(StringValue message, LogLevel level, StringValue categoryName)
         {
-            RealmLogger.LogDefault(level, LogCategory.FromName(categoryName!), message!);
+            RealmLogger.CoreLogDefault(level, LogCategory.FromName(categoryName!), message!);
         }
 
         [MonoPInvokeCallback(typeof(NativeMethods.MigrationCallback))]

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -839,7 +839,7 @@ namespace Realms
         [MonoPInvokeCallback(typeof(NativeMethods.LogMessageCallback))]
         private static void LogMessage(StringValue message, LogLevel level, StringValue categoryName)
         {
-            Logger.LogDefault(level, LogCategory.FromName(categoryName!), message!);
+            Logger.LogDefault(level, message!, LogCategory.FromName(categoryName!));
         }
 
         [MonoPInvokeCallback(typeof(NativeMethods.MigrationCallback))]

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -75,9 +75,8 @@ namespace Realms
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void DisposeGCHandleCallback(IntPtr handle);
 
-            // TODO(lj): Update arg order to be the same across the SDK.
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            public delegate void LogMessageCallback(StringValue message, LogLevel level, StringValue categoryName);
+            public delegate void LogMessageCallback(LogLevel level, StringValue categoryName, StringValue message);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void HandleTaskCompletionCallback(IntPtr tcs_ptr, [MarshalAs(UnmanagedType.U1)] bool invoke_async, NativeException ex);
@@ -849,7 +848,7 @@ namespace Realms
         }
 
         [MonoPInvokeCallback(typeof(NativeMethods.LogMessageCallback))]
-        private static void LogMessage(StringValue message, LogLevel level, StringValue categoryName)
+        private static void LogMessage(LogLevel level, StringValue categoryName, StringValue message)
         {
             RealmLogger.CoreLogDefault(level, LogCategory.FromName(categoryName!), message!);
         }

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -224,6 +224,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_refresh_async", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool refresh_async(SharedRealmHandle realm, IntPtr tcs_handle, out NativeException ex);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_log_level", CallingConvention = CallingConvention.Cdecl)]
+            public static extern LogLevel get_log_level([MarshalAs(UnmanagedType.LPWStr)] string category_name, IntPtr category_name_len);
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_set_log_level", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_log_level(LogLevel level, [MarshalAs(UnmanagedType.LPWStr)] string category_name, IntPtr category_name_len);
 
@@ -271,6 +274,8 @@ namespace Realms
             NativeMethods.install_callbacks(notifyRealm, getNativeSchema, openRealm, disposeGCHandle, logMessage,
                 notifyObject, notifyDictionary, onMigration, shouldCompact, handleTaskCompletion, onInitialization);
         }
+
+        public static LogLevel GetLogLevel(LogCategory category) => NativeMethods.get_log_level(category.Name, (IntPtr)category.Name.Length);
 
         public static void SetLogLevel(LogLevel level, LogCategory category) => NativeMethods.set_log_level(level, category.Name, (IntPtr)category.Name.Length);
 

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -850,7 +850,7 @@ namespace Realms
         [MonoPInvokeCallback(typeof(NativeMethods.LogMessageCallback))]
         private static void LogMessage(LogLevel level, StringValue categoryName, StringValue message)
         {
-            RealmLogger.CoreLogDefault(level, LogCategory.FromName(categoryName!), message!);
+            RealmLogger.Default.LogAnyLevel(level, LogCategory.FromName(categoryName!), message!);
         }
 
         [MonoPInvokeCallback(typeof(NativeMethods.MigrationCallback))]

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -851,7 +851,7 @@ namespace Realms
         [MonoPInvokeCallback(typeof(NativeMethods.LogMessageCallback))]
         private static void LogMessage(StringValue message, LogLevel level, StringValue categoryName)
         {
-            Logger.LogDefault(level, message!, LogCategory.FromName(categoryName!));
+            RealmLogger.LogDefault(level, LogCategory.FromName(categoryName!), message!);
         }
 
         [MonoPInvokeCallback(typeof(NativeMethods.MigrationCallback))]

--- a/Realm/Realm/Handles/SharedRealmHandle.cs
+++ b/Realm/Realm/Handles/SharedRealmHandle.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -230,6 +231,9 @@ namespace Realms
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_set_log_level", CallingConvention = CallingConvention.Cdecl)]
             public static extern void set_log_level(LogLevel level, [MarshalAs(UnmanagedType.LPWStr)] string category_name, IntPtr category_name_len);
 
+            [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_log_category_names", CallingConvention = CallingConvention.Cdecl)]
+            public static extern MarshaledVector<StringValue> get_log_category_names();
+
             [DllImport(InteropConfig.DLL_NAME, EntryPoint = "shared_realm_get_operating_system", CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr get_operating_system(IntPtr buffer, IntPtr buffer_length);
 
@@ -278,6 +282,11 @@ namespace Realms
         public static LogLevel GetLogLevel(LogCategory category) => NativeMethods.get_log_level(category.Name, (IntPtr)category.Name.Length);
 
         public static void SetLogLevel(LogLevel level, LogCategory category) => NativeMethods.set_log_level(level, category.Name, (IntPtr)category.Name.Length);
+
+        public static string[] GetLogCategoryNames() => NativeMethods.get_log_category_names()
+            .ToEnumerable()
+            .Select(name => name.ToDotnetString()!)
+            .ToArray();
 
         [Preserve]
         protected SharedRealmHandle(IntPtr handle) : base(handle)

--- a/Realm/Realm/Handles/SyncUserHandle.cs
+++ b/Realm/Realm/Handles/SyncUserHandle.cs
@@ -463,7 +463,7 @@ namespace Realms.Sync
             }
             catch (Exception ex)
             {
-                Logger.Default.Log(LogLevel.Error, $"An error has occurred while raising User.Changed event: {ex}");
+                RealmLogger.Default.Log(LogLevel.Error, $"An error has occurred while raising User.Changed event: {ex}");
             }
         }
     }

--- a/Realm/Realm/Helpers/Argument.cs
+++ b/Realm/Realm/Helpers/Argument.cs
@@ -95,7 +95,7 @@ namespace Realms.Helpers
 
         public static void AssertDebug(string message)
         {
-            Logger.LogDefault(LogLevel.Error, $"{message} {OpenIssueText}");
+            RealmLogger.LogDefault(LogLevel.Error, $"{message} {OpenIssueText}");
 
 #if DEBUG
             throw new Exception(message);

--- a/Realm/Realm/Helpers/Argument.cs
+++ b/Realm/Realm/Helpers/Argument.cs
@@ -95,7 +95,7 @@ namespace Realms.Helpers
 
         public static void AssertDebug(string message)
         {
-            RealmLogger.LogDefault(LogLevel.Error, $"{message} {OpenIssueText}");
+            RealmLogger.Default.Log(LogLevel.Error, $"{message} {OpenIssueText}");
 
 #if DEBUG
             throw new Exception(message);

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -47,7 +47,7 @@ namespace Realms.Logging
             { Realm.SDK.Name, Realm.SDK },
         };
 
-        private LogCategory(string name) => Name = name;
+        private LogCategory(string name, LogCategory? parent) => Name = parent == null ? name : $"{parent}.{name}";
 
         internal static LogCategory FromName(string name)
         {
@@ -62,62 +62,74 @@ namespace Realms.Logging
         /// <returns>A string that represents the category, equivalent to its name.</returns>
         public override string ToString() => Name;
 
-        // TODO(lj): Passing entire category name path for now, can update later to
-        //           pass the current-level name (e.g. "Storage") and the parent.
-
         public class RealmLogCategory : LogCategory
         {
-            public StorageLogCategory Storage { get; } = new();
+            public StorageLogCategory Storage { get; }
 
-            public SyncLogCategory Sync { get; } = new();
+            public SyncLogCategory Sync { get; }
 
-            public LogCategory App { get; } = new("Realm.App");
+            public LogCategory App { get; }
 
-            public LogCategory SDK { get; } = new("Realm.SDK");
+            // TODO(lj): Prefer `SDK` or `Sdk` for c#?
+            public LogCategory SDK { get; }
 
-            internal RealmLogCategory() : base("Realm")
+            internal RealmLogCategory() : base("Realm", null)
             {
+                Storage = new StorageLogCategory(this);
+                Sync = new SyncLogCategory(this);
+                App = new LogCategory("App", this);
+                SDK = new LogCategory("SDK", this);
             }
         }
 
         public class StorageLogCategory : LogCategory
         {
-            public LogCategory Transaction { get; } = new("Realm.Storage.Transaction");
+            public LogCategory Transaction { get; }
 
-            public LogCategory Query { get; } = new("Realm.Storage.Query");
+            public LogCategory Query { get; }
 
-            public LogCategory Object { get; } = new("Realm.Storage.Object");
+            public LogCategory Object { get; }
 
-            public LogCategory Notification { get; } = new("Realm.Storage.Notification");
+            public LogCategory Notification { get; }
 
-            internal StorageLogCategory() : base("Realm.Storage")
+            internal StorageLogCategory(LogCategory parent) : base("Storage", parent)
             {
+                Transaction = new LogCategory("Transaction", this);
+                Query = new LogCategory("Query", this);
+                Object = new LogCategory("Object", this);
+                Notification = new LogCategory("Notification", this);
             }
         }
 
         public class SyncLogCategory : LogCategory
         {
-            public ClientLogCategory Client { get; } = new();
+            public ClientLogCategory Client { get; }
 
-            public LogCategory Server { get; } = new("Realm.Sync.Server");
+            public LogCategory Server { get; }
 
-            internal SyncLogCategory() : base("Realm.Sync")
+            internal SyncLogCategory(LogCategory parent) : base("Sync", parent)
             {
+                Client = new ClientLogCategory(this);
+                Server = new LogCategory("Server", this);
             }
         }
 
         public class ClientLogCategory : LogCategory
         {
-            public LogCategory Session { get; } = new("Realm.Sync.Client.Session");
+            public LogCategory Session { get; }
 
-            public LogCategory Changeset { get; } = new("Realm.Sync.Client.Changeset");
+            public LogCategory Changeset { get; }
 
-            public LogCategory Network { get; } = new("Realm.Sync.Client.Network");
+            public LogCategory Network { get; }
 
-            public LogCategory Reset { get; } = new("Realm.Sync.Client.Reset");
+            public LogCategory Reset { get; }
 
-            internal ClientLogCategory() : base("Realm.Sync.Client")
+            internal ClientLogCategory(LogCategory parent) : base("Client", parent)
             {
+                Session = new LogCategory("Session", this);
+                Changeset = new LogCategory("Changeset", this);
+                Network = new LogCategory("Network", this);
+                Reset = new LogCategory("Reset", this);
             }
         }
     }

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -28,7 +28,7 @@ namespace Realms.Logging
 
         public static RealmLogCategory Realm { get; } = new();
 
-        private static readonly Dictionary<string, LogCategory> _nameToCategory = new()
+        internal static readonly Dictionary<string, LogCategory> NameToCategory = new()
         {
             { Realm.Name, Realm },
             { Realm.Storage.Name, Realm.Storage },
@@ -51,7 +51,7 @@ namespace Realms.Logging
 
         internal static LogCategory FromName(string name)
         {
-            Argument.Ensure(_nameToCategory.TryGetValue(name, out var category), $"Unexpected category name: '{name}'", nameof(name));
+            Argument.Ensure(NameToCategory.TryGetValue(name, out var category), $"Unexpected category name: '{name}'", nameof(name));
 
             return category;
         }

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -16,16 +16,27 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-using System;
 using System.Collections.Generic;
 using Realms.Helpers;
 
 namespace Realms.Logging
 {
+    /// <summary>
+    /// Specifies the category to receive log messages for when logged by the default
+    /// logger. The <see cref="LogLevel"/> will always be set for a specific category.
+    /// Setting the log level for one category will automatically set the same level
+    /// for all of its subcategories.
+    /// </summary>
     public class LogCategory
     {
+        /// <summary>
+        /// Gets the name of the category.
+        /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Gets the top-level category for receiving log messages for all categories.
+        /// </summary>
         public static RealmLogCategory Realm { get; } = new();
 
         internal static readonly Dictionary<string, LogCategory> NameToCategory = new()
@@ -62,15 +73,30 @@ namespace Realms.Logging
         /// <returns>A string that represents the category, equivalent to its name.</returns>
         public override string ToString() => Name;
 
+        /// <summary>
+        /// The top-level category for receiving log messages for all categories.
+        /// </summary>
         public class RealmLogCategory : LogCategory
         {
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to database events.
+            /// </summary>
             public StorageLogCategory Storage { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to Atlas Device Sync.
+            /// </summary>
             public SyncLogCategory Sync { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to Atlas App.
+            /// </summary>
             public LogCategory App { get; }
 
             // TODO(lj): Prefer `SDK` or `Sdk` for c#?
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to the SDK.
+            /// </summary>
             public LogCategory SDK { get; }
 
             internal RealmLogCategory() : base("Realm", null)
@@ -82,14 +108,31 @@ namespace Realms.Logging
             }
         }
 
+        /// <summary>
+        /// The category for receiving log messages pertaining to database events.
+        /// </summary>
         public class StorageLogCategory : LogCategory
         {
+            /// <summary>
+            /// Gets the category for receiving log messages when creating, advancing, and
+            /// committing transactions.
+            /// </summary>
             public LogCategory Transaction { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages when querying the database.
+            /// </summary>
             public LogCategory Query { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages when mutating the database.
+            /// </summary>
             public LogCategory Object { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages when there are notifications
+            /// of changes to the database.
+            /// </summary>
             public LogCategory Notification { get; }
 
             internal StorageLogCategory(LogCategory parent) : base("Storage", parent)
@@ -101,10 +144,19 @@ namespace Realms.Logging
             }
         }
 
+        /// <summary>
+        /// The category for receiving log messages pertaining to Atlas Device Sync.
+        /// </summary>
         public class SyncLogCategory : LogCategory
         {
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to sync client operations.
+            /// </summary>
             public ClientLogCategory Client { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to sync server operations.
+            /// </summary>
             public LogCategory Server { get; }
 
             internal SyncLogCategory(LogCategory parent) : base("Sync", parent)
@@ -114,14 +166,30 @@ namespace Realms.Logging
             }
         }
 
+        /// <summary>
+        /// The category for receiving log messages pertaining to sync client operations.
+        /// </summary>
         public class ClientLogCategory : LogCategory
         {
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to the sync session.
+            /// </summary>
             public LogCategory Session { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages when receiving, uploading, and
+            /// integrating changesets.
+            /// </summary>
             public LogCategory Changeset { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages pertaining to low-level network activity.
+            /// </summary>
             public LogCategory Network { get; }
 
+            /// <summary>
+            /// Gets the category for receiving log messages when there are client reset operations.
+            /// </summary>
             public LogCategory Reset { get; }
 
             internal ClientLogCategory(LogCategory parent) : base("Client", parent)

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -26,6 +26,8 @@ namespace Realms.Logging
     /// logger. The <see cref="LogLevel"/> will always be set for a specific category.
     /// Setting the log level for one category will automatically set the same level
     /// for all of its subcategories.
+    /// <br/><br/>
+    /// The category hierarchy is the following:
     /// <code>
     /// Realm
     /// ├─► Storage
@@ -41,7 +43,7 @@ namespace Realms.Logging
     /// │   │   └─► Reset
     /// │   └─► Server
     /// ├─► App
-    /// └─► Sdk
+    /// └─► SDK
     /// </code>
     /// </summary>
     /// <example>

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -1,0 +1,132 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Collections.Generic;
+using Realms.Helpers;
+
+namespace Realms.Logging
+{
+    // TODO(lj): Remove 'abstract' and use this class instead of 'LeafLogCategory'?
+    public abstract class LogCategory
+    {
+        public string Name { get; }
+
+        public static RealmLogCategory Realm { get; } = new();
+
+        private static readonly Dictionary<string, LogCategory> _nameToCategory = new()
+        {
+            { Realm.Name, Realm },
+            { Realm.Storage.Name, Realm.Storage },
+            { Realm.Storage.Transaction.Name, Realm.Storage.Transaction },
+            { Realm.Storage.Query.Name, Realm.Storage.Query },
+            { Realm.Storage.Object.Name, Realm.Storage.Object },
+            { Realm.Storage.Notification.Name, Realm.Storage.Notification },
+            { Realm.Sync.Name, Realm.Sync },
+            { Realm.Sync.Client.Name, Realm.Sync.Client },
+            { Realm.Sync.Client.Session.Name, Realm.Sync.Client.Session },
+            { Realm.Sync.Client.Changeset.Name, Realm.Sync.Client.Changeset },
+            { Realm.Sync.Client.Network.Name, Realm.Sync.Client.Network },
+            { Realm.Sync.Client.Reset.Name, Realm.Sync.Client.Reset },
+            { Realm.Sync.Server.Name, Realm.Sync.Server },
+            { Realm.App.Name, Realm.App },
+            { Realm.SDK.Name, Realm.SDK },
+        };
+
+        private LogCategory(string name) => Name = name;
+
+        internal static LogCategory FromName(string name)
+        {
+            Argument.Ensure(_nameToCategory.TryGetValue(name, out var category), $"Unexpected category name: '{name}'", nameof(name));
+
+            return category;
+        }
+
+        /// <summary>
+        /// Returns a string that represents the category, equivalent to its name.
+        /// </summary>
+        /// <returns>A string that represents the category, equivalent to its name.</returns>
+        public override string ToString() => Name;
+
+        // TODO(lj): Passing entire category name path for now, can update later to
+        //           pass the current-level name (e.g. "Storage") and the parent.
+
+        public class RealmLogCategory : LogCategory
+        {
+            public StorageLogCategory Storage { get; } = new();
+
+            public SyncLogCategory Sync { get; } = new();
+
+            public LeafLogCategory App { get; } = new("Realm.App");
+
+            public LeafLogCategory SDK { get; } = new("Realm.SDK");
+
+            internal RealmLogCategory() : base("Realm")
+            {
+            }
+        }
+
+        public class StorageLogCategory : LogCategory
+        {
+            public LeafLogCategory Transaction { get; } = new("Realm.Storage.Transaction");
+
+            public LeafLogCategory Query { get; } = new("Realm.Storage.Query");
+
+            public LeafLogCategory Object { get; } = new("Realm.Storage.Object");
+
+            public LeafLogCategory Notification { get; } = new("Realm.Storage.Notification");
+
+            internal StorageLogCategory() : base("Realm.Storage")
+            {
+            }
+        }
+
+        public class SyncLogCategory : LogCategory
+        {
+            public ClientLogCategory Client { get; } = new();
+
+            public LeafLogCategory Server { get; } = new("Realm.Sync.Server");
+
+            internal SyncLogCategory() : base("Realm.Sync")
+            {
+            }
+        }
+
+        public class ClientLogCategory : LogCategory
+        {
+            public LeafLogCategory Session { get; } = new("Realm.Sync.Client.Session");
+
+            public LeafLogCategory Changeset { get; } = new("Realm.Sync.Client.Changeset");
+
+            public LeafLogCategory Network { get; } = new("Realm.Sync.Client.Network");
+
+            public LeafLogCategory Reset { get; } = new("Realm.Sync.Client.Reset");
+
+            internal ClientLogCategory() : base("Realm.Sync.Client")
+            {
+            }
+        }
+
+        public class LeafLogCategory : LogCategory
+        {
+            internal LeafLogCategory(string name) : base(name)
+            {
+            }
+        }
+    }
+}

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -22,8 +22,7 @@ using Realms.Helpers;
 
 namespace Realms.Logging
 {
-    // TODO(lj): Remove 'abstract' and use this class instead of 'LeafLogCategory'?
-    public abstract class LogCategory
+    public class LogCategory
     {
         public string Name { get; }
 
@@ -72,9 +71,9 @@ namespace Realms.Logging
 
             public SyncLogCategory Sync { get; } = new();
 
-            public LeafLogCategory App { get; } = new("Realm.App");
+            public LogCategory App { get; } = new("Realm.App");
 
-            public LeafLogCategory SDK { get; } = new("Realm.SDK");
+            public LogCategory SDK { get; } = new("Realm.SDK");
 
             internal RealmLogCategory() : base("Realm")
             {
@@ -83,13 +82,13 @@ namespace Realms.Logging
 
         public class StorageLogCategory : LogCategory
         {
-            public LeafLogCategory Transaction { get; } = new("Realm.Storage.Transaction");
+            public LogCategory Transaction { get; } = new("Realm.Storage.Transaction");
 
-            public LeafLogCategory Query { get; } = new("Realm.Storage.Query");
+            public LogCategory Query { get; } = new("Realm.Storage.Query");
 
-            public LeafLogCategory Object { get; } = new("Realm.Storage.Object");
+            public LogCategory Object { get; } = new("Realm.Storage.Object");
 
-            public LeafLogCategory Notification { get; } = new("Realm.Storage.Notification");
+            public LogCategory Notification { get; } = new("Realm.Storage.Notification");
 
             internal StorageLogCategory() : base("Realm.Storage")
             {
@@ -100,7 +99,7 @@ namespace Realms.Logging
         {
             public ClientLogCategory Client { get; } = new();
 
-            public LeafLogCategory Server { get; } = new("Realm.Sync.Server");
+            public LogCategory Server { get; } = new("Realm.Sync.Server");
 
             internal SyncLogCategory() : base("Realm.Sync")
             {
@@ -109,22 +108,15 @@ namespace Realms.Logging
 
         public class ClientLogCategory : LogCategory
         {
-            public LeafLogCategory Session { get; } = new("Realm.Sync.Client.Session");
+            public LogCategory Session { get; } = new("Realm.Sync.Client.Session");
 
-            public LeafLogCategory Changeset { get; } = new("Realm.Sync.Client.Changeset");
+            public LogCategory Changeset { get; } = new("Realm.Sync.Client.Changeset");
 
-            public LeafLogCategory Network { get; } = new("Realm.Sync.Client.Network");
+            public LogCategory Network { get; } = new("Realm.Sync.Client.Network");
 
-            public LeafLogCategory Reset { get; } = new("Realm.Sync.Client.Reset");
+            public LogCategory Reset { get; } = new("Realm.Sync.Client.Reset");
 
             internal ClientLogCategory() : base("Realm.Sync.Client")
-            {
-            }
-        }
-
-        public class LeafLogCategory : LogCategory
-        {
-            internal LeafLogCategory(string name) : base(name)
             {
             }
         }

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -115,7 +115,6 @@ namespace Realms.Logging
             /// </summary>
             public LogCategory App { get; }
 
-            // TODO(lj): Prefer `SDK` or `Sdk` for c#?
             /// <summary>
             /// Gets the category for receiving log messages pertaining to the SDK.
             /// </summary>

--- a/Realm/Realm/Logging/LogCategory.cs
+++ b/Realm/Realm/Logging/LogCategory.cs
@@ -26,7 +26,29 @@ namespace Realms.Logging
     /// logger. The <see cref="LogLevel"/> will always be set for a specific category.
     /// Setting the log level for one category will automatically set the same level
     /// for all of its subcategories.
+    /// <code>
+    /// Realm
+    /// ├─► Storage
+    /// │   ├─► Transaction
+    /// │   ├─► Query
+    /// │   ├─► Object
+    /// │   └─► Notification
+    /// ├─► Sync
+    /// │   ├─► Client
+    /// │   │   ├─► Session
+    /// │   │   ├─► Changeset
+    /// │   │   ├─► Network
+    /// │   │   └─► Reset
+    /// │   └─► Server
+    /// ├─► App
+    /// └─► Sdk
+    /// </code>
     /// </summary>
+    /// <example>
+    /// <code>
+    /// LogCategory.Realm.Sync.Client
+    /// </code>
+    /// </example>
     public class LogCategory
     {
         /// <summary>

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -199,14 +199,7 @@ namespace Realms.Logging
                 return;
             }
 
-            try
-            {
-                LogImpl(level, category, message);
-            }
-            catch (Exception ex)
-            {
-                Console.Log(LogLevel.Error, $"An exception occurred while trying to log the message: '{message}' at level: '{level}' in category: '{category}'. Error: {ex}");
-            }
+            CoreLog(level, category, message);
         }
 
         /// <summary>

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -35,10 +35,7 @@ namespace Realms.Logging
     {
         private readonly Lazy<GCHandle> _gcHandle;
 
-        // TODO(lj): Use this default log level?
-        private static readonly LogLevel _defaultLogLevel = LogLevel.Info;
         private static readonly LogCategory _defaultLogCategory = LogCategory.Realm;
-        private static LogCategory _logCategory = _defaultLogCategory;
         private static Logger? _defaultLogger;
 
         /// <summary>
@@ -111,16 +108,8 @@ namespace Realms.Logging
             }
         }
 
-        public static LogCategory LogCategory
-        {
-            get => _logCategory;
-        }
-
         public static LogLevel GetLogLevel(LogCategory? category = null)
         {
-            // TODO(lj): Perhaps we should grab the current category (`_logCategory`)
-            //           instead of the default here? If there hasn't been a category
-            //           explicitly set, it will still be the default.
             category ??= _defaultLogCategory;
             return SharedRealmHandle.GetLogLevel(category);
         }
@@ -129,7 +118,6 @@ namespace Realms.Logging
         {
             category ??= _defaultLogCategory;
             SharedRealmHandle.SetLogLevel(level, category);
-            _logCategory = category;
         }
 
         // TODO(lj): Would it make sense to also deprecate the Default setter
@@ -166,7 +154,8 @@ namespace Realms.Logging
         /// <param name="message">The message to log.</param>
         public void Log(LogLevel level, string message)
         {
-            Log(level, LogCategory, message);
+            // TODO(lj): See if `LogCategory.Realm.SDK` should be preferred.
+            Log(level, _defaultLogCategory, message);
         }
 
         public void Log(LogLevel level, LogCategory category, string message)

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -174,7 +174,7 @@ namespace Realms.Logging
 
         internal static void LogDefault(LogLevel level, LogCategory category, string message) => Default?.Log(level, category, message);
 
-        internal static void CoreLogDefault(LogLevel level, LogCategory category, string message) => Default?.CoreLog(level, category, message);
+        internal static void CoreLogDefault(LogLevel level, LogCategory category, string message) => Default?.LogAnyLevel(level, category, message);
 
         /// <summary>
         /// Log a message at the supplied level and default category <see cref="LogCategory.RealmLogCategory.SDK"/>.
@@ -199,14 +199,14 @@ namespace Realms.Logging
                 return;
             }
 
-            CoreLog(level, category, message);
+            LogAnyLevel(level, category, message);
         }
 
         /// <summary>
-        /// Log a message from Core that does not require checking the current
-        /// level as that check has already been performed by Core.
+        /// Log a message without calling into Core to check the current level. Logs from
+        /// Core should always call this API as they already check the level prior to notifying.
         /// </summary>
-        private void CoreLog(LogLevel level, LogCategory category, string message)
+        private void LogAnyLevel(LogLevel level, LogCategory category, string message)
         {
             try
             {

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -74,7 +74,6 @@ namespace Realms.Logging
         /// </returns>
         public static Logger Function(Action<string> logFunction) => new FunctionLogger((level, category, message) => logFunction(FormatLog(level, message, category)));
 
-        // TODO(lj): Deprecate
         /// <summary>
         /// Gets a <see cref="FunctionLogger"/> that proxies Log calls to the supplied function.
         /// </summary>
@@ -82,6 +81,7 @@ namespace Realms.Logging
         /// <returns>
         /// A <see cref="Logger"/> instance that will invoke <paramref name="logFunction"/> for each message.
         /// </returns>
+        [Obsolete("Use Function(Action<LogLevel, LogCategory, string> logFunction).")]
         public static Logger Function(Action<LogLevel, string> logFunction) => new FunctionLogger((level, _, message) => logFunction(level, message));
 
         /// <summary>
@@ -93,11 +93,11 @@ namespace Realms.Logging
         /// </returns>
         public static Logger Function(Action<LogLevel, LogCategory, string> logFunction) => new FunctionLogger(logFunction);
 
-        // TODO(lj): Deprecate
         /// <summary>
         /// Gets or sets the verbosity of log messages for all log categories via <see cref="LogCategory.Realm"/>.
         /// </summary>
         /// <value>The log level for Realm-originating messages.</value>
+        [Obsolete("Use GetLogLevel() and SetLogLevel().")]
         public static LogLevel LogLevel
         {
             get => GetLogLevel();

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -174,6 +174,8 @@ namespace Realms.Logging
 
         internal static void LogDefault(LogLevel level, LogCategory category, string message) => Default?.Log(level, category, message);
 
+        internal static void CoreLogDefault(LogLevel level, LogCategory category, string message) => Default?.CoreLog(level, category, message);
+
         /// <summary>
         /// Log a message at the supplied level and default category <see cref="LogCategory.RealmLogCategory.SDK"/>.
         /// </summary>
@@ -197,6 +199,22 @@ namespace Realms.Logging
                 return;
             }
 
+            try
+            {
+                LogImpl(level, category, message);
+            }
+            catch (Exception ex)
+            {
+                Console.Log(LogLevel.Error, $"An exception occurred while trying to log the message: '{message}' at level: '{level}' in category: '{category}'. Error: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Log a message from Core that does not require checking the current
+        /// level as that check has already been performed by Core.
+        /// </summary>
+        private void CoreLog(LogLevel level, LogCategory category, string message)
+        {
             try
             {
                 LogImpl(level, category, message);

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -30,7 +30,7 @@ namespace Realms.Logging
     public abstract class Logger : RealmLogger
     {
         /// <summary>
-        /// The internal implementation being called from <see cref="Log"/>.
+        /// The internal implementation being called from <see cref="RealmLogger.Log(LogLevel, string)"/>.
         /// </summary>
         /// <param name="level">The criticality level for the message.</param>
         /// <param name="message">The message to log.</param>
@@ -208,7 +208,7 @@ namespace Realms.Logging
         }
 
         /// <summary>
-        /// The internal implementation being called from <see cref="Log"/>.
+        /// The internal implementation being called from <see cref="Log(Realms.Logging.LogLevel, LogCategory, string)"/>.
         /// </summary>
         /// <param name="level">The criticality level for the message.</param>
         /// <param name="category">The category for the message.</param>

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -35,11 +35,11 @@ namespace Realms.Logging
     {
         private readonly Lazy<GCHandle> _gcHandle;
 
+        // TODO(lj): Use this default log level?
+        private static readonly LogLevel _defaultLogLevel = LogLevel.Info;
         private static readonly LogCategory _defaultLogCategory = LogCategory.Realm;
-        private static Logger? _defaultLogger;
-        // TODO(lj): Remove since it's not one level anymore. (Get it from Core)
-        private static LogLevel _logLevel = LogLevel.Info;
         private static LogCategory _logCategory = _defaultLogCategory;
+        private static Logger? _defaultLogger;
 
         /// <summary>
         /// Gets a <see cref="ConsoleLogger"/> that outputs messages to the default console. For most project types, that will be
@@ -102,7 +102,8 @@ namespace Realms.Logging
         /// <value>The log level for Realm-originating messages.</value>
         public static LogLevel LogLevel
         {
-            get => _logLevel;
+            // TODO(lj): Do we want to deprecate the getter as well?
+            get => GetLogLevel();
             // TODO(lj): Deprecate and refer to `SetLogLevel`.
             set
             {
@@ -115,12 +116,19 @@ namespace Realms.Logging
             get => _logCategory;
         }
 
+        public static LogLevel GetLogLevel(LogCategory? category = null)
+        {
+            // TODO(lj): Perhaps we should grab the current category (`_logCategory`)
+            //           instead of the default here? If there hasn't been a category
+            //           explicitly set, it will still be the default.
+            category ??= _defaultLogCategory;
+            return SharedRealmHandle.GetLogLevel(category);
+        }
+
         public static void SetLogLevel(LogLevel level, LogCategory? category = null)
         {
             category ??= _defaultLogCategory;
             SharedRealmHandle.SetLogLevel(level, category);
-            // TODO(lj): Remove setting `_logLevel` as we should get the level at the current category.
-            _logLevel = level;
             _logCategory = category;
         }
 

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -93,15 +93,14 @@ namespace Realms.Logging
         /// </returns>
         public static Logger Function(Action<LogLevel, LogCategory, string> logFunction) => new FunctionLogger(logFunction);
 
+        // TODO(lj): Deprecate
         /// <summary>
         /// Gets or sets the verbosity of log messages.
         /// </summary>
         /// <value>The log level for Realm-originating messages.</value>
         public static LogLevel LogLevel
         {
-            // TODO(lj): Do we want to deprecate the getter as well?
             get => GetLogLevel();
-            // TODO(lj): Deprecate and refer to `SetLogLevel`.
             set
             {
                 SetLogLevel(value);
@@ -120,8 +119,6 @@ namespace Realms.Logging
             SharedRealmHandle.SetLogLevel(level, category);
         }
 
-        // TODO(lj): Would it make sense to also deprecate the Default setter
-        //           and provide e.g. `SetDefaultLogger()`?
         /// <summary>
         /// Gets or sets a custom <see cref="Logger"/> implementation that will be used by
         /// Realm whenever information must be logged.
@@ -147,6 +144,7 @@ namespace Realms.Logging
 
         internal static void LogDefault(LogLevel level, LogCategory category, string message) => Default?.Log(level, category, message);
 
+        // TODO(lj): Deprecate
         /// <summary>
         /// Log a message at the supplied level.
         /// </summary>
@@ -158,9 +156,10 @@ namespace Realms.Logging
             Log(level, _defaultLogCategory, message);
         }
 
+        // TODO(lj): Use category as optional 3rd param.
         public void Log(LogLevel level, LogCategory category, string message)
         {
-            if (level < LogLevel)
+            if (level < GetLogLevel(category))
             {
                 return;
             }

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -95,7 +95,7 @@ namespace Realms.Logging
 
         // TODO(lj): Deprecate
         /// <summary>
-        /// Gets or sets the verbosity of log messages.
+        /// Gets or sets the verbosity of log messages for all log categories via <see cref="LogCategory.Realm"/>.
         /// </summary>
         /// <value>The log level for Realm-originating messages.</value>
         public static LogLevel LogLevel
@@ -107,12 +107,24 @@ namespace Realms.Logging
             }
         }
 
+        /// <summary>
+        /// Gets the verbosity of log messages for the given category.
+        /// </summary>
+        /// <param name="category">The category to get the level for. Defaults to <see cref="LogCategory.Realm"/> if not specified.</param>
+        /// <returns>
+        /// The log level used.
+        /// </returns>
         public static LogLevel GetLogLevel(LogCategory? category = null)
         {
             category ??= _defaultLogCategory;
             return SharedRealmHandle.GetLogLevel(category);
         }
 
+        /// <summary>
+        /// Sets the verbosity of log messages for the given category.
+        /// </summary>
+        /// <param name="level">The log level to use for messages.</param>
+        /// <param name="category">The category to set the level for. Defaults to <see cref="LogCategory.Realm"/> if not specified.</param>
         public static void SetLogLevel(LogLevel level, LogCategory? category = null)
         {
             category ??= _defaultLogCategory;
@@ -156,6 +168,12 @@ namespace Realms.Logging
         }
 
         // TODO(lj): Use category as optional 3rd param.
+        /// <summary>
+        /// Log a message at the supplied level and category.
+        /// </summary>
+        /// <param name="level">The criticality level for the message.</param>
+        /// <param name="category">The category for the message.</param>
+        /// <param name="message">The message to log.</param>
         public void Log(LogLevel level, LogCategory category, string message)
         {
             if (level < GetLogLevel(category))
@@ -173,11 +191,13 @@ namespace Realms.Logging
             }
         }
 
+        // TODO(lj): Set category as optional 3rd arg as we'll do for `Log`,
+        //           so that we don't break the API.
         /// <summary>
         /// The internal implementation being called from <see cref="Log"/>.
         /// </summary>
         /// <param name="level">The criticality level for the message.</param>
-        /// <param name="category">TODO(lj).</param>
+        /// <param name="category">The category for the message.</param>
         /// <param name="message">The message to log.</param>
         protected abstract void LogImpl(LogLevel level, LogCategory category, string message);
 

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -170,12 +170,6 @@ namespace Realms.Logging
             _gcHandle = new Lazy<GCHandle>(() => GCHandle.Alloc(this));
         }
 
-        internal static void LogDefault(LogLevel level, string message) => Default?.Log(level, message);
-
-        internal static void LogDefault(LogLevel level, LogCategory category, string message) => Default?.Log(level, category, message);
-
-        internal static void CoreLogDefault(LogLevel level, LogCategory category, string message) => Default?.LogAnyLevel(level, category, message);
-
         /// <summary>
         /// Log a message at the supplied level and default category <see cref="LogCategory.RealmLogCategory.SDK"/>.
         /// </summary>
@@ -206,7 +200,7 @@ namespace Realms.Logging
         /// Log a message without calling into Core to check the current level. Logs from
         /// Core should always call this API as they already check the level prior to notifying.
         /// </summary>
-        private void LogAnyLevel(LogLevel level, LogCategory category, string message)
+        internal void LogAnyLevel(LogLevel level, LogCategory category, string message)
         {
             try
             {

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -112,7 +112,7 @@ namespace Realms.Logging
         /// </summary>
         /// <param name="category">The category to get the level for. Defaults to <see cref="LogCategory.Realm"/> if not specified.</param>
         /// <returns>
-        /// The log level used.
+        /// The log level used for the given category.
         /// </returns>
         public static LogLevel GetLogLevel(LogCategory? category = null)
         {

--- a/Realm/Realm/Logging/Logger.cs
+++ b/Realm/Realm/Logging/Logger.cs
@@ -152,8 +152,7 @@ namespace Realms.Logging
         /// <param name="message">The message to log.</param>
         public void Log(LogLevel level, string message)
         {
-            // TODO(lj): See if `LogCategory.Realm.SDK` should be preferred.
-            Log(level, _defaultLogCategory, message);
+            Log(level, LogCategory.Realm.SDK, message);
         }
 
         // TODO(lj): Use category as optional 3rd param.

--- a/Realm/Realm/Native/NativeCommon.cs
+++ b/Realm/Realm/Native/NativeCommon.cs
@@ -96,7 +96,7 @@ namespace Realms
             {
                 if (Interlocked.CompareExchange(ref _isInitialized, 0, 1) == 1)
                 {
-                    Logger.LogDefault(LogLevel.Info, $"Realm: Force closing all native instances: {reason}");
+                    RealmLogger.LogDefault(LogLevel.Info, $"Realm: Force closing all native instances: {reason}");
 
                     var sw = new Stopwatch();
                     sw.Start();
@@ -106,12 +106,12 @@ namespace Realms
                     SharedRealmHandle.ForceCloseNativeRealms();
 
                     sw.Stop();
-                    Logger.LogDefault(LogLevel.Info, $"Realm: Closed all native instances in {sw.ElapsedMilliseconds} ms.");
+                    RealmLogger.LogDefault(LogLevel.Info, $"Realm: Closed all native instances in {sw.ElapsedMilliseconds} ms.");
                 }
             }
             catch (Exception ex)
             {
-                Logger.LogDefault(LogLevel.Error, $"Realm: Failed to close all native instances. You may need to restart your app. Error: {ex}");
+                RealmLogger.LogDefault(LogLevel.Error, $"Realm: Failed to close all native instances. You may need to restart your app. Error: {ex}");
             }
         }
 

--- a/Realm/Realm/Native/NativeCommon.cs
+++ b/Realm/Realm/Native/NativeCommon.cs
@@ -96,7 +96,7 @@ namespace Realms
             {
                 if (Interlocked.CompareExchange(ref _isInitialized, 0, 1) == 1)
                 {
-                    RealmLogger.LogDefault(LogLevel.Info, $"Realm: Force closing all native instances: {reason}");
+                    RealmLogger.Default.Log(LogLevel.Info, $"Realm: Force closing all native instances: {reason}");
 
                     var sw = new Stopwatch();
                     sw.Start();
@@ -106,12 +106,12 @@ namespace Realms
                     SharedRealmHandle.ForceCloseNativeRealms();
 
                     sw.Stop();
-                    RealmLogger.LogDefault(LogLevel.Info, $"Realm: Closed all native instances in {sw.ElapsedMilliseconds} ms.");
+                    RealmLogger.Default.Log(LogLevel.Info, $"Realm: Closed all native instances in {sw.ElapsedMilliseconds} ms.");
                 }
             }
             catch (Exception ex)
             {
-                RealmLogger.LogDefault(LogLevel.Error, $"Realm: Failed to close all native instances. You may need to restart your app. Error: {ex}");
+                RealmLogger.Default.Log(LogLevel.Error, $"Realm: Failed to close all native instances. You may need to restart your app. Error: {ex}");
             }
         }
 

--- a/Realm/Realm/Native/SyncSocketProvider.EventLoop.cs
+++ b/Realm/Realm/Native/SyncSocketProvider.EventLoop.cs
@@ -32,7 +32,7 @@ internal partial class SyncSocketProvider
 
         internal Timer(TimeSpan delay, IntPtr nativeCallback, ChannelWriter<IWork> workQueue)
         {
-            Logger.LogDefault(LogLevel.Trace, $"Creating timer with delay {delay} and target {nativeCallback}.");
+            RealmLogger.LogDefault(LogLevel.Trace, $"Creating timer with delay {delay} and target {nativeCallback}.");
             var cancellationToken = _cts.Token;
             Task.Delay(delay, cancellationToken).ContinueWith(async _ =>
             {
@@ -42,7 +42,7 @@ internal partial class SyncSocketProvider
 
         internal void Cancel()
         {
-            Logger.LogDefault(LogLevel.Trace, $"Canceling timer.");
+            RealmLogger.LogDefault(LogLevel.Trace, $"Canceling timer.");
             _cts.Cancel();
             _cts.Dispose();
         }
@@ -72,7 +72,7 @@ internal partial class SyncSocketProvider
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                Logger.LogDefault(LogLevel.Trace, "Deleting EventLoopWork callback only because event loop was cancelled.");
+                RealmLogger.LogDefault(LogLevel.Trace, "Deleting EventLoopWork callback only because event loop was cancelled.");
                 NativeMethods.delete_callback(nativeCallback);
                 return;
             }
@@ -83,7 +83,7 @@ internal partial class SyncSocketProvider
 
     private static void RunCallback(IntPtr nativeCallback, Status status)
     {
-        Logger.LogDefault(LogLevel.Trace, $"SyncSocketProvider running native callback {nativeCallback} with status {status.Code} \"{status.Reason}\".");
+        RealmLogger.LogDefault(LogLevel.Trace, $"SyncSocketProvider running native callback {nativeCallback} with status {status.Code} \"{status.Reason}\".");
 
         using var arena = new Arena();
         NativeMethods.run_callback(nativeCallback, status.Code, StringValue.AllocateFrom(status.Reason, arena));
@@ -91,13 +91,13 @@ internal partial class SyncSocketProvider
 
     private async Task PostWorkAsync(IntPtr nativeCallback)
     {
-        Logger.LogDefault(LogLevel.Trace, "Posting work to SyncSocketProvider event loop.");
+        RealmLogger.LogDefault(LogLevel.Trace, "Posting work to SyncSocketProvider event loop.");
         await _workQueue.Writer.WriteAsync(new EventLoopWork(nativeCallback, _cts.Token));
     }
 
     private async partial Task WorkThread()
     {
-        Logger.LogDefault(LogLevel.Trace, "Starting SyncSocketProvider event loop.");
+        RealmLogger.LogDefault(LogLevel.Trace, "Starting SyncSocketProvider event loop.");
         try
         {
             while (await _workQueue.Reader.WaitToReadAsync())
@@ -110,15 +110,15 @@ internal partial class SyncSocketProvider
         }
         catch (Exception e)
         {
-            Logger.LogDefault(LogLevel.Error, $"Error occurred in SyncSocketProvider event loop {e.GetType().FullName}: {e.Message}");
+            RealmLogger.LogDefault(LogLevel.Error, $"Error occurred in SyncSocketProvider event loop {e.GetType().FullName}: {e.Message}");
             if (!string.IsNullOrEmpty(e.StackTrace))
             {
-                Logger.LogDefault(LogLevel.Trace, e.StackTrace);
+                RealmLogger.LogDefault(LogLevel.Trace, e.StackTrace);
             }
 
             throw;
         }
 
-        Logger.LogDefault(LogLevel.Trace, "Exiting SyncSocketProvider event loop.");
+        RealmLogger.LogDefault(LogLevel.Trace, "Exiting SyncSocketProvider event loop.");
     }
 }

--- a/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
+++ b/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
@@ -45,7 +45,7 @@ internal partial class SyncSocketProvider
 
         internal Socket(ClientWebSocket webSocket, IntPtr observer, ChannelWriter<IWork> workQueue, Uri uri)
         {
-            RealmLogger.LogDefault(LogLevel.Trace, $"Creating a WebSocket to {uri.GetLeftPart(UriPartial.Path)}");
+            RealmLogger.Default.Log(LogLevel.Trace, $"Creating a WebSocket to {uri.GetLeftPart(UriPartial.Path)}");
             _webSocket = webSocket;
             _observer = observer;
             _workQueue = workQueue;
@@ -56,7 +56,7 @@ internal partial class SyncSocketProvider
 
         private async Task ReadThread()
         {
-            RealmLogger.LogDefault(LogLevel.Trace, "Entering WebSocket event loop.");
+            RealmLogger.Default.Log(LogLevel.Trace, "Entering WebSocket event loop.");
 
             try
             {
@@ -67,7 +67,7 @@ internal partial class SyncSocketProvider
             {
                 var builder = new StringBuilder();
                 FormatExceptionForLogging(e, builder);
-                RealmLogger.LogDefault(LogLevel.Error, $"Error establishing WebSocket connection {builder}");
+                RealmLogger.Default.Log(LogLevel.Error, $"Error establishing WebSocket connection {builder}");
 
                 await _workQueue.WriteAsync(new WebSocketClosedWork(false, (WebSocketCloseStatus)RLM_ERR_WEBSOCKET_CONNECTION_FAILED, e.Message, _observer, _cancellationToken));
                 return;
@@ -92,11 +92,11 @@ internal partial class SyncSocketProvider
 
                             break;
                         case WebSocketMessageType.Close:
-                            RealmLogger.LogDefault(LogLevel.Trace, $"WebSocket closed with status {result.CloseStatus!.Value} and description \"{result.CloseStatusDescription}\"");
+                            RealmLogger.Default.Log(LogLevel.Trace, $"WebSocket closed with status {result.CloseStatus!.Value} and description \"{result.CloseStatusDescription}\"");
                             await _workQueue.WriteAsync(new WebSocketClosedWork(clean: true, result.CloseStatus!.Value, result.CloseStatusDescription!, _observer, _cancellationToken));
                             break;
                         default:
-                            RealmLogger.LogDefault(LogLevel.Trace, $"Received unexpected text WebSocket message: {Encoding.UTF8.GetString(buffer, 0, result.Count)}");
+                            RealmLogger.Default.Log(LogLevel.Trace, $"Received unexpected text WebSocket message: {Encoding.UTF8.GetString(buffer, 0, result.Count)}");
                             break;
                     }
                 }
@@ -104,7 +104,7 @@ internal partial class SyncSocketProvider
                 {
                     var builder = new StringBuilder();
                     FormatExceptionForLogging(e, builder);
-                    RealmLogger.LogDefault(LogLevel.Error, $"Error reading from WebSocket {builder}");
+                    RealmLogger.Default.Log(LogLevel.Error, $"Error reading from WebSocket {builder}");
 
                     await _workQueue.WriteAsync(new WebSocketClosedWork(false, (WebSocketCloseStatus)RLM_ERR_WEBSOCKET_READ_ERROR, e.Message, _observer, _cancellationToken));
                     return;
@@ -130,7 +130,7 @@ internal partial class SyncSocketProvider
             {
                 var builder = new StringBuilder();
                 FormatExceptionForLogging(e, builder);
-                RealmLogger.LogDefault(LogLevel.Error, $"Error writing to WebSocket {builder}");
+                RealmLogger.Default.Log(LogLevel.Error, $"Error writing to WebSocket {builder}");
 
                 // in case of errors notify the websocket observer and just dispose the callback
                 await _workQueue.WriteAsync(new WebSocketClosedWork(false, (WebSocketCloseStatus)RLM_ERR_WEBSOCKET_WRITE_ERROR, e.Message, _observer, _cancellationToken));
@@ -164,7 +164,7 @@ internal partial class SyncSocketProvider
             _webSocket.Dispose();
             _receiveBuffer.Dispose();
             _cts.Dispose();
-            RealmLogger.LogDefault(LogLevel.Trace, "Disposing WebSocket.");
+            RealmLogger.Default.Log(LogLevel.Trace, "Disposing WebSocket.");
 
             try
             {

--- a/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
+++ b/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
@@ -28,7 +28,6 @@ using Realms.Logging;
 
 namespace Realms.Native;
 
-// TODO(lj): For the logs happening in this class, should we log for `LogCategory.Realm.Sync.Client`?
 internal partial class SyncSocketProvider
 {
     private class Socket : IDisposable
@@ -186,8 +185,7 @@ internal partial class SyncSocketProvider
 
             builder.AppendFormat("{0}: {1}", ex.GetType().FullName, ex.Message);
             builder.AppendLine();
-            // TODO(lj): May update to log for a specific category.
-            if (RealmLogger.GetLogLevel() >= LogLevel.Trace && !string.IsNullOrEmpty(ex.StackTrace))
+            if (RealmLogger.GetLogLevel(LogCategory.Realm.SDK) >= LogLevel.Trace && !string.IsNullOrEmpty(ex.StackTrace))
             {
                 builder.Append(indentation);
                 var indentedTrace = ex.StackTrace.Replace(Environment.NewLine, Environment.NewLine + indentation);

--- a/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
+++ b/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
@@ -28,6 +28,7 @@ using Realms.Logging;
 
 namespace Realms.Native;
 
+// TODO(lj): For the logs happening in this class, should we log for `LogCategory.Realm.Sync.Client`?
 internal partial class SyncSocketProvider
 {
     private class Socket : IDisposable
@@ -185,7 +186,8 @@ internal partial class SyncSocketProvider
 
             builder.AppendFormat("{0}: {1}", ex.GetType().FullName, ex.Message);
             builder.AppendLine();
-            if (Logger.LogLevel >= LogLevel.Trace && !string.IsNullOrEmpty(ex.StackTrace))
+            // TODO(lj): May update to log for a specific category.
+            if (Logger.GetLogLevel() >= LogLevel.Trace && !string.IsNullOrEmpty(ex.StackTrace))
             {
                 builder.Append(indentation);
                 var indentedTrace = ex.StackTrace.Replace(Environment.NewLine, Environment.NewLine + indentation);

--- a/Realm/Realm/Native/SyncSocketProvider.cs
+++ b/Realm/Realm/Native/SyncSocketProvider.cs
@@ -156,7 +156,7 @@ internal partial class SyncSocketProvider : IDisposable
 
     internal SyncSocketProvider(Action<ClientWebSocketOptions>? onWebSocketConnection)
     {
-        Logger.LogDefault(LogLevel.Debug, "Creating SyncSocketProvider.");
+        RealmLogger.LogDefault(LogLevel.Debug, "Creating SyncSocketProvider.");
         _onWebSocketConnection = onWebSocketConnection;
         _workQueue = Channel.CreateUnbounded<IWork>(new() { SingleReader = true });
         _workThread = Task.Run(WorkThread);
@@ -166,7 +166,7 @@ internal partial class SyncSocketProvider : IDisposable
 
     public void Dispose()
     {
-        Logger.LogDefault(LogLevel.Debug, "Destroying SyncSocketProvider.");
+        RealmLogger.LogDefault(LogLevel.Debug, "Destroying SyncSocketProvider.");
         _workQueue.Writer.Complete();
         _cts.Cancel();
         _cts.Dispose();

--- a/Realm/Realm/Native/SyncSocketProvider.cs
+++ b/Realm/Realm/Native/SyncSocketProvider.cs
@@ -156,7 +156,7 @@ internal partial class SyncSocketProvider : IDisposable
 
     internal SyncSocketProvider(Action<ClientWebSocketOptions>? onWebSocketConnection)
     {
-        RealmLogger.LogDefault(LogLevel.Debug, "Creating SyncSocketProvider.");
+        RealmLogger.Default.Log(LogLevel.Debug, "Creating SyncSocketProvider.");
         _onWebSocketConnection = onWebSocketConnection;
         _workQueue = Channel.CreateUnbounded<IWork>(new() { SingleReader = true });
         _workThread = Task.Run(WorkThread);
@@ -166,7 +166,7 @@ internal partial class SyncSocketProvider : IDisposable
 
     public void Dispose()
     {
-        RealmLogger.LogDefault(LogLevel.Debug, "Destroying SyncSocketProvider.");
+        RealmLogger.Default.Log(LogLevel.Debug, "Destroying SyncSocketProvider.");
         _workQueue.Writer.Complete();
         _cts.Cancel();
         _cts.Dispose();

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -414,7 +414,7 @@ namespace Realms
         {
             if (Error is null)
             {
-                RealmLogger.LogDefault(LogLevel.Error, "A realm-level exception has occurred. To handle and react to those, subscribe to the Realm.Error event.");
+                RealmLogger.Default.Log(LogLevel.Error, "A realm-level exception has occurred. To handle and react to those, subscribe to the Realm.Error event.");
             }
 
             Error?.Invoke(this, new ErrorEventArgs(ex));

--- a/Realm/Realm/Realm.cs
+++ b/Realm/Realm/Realm.cs
@@ -414,7 +414,7 @@ namespace Realms
         {
             if (Error is null)
             {
-                Logger.LogDefault(LogLevel.Error, "A realm-level exception has occurred. To handle and react to those, subscribe to the Realm.Error event.");
+                RealmLogger.LogDefault(LogLevel.Error, "A realm-level exception has occurred. To handle and react to those, subscribe to the Realm.Error event.");
             }
 
             Error?.Invoke(this, new ErrorEventArgs(ex));

--- a/Realm/Realm/Sync/ProgressNotifications/ProgressNotificationToken.cs
+++ b/Realm/Realm/Sync/ProgressNotifications/ProgressNotificationToken.cs
@@ -58,7 +58,7 @@ namespace Realms.Sync
                 }
                 catch (Exception ex)
                 {
-                    Logger.Default.Log(LogLevel.Warn, $"An error occurred while reporting progress: {ex}");
+                    RealmLogger.Default.Log(LogLevel.Warn, $"An error occurred while reporting progress: {ex}");
                 }
             });
         }

--- a/Tests/Realm.Tests/Database/GuidRepresentationMigrationTests.cs
+++ b/Tests/Realm.Tests/Database/GuidRepresentationMigrationTests.cs
@@ -55,8 +55,8 @@ namespace Realms.Tests.Database
         [Test]
         public void Migration_FromLittleEndianGuidFile([Values(true, false)] bool useLegacyRepresentation)
         {
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
 
 #pragma warning disable CS0618 // Type or member is obsolete
             Realm.UseLegacyGuidRepresentation = useLegacyRepresentation;
@@ -94,8 +94,8 @@ namespace Realms.Tests.Database
         [Test]
         public void PopulatingANewFile([Values(true, false)] bool useLegacyRepresentation)
         {
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
 
 #pragma warning disable CS0618 // Type or member is obsolete
             Realm.UseLegacyGuidRepresentation = useLegacyRepresentation;
@@ -171,8 +171,8 @@ namespace Realms.Tests.Database
         [Test]
         public void UnmigratedRealm_WhenOpenedAsReadonly_LogsAMessageAndDoesntChangeFile()
         {
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
             TestHelpers.CopyBundledFileToDocuments("guids.realm", _configuration.DatabasePath);
 
             _configuration.IsReadOnly = true;
@@ -213,8 +213,8 @@ namespace Realms.Tests.Database
                 // Open the Realm to migrate it
             }
 
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
 
             _configuration.IsReadOnly = true;
 
@@ -243,8 +243,8 @@ namespace Realms.Tests.Database
         {
             // This tests that a file that doesn't appear to have little-endian guids is not migrated
             // See comment in guid_representation_migration.cpp/flip_guid
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
 
             TestHelpers.CopyBundledFileToDocuments("bad-guids.realm", _configuration.DatabasePath);
 
@@ -273,8 +273,8 @@ namespace Realms.Tests.Database
             // This tests that a file that contains both ambiguous (xxxxxxxx-xxxx-4x4x-xxxx-xxxxxxxx) and unambiguous guids
             // does get migrated.
             // See comment in guid_representation_migration.cpp/flip_guid
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
 
             TestHelpers.CopyBundledFileToDocuments("mixed-guids.realm", _configuration.DatabasePath);
 
@@ -301,8 +301,8 @@ namespace Realms.Tests.Database
         [Test]
         public void SynchronizedRealm_DoesntMigrate([Values(true, false)] bool useLegacyRepresentation)
         {
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
 
 #pragma warning disable CS0618 // Type or member is obsolete
             Realm.UseLegacyGuidRepresentation = useLegacyRepresentation;

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -1281,14 +1281,14 @@ namespace Realms.Tests.Database
             // We're at info level, so we don't expect any statements.
             WriteAndVerifyLogs();
 
-            Logger.LogLevel = LogLevel.Debug;
+            Logger.SetLogLevel(LogLevel.Debug);
 
             // We're at Debug level now, so we should see the write message.
             var expectedWriteLog = new Regex("Debug: DB: .* Commit of size [^ ]* done in [^ ]* us");
             WriteAndVerifyLogs(expectedWriteLog);
 
             // Revert back to Info level and make sure we don't log anything
-            Logger.LogLevel = LogLevel.Info;
+            Logger.SetLogLevel(LogLevel.Info);
             WriteAndVerifyLogs();
 
             void WriteAndVerifyLogs(Regex? expectedRegex = null)

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -1271,8 +1271,8 @@ namespace Realms.Tests.Database
         [Test]
         public void Logger_ChangeLevel_ReflectedImmediately()
         {
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
 
             using var realm = GetRealm(Guid.NewGuid().ToString());
 
@@ -1281,14 +1281,14 @@ namespace Realms.Tests.Database
             // We're at info level, so we don't expect any statements.
             WriteAndVerifyLogs();
 
-            Logger.SetLogLevel(LogLevel.Debug);
+            RealmLogger.SetLogLevel(LogLevel.Debug);
 
             // We're at Debug level now, so we should see the write message.
             var expectedWriteLog = new Regex("Debug: DB: .* Commit of size [^ ]* done in [^ ]* us");
             WriteAndVerifyLogs(expectedWriteLog);
 
             // Revert back to Info level and make sure we don't log anything
-            Logger.SetLogLevel(LogLevel.Info);
+            RealmLogger.SetLogLevel(LogLevel.Info);
             WriteAndVerifyLogs();
 
             void WriteAndVerifyLogs(Regex? expectedRegex = null)

--- a/Tests/Realm.Tests/Database/LoggerTests.cs
+++ b/Tests/Realm.Tests/Database/LoggerTests.cs
@@ -109,6 +109,7 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        [Obsolete("Using LogLevel setter.")]
         public void Logger_WhenUsingLogLevelSetter_OverwritesCategory()
         {
             var category = LogCategory.Realm.Storage;

--- a/Tests/Realm.Tests/Database/LoggerTests.cs
+++ b/Tests/Realm.Tests/Database/LoggerTests.cs
@@ -86,6 +86,39 @@ namespace Realms.Tests.Database
             }
         }
 
+        [Test]
+        public void Logger_SetsLogLevelAtSubcategories()
+        {
+            var storageCategories = new[]
+            {
+                LogCategory.Realm.Storage.Transaction,
+                LogCategory.Realm.Storage.Query,
+                LogCategory.Realm.Storage.Object,
+                LogCategory.Realm.Storage.Notification
+            };
+            foreach (var category in storageCategories)
+            {
+                Assert.That(Logger.GetLogLevel(category), Is.Not.EqualTo(LogLevel.Error));
+            }
+
+            Logger.SetLogLevel(LogLevel.Error, LogCategory.Realm.Storage);
+            foreach (var category in storageCategories)
+            {
+                Assert.That(Logger.GetLogLevel(category), Is.EqualTo(LogLevel.Error));
+            }
+        }
+
+        [Test]
+        public void Logger_WhenUsingLogLevelSetter_OverwritesCategory()
+        {
+            var category = LogCategory.Realm.Storage;
+            Logger.SetLogLevel(LogLevel.Error, category);
+            Assert.That(Logger.GetLogLevel(category), Is.EqualTo(LogLevel.Error));
+
+            Logger.LogLevel = LogLevel.All;
+            Assert.That(Logger.GetLogLevel(category), Is.EqualTo(LogLevel.All));
+        }
+
         [TestCase(LogLevel.Error)]
         [TestCase(LogLevel.Info)]
         [TestCase(LogLevel.Debug)]
@@ -148,6 +181,16 @@ namespace Realms.Tests.Database
                 Assert.That(sdkCategoriesMap.TryGetValue(name!, out var category), Is.True);
                 Assert.That(category!.Name, Is.EqualTo(name));
                 Assert.That(LogCategory.FromName(name!), Is.SameAs(category));
+            }
+        }
+
+        [Test]
+        public void Logger_WhenNonExistentCategoryName_FromNameThrows()
+        {
+            var nonExistentNames = new[] { "realm", "Realm.app", string.Empty };
+            foreach (var name in nonExistentNames)
+            {
+                Assert.That(() => LogCategory.FromName(name), Throws.TypeOf<ArgumentException>().And.Message.Contains($"Unexpected category name: '{name}'"));
             }
         }
 

--- a/Tests/Realm.Tests/Database/LoggerTests.cs
+++ b/Tests/Realm.Tests/Database/LoggerTests.cs
@@ -83,7 +83,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             RealmLogger.Default = RealmLogger.Function(message => messages.Add(message));
 
-            RealmLogger.LogDefault(LogLevel.Warn, LogCategory.Realm.SDK, "This is very dangerous!");
+            RealmLogger.Default.Log(LogLevel.Warn, LogCategory.Realm.SDK, "This is very dangerous!");
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "This is very dangerous!");
@@ -95,7 +95,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             RealmLogger.Default = new UserDefinedLogger((level, category, message) => messages.Add(RealmLogger.FormatLog(level, category, message)));
 
-            RealmLogger.LogDefault(LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
+            RealmLogger.Default.Log(LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
@@ -108,7 +108,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             Logger.Default = new ObsoleteUserDefinedLogger((level, message) => messages.Add(Logger.FormatLog(level, LogCategory.Realm.SDK, message)));
 
-            Logger.LogDefault(LogLevel.Warn, "A log message");
+            Logger.Default.Log(LogLevel.Warn, "A log message");
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
@@ -120,7 +120,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             RealmLogger.Default = RealmLogger.Function(message => messages.Add(message));
 
-            RealmLogger.LogDefault(LogLevel.Debug, "This is a debug message!");
+            RealmLogger.Default.Log(LogLevel.Debug, "This is a debug message!");
 
             Assert.That(messages.Count, Is.EqualTo(0));
         }
@@ -182,9 +182,9 @@ namespace Realms.Tests.Database
                 RealmLogger.Default = RealmLogger.Function(message => messages.Add(message));
                 RealmLogger.SetLogLevel(level, category);
 
-                RealmLogger.LogDefault(level - 1, category, "This is at level - 1");
-                RealmLogger.LogDefault(level, category, "This is at the same level");
-                RealmLogger.LogDefault(level + 1, category, "This is at level + 1");
+                RealmLogger.Default.Log(level - 1, category, "This is at level - 1");
+                RealmLogger.Default.Log(level, category, "This is at the same level");
+                RealmLogger.Default.Log(level + 1, category, "This is at level + 1");
 
                 Assert.That(messages.Count, Is.EqualTo(2));
                 AssertLogMessageContains(messages[0], level, category, "This is at the same level");
@@ -201,7 +201,7 @@ namespace Realms.Tests.Database
                 var messages = new List<string>();
                 RealmLogger.Default = RealmLogger.Function((message) => messages.Add(message));
 
-                RealmLogger.LogDefault(LogLevel.Warn, category, "A log message");
+                RealmLogger.Default.Log(LogLevel.Warn, category, "A log message");
 
                 Assert.That(messages.Count, Is.EqualTo(1));
                 AssertLogMessageContains(messages[0], LogLevel.Warn, category, "A log message");
@@ -214,7 +214,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             RealmLogger.Default = RealmLogger.Function((message) => messages.Add(message));
 
-            RealmLogger.LogDefault(LogLevel.Warn, "A log message");
+            RealmLogger.Default.Log(LogLevel.Warn, "A log message");
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
@@ -226,7 +226,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             RealmLogger.Default = RealmLogger.Function((level, category, message) => messages.Add(RealmLogger.FormatLog(level, category, message)));
 
-            RealmLogger.LogDefault(LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
+            RealmLogger.Default.Log(LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
@@ -239,7 +239,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             RealmLogger.Default = RealmLogger.Function((level, message) => messages.Add(RealmLogger.FormatLog(level, LogCategory.Realm.SDK, message)));
 
-            RealmLogger.LogDefault(LogLevel.Warn, "A log message");
+            RealmLogger.Default.Log(LogLevel.Warn, "A log message");
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
@@ -283,9 +283,9 @@ namespace Realms.Tests.Database
             var errorMessage = "This is an error!";
             var timeString = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd");
 
-            RealmLogger.LogDefault(LogLevel.Warn, warnMessage);
-            RealmLogger.LogDefault(LogLevel.Debug, debugMessage);
-            RealmLogger.LogDefault(LogLevel.Error, errorMessage);
+            RealmLogger.Default.Log(LogLevel.Warn, warnMessage);
+            RealmLogger.Default.Log(LogLevel.Debug, debugMessage);
+            RealmLogger.Default.Log(LogLevel.Error, errorMessage);
 
             var loggedStrings = File.ReadAllLines(tempFilePath);
 

--- a/Tests/Realm.Tests/Database/LoggerTests.cs
+++ b/Tests/Realm.Tests/Database/LoggerTests.cs
@@ -136,7 +136,20 @@ namespace Realms.Tests.Database
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
         }
 
-        // TODO(lj): Test that all Core categories are being used and matches names.
+        [Test]
+        public void Logger_MatchesCoreCategoryNames()
+        {
+            var coreCategoryNames = SharedRealmHandle.GetLogCategoryNames();
+            var sdkCategoriesMap = LogCategory.NameToCategory;
+
+            Assert.That(sdkCategoriesMap.Count, Is.EqualTo(coreCategoryNames.Length));
+            foreach (var name in coreCategoryNames)
+            {
+                Assert.That(sdkCategoriesMap.TryGetValue(name!, out var category), Is.True);
+                Assert.That(category!.Name, Is.EqualTo(name));
+                Assert.That(LogCategory.FromName(name!), Is.SameAs(category));
+            }
+        }
 
         [Test]
         public void FileLogger()

--- a/Tests/Realm.Tests/Database/LoggerTests.cs
+++ b/Tests/Realm.Tests/Database/LoggerTests.cs
@@ -109,7 +109,7 @@ namespace Realms.Tests.Database
         }
 
         [Test]
-        [Obsolete("Using LogLevel setter.")]
+        [Obsolete("Using LogLevel set accessor.")]
         public void Logger_WhenUsingLogLevelSetter_OverwritesCategory()
         {
             var category = LogCategory.Realm.Storage;
@@ -183,6 +183,19 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        [Obsolete("Using function not accepting category.")]
+        public void Logger_CallsObsoleteCustomFunction()
+        {
+            var messages = new List<string>();
+            Logger.Default = Logger.Function((level, message) => messages.Add(Logger.FormatLog(level, message, LogCategory.Realm.SDK)));
+
+            Logger.LogDefault(LogLevel.Warn, "A log message");
+
+            Assert.That(messages.Count, Is.EqualTo(1));
+            AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
+        }
+
+        [Test]
         public void Logger_MatchesCoreCategoryNames()
         {
             var coreCategoryNames = SharedRealmHandle.GetLogCategoryNames();
@@ -212,7 +225,7 @@ namespace Realms.Tests.Database
         {
             var tempFilePath = Path.GetTempFileName();
 
-            Logger.LogLevel = LogLevel.All;
+            Logger.SetLogLevel(LogLevel.All);
             Logger.Default = Logger.File(tempFilePath);
 
             var warnMessage = "This is very dangerous!";

--- a/Tests/Realm.Tests/Database/LoggerTests.cs
+++ b/Tests/Realm.Tests/Database/LoggerTests.cs
@@ -58,7 +58,7 @@ namespace Realms.Tests.Database
             var messages = new List<string>();
             Logger.Default = Logger.Function(message => messages.Add(message));
 
-            Logger.LogDefault(LogLevel.Warn, LogCategory.Realm.SDK, "This is very dangerous!");
+            Logger.LogDefault(LogLevel.Warn, "This is very dangerous!", LogCategory.Realm.SDK);
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "This is very dangerous!");
@@ -131,9 +131,9 @@ namespace Realms.Tests.Database
                 Logger.Default = Logger.Function(message => messages.Add(message));
                 Logger.SetLogLevel(level, category);
 
-                Logger.LogDefault(level - 1, category, "This is at level - 1");
-                Logger.LogDefault(level, category, "This is at the same level");
-                Logger.LogDefault(level + 1, category, "This is at level + 1");
+                Logger.LogDefault(level - 1, "This is at level - 1", category);
+                Logger.LogDefault(level, "This is at the same level", category);
+                Logger.LogDefault(level + 1, "This is at level + 1", category);
 
                 Assert.That(messages.Count, Is.EqualTo(2));
                 AssertLogMessageContains(messages[0], level, category, "This is at the same level");
@@ -150,7 +150,7 @@ namespace Realms.Tests.Database
                 var messages = new List<string>();
                 Logger.Default = Logger.Function((message) => messages.Add(message));
 
-                Logger.LogDefault(LogLevel.Warn, category, "A log message");
+                Logger.LogDefault(LogLevel.Warn, "A log message", category);
 
                 Assert.That(messages.Count, Is.EqualTo(1));
                 AssertLogMessageContains(messages[0], LogLevel.Warn, category, "A log message");
@@ -158,12 +158,24 @@ namespace Realms.Tests.Database
         }
 
         [Test]
+        public void Logger_LogsSdkCategoryByDefault()
+        {
+            var messages = new List<string>();
+            Logger.Default = Logger.Function((message) => messages.Add(message));
+
+            Logger.LogDefault(LogLevel.Warn, "A log message");
+
+            Assert.That(messages.Count, Is.EqualTo(1));
+            AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
+        }
+
+        [Test]
         public void Logger_CallsCustomFunction()
         {
             var messages = new List<string>();
-            Logger.Default = Logger.Function((level, category, message) => messages.Add(Logger.FormatLog(level, category, message)));
+            Logger.Default = Logger.Function((level, category, message) => messages.Add(Logger.FormatLog(level, message, category)));
 
-            Logger.LogDefault(LogLevel.Warn, LogCategory.Realm.SDK, "A log message");
+            Logger.LogDefault(LogLevel.Warn, "A log message", LogCategory.Realm.SDK);
 
             Assert.That(messages.Count, Is.EqualTo(1));
             AssertLogMessageContains(messages[0], LogLevel.Warn, LogCategory.Realm.SDK, "A log message");

--- a/Tests/Realm.Tests/Database/NotificationTests.cs
+++ b/Tests/Realm.Tests/Database/NotificationTests.cs
@@ -53,8 +53,8 @@ namespace Realms.Tests.Database
         [Test]
         public void RealmError_WhenNoSubscribers_OutputsMessageInConsole()
         {
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
             _realm.NotifyError(new Exception());
 
             Assert.That(logger.GetLog(), Does.Contain("exception").And.Contains("Realm.Error"));

--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -33,8 +33,8 @@ namespace Realms.Tests
     {
         private readonly ConcurrentQueue<StrongBox<Realm>> _realms = new();
         private readonly LogCategory _originalLogCategory = LogCategory.Realm;
-        private readonly LogLevel _originalLogLevel = Logger.GetLogLevel(LogCategory.Realm);
-        private Logger _originalLogger = null!;
+        private readonly LogLevel _originalLogLevel = RealmLogger.GetLogLevel(LogCategory.Realm);
+        private RealmLogger _originalLogger = null!;
 
         private bool _isSetup;
 
@@ -58,7 +58,7 @@ namespace Realms.Tests
         {
             if (!_isSetup)
             {
-                _originalLogger = Logger.Default;
+                _originalLogger = RealmLogger.Default;
 
                 if (OverrideDefaultConfig)
                 {
@@ -86,8 +86,8 @@ namespace Realms.Tests
             {
                 CustomTearDown();
 
-                Logger.Default = _originalLogger;
-                Logger.SetLogLevel(_originalLogLevel, _originalLogCategory);
+                RealmLogger.Default = _originalLogger;
+                RealmLogger.SetLogLevel(_originalLogLevel, _originalLogCategory);
 
 #pragma warning disable CS0618 // Type or member is obsolete
                 Realm.UseLegacyGuidRepresentation = false;

--- a/Tests/Realm.Tests/RealmTest.cs
+++ b/Tests/Realm.Tests/RealmTest.cs
@@ -32,8 +32,9 @@ namespace Realms.Tests
     public abstract class RealmTest
     {
         private readonly ConcurrentQueue<StrongBox<Realm>> _realms = new();
+        private readonly LogCategory _originalLogCategory = LogCategory.Realm;
+        private readonly LogLevel _originalLogLevel = Logger.GetLogLevel(LogCategory.Realm);
         private Logger _originalLogger = null!;
-        private LogLevel _originalLogLevel;
 
         private bool _isSetup;
 
@@ -58,7 +59,6 @@ namespace Realms.Tests
             if (!_isSetup)
             {
                 _originalLogger = Logger.Default;
-                _originalLogLevel = Logger.LogLevel;
 
                 if (OverrideDefaultConfig)
                 {
@@ -87,7 +87,7 @@ namespace Realms.Tests
                 CustomTearDown();
 
                 Logger.Default = _originalLogger;
-                Logger.LogLevel = _originalLogLevel;
+                Logger.SetLogLevel(_originalLogLevel, _originalLogCategory);
 
 #pragma warning disable CS0618 // Type or member is obsolete
                 Realm.UseLegacyGuidRepresentation = false;

--- a/Tests/Realm.Tests/Sync/AppTests.cs
+++ b/Tests/Realm.Tests/Sync/AppTests.cs
@@ -167,7 +167,7 @@ namespace Realms.Tests.Sync
         {
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
-                Logger.LogLevel = logLevel;
+                Logger.SetLogLevel(logLevel);
                 var logger = new Logger.InMemoryLogger();
                 Logger.Default = logger;
 

--- a/Tests/Realm.Tests/Sync/AppTests.cs
+++ b/Tests/Realm.Tests/Sync/AppTests.cs
@@ -167,9 +167,9 @@ namespace Realms.Tests.Sync
         {
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
-                Logger.SetLogLevel(logLevel);
-                var logger = new Logger.InMemoryLogger();
-                Logger.Default = logger;
+                RealmLogger.SetLogLevel(logLevel);
+                var logger = new RealmLogger.InMemoryLogger();
+                RealmLogger.Default = logger;
 
                 var config = await GetIntegrationConfigAsync(Guid.NewGuid().ToString());
                 using var realm = await GetRealmAsync(config);

--- a/Tests/Realm.Tests/Sync/SyncTestHelpers.cs
+++ b/Tests/Realm.Tests/Sync/SyncTestHelpers.cs
@@ -142,10 +142,10 @@ namespace Realms.Tests.Sync
                 var logLevel = (LogLevel)Enum.Parse(typeof(LogLevel), extracted.RealmLogLevel!);
                 TestHelpers.Output.WriteLine($"Setting log level to {logLevel}");
 
-                Logger.SetLogLevel(logLevel);
+                RealmLogger.SetLogLevel(logLevel);
             }
 
-            Logger.AsyncFileLogger? logger = null;
+            RealmLogger.AsyncFileLogger? logger = null;
             if (!string.IsNullOrEmpty(extracted.RealmLogFile))
             {
                 if (!Process.GetCurrentProcess().ProcessName.ToLower().Contains("testhost"))
@@ -153,14 +153,14 @@ namespace Realms.Tests.Sync
                     TestHelpers.Output.WriteLine($"Setting sync logger to file: {extracted.RealmLogFile}");
 
                     // We're running in a test runner, so we need to use the sync logger
-                    Logger.Default = Logger.File(extracted.RealmLogFile!);
+                    RealmLogger.Default = RealmLogger.File(extracted.RealmLogFile!);
                 }
                 else
                 {
                     TestHelpers.Output.WriteLine($"Setting async logger to file: {extracted.RealmLogFile}");
 
                     // We're running standalone (likely on CI), so we use the async logger
-                    Logger.Default = logger = new Logger.AsyncFileLogger(extracted.RealmLogFile!);
+                    RealmLogger.Default = logger = new RealmLogger.AsyncFileLogger(extracted.RealmLogFile!);
                 }
             }
 

--- a/Tests/Realm.Tests/Sync/SyncTestHelpers.cs
+++ b/Tests/Realm.Tests/Sync/SyncTestHelpers.cs
@@ -142,7 +142,7 @@ namespace Realms.Tests.Sync
                 var logLevel = (LogLevel)Enum.Parse(typeof(LogLevel), extracted.RealmLogLevel!);
                 TestHelpers.Output.WriteLine($"Setting log level to {logLevel}");
 
-                Logger.LogLevel = logLevel;
+                Logger.SetLogLevel(logLevel);
             }
 
             Logger.AsyncFileLogger? logger = null;

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -214,8 +214,8 @@ namespace Realms.Tests.Sync
 
                 await PopulateData(config);
 
-                var logger = new Logger.InMemoryLogger();
-                Logger.Default = logger;
+                var logger = new RealmLogger.InMemoryLogger();
+                RealmLogger.Default = logger;
 
                 config = await GetIntegrationConfigAsync((string?)config.Partition);
                 config.OnProgress = _ => throw new Exception("Exception in OnProgress");
@@ -726,9 +726,9 @@ namespace Realms.Tests.Sync
         [Test]
         public void SyncTimeouts_ArePassedCorrectlyToCore()
         {
-            var logger = new Logger.InMemoryLogger();
-            Logger.Default = logger;
-            Logger.SetLogLevel(LogLevel.Debug);
+            var logger = new RealmLogger.InMemoryLogger();
+            RealmLogger.Default = logger;
+            RealmLogger.SetLogLevel(LogLevel.Debug);
 
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
@@ -803,7 +803,7 @@ namespace Realms.Tests.Sync
             }
 
             var regex = new Regex("Connection\\[\\d+] Session\\[\\d+]");
-            var logger = Logger.Function((level, msg) =>
+            var logger = RealmLogger.Function((level, msg) =>
             {
                 if (regex.IsMatch(msg))
                 {
@@ -811,8 +811,8 @@ namespace Realms.Tests.Sync
                 }
             });
 
-            Logger.SetLogLevel(LogLevel.Info);
-            Logger.Default = logger;
+            RealmLogger.SetLogLevel(LogLevel.Info);
+            RealmLogger.Default = logger;
 
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
@@ -824,7 +824,7 @@ namespace Realms.Tests.Sync
                 Assert.That(initialInfoLogs, Is.GreaterThan(0));
                 Assert.That(logs[LogLevel.Debug].Count, Is.EqualTo(0));
 
-                Logger.SetLogLevel(LogLevel.Debug);
+                RealmLogger.SetLogLevel(LogLevel.Debug);
 
                 realm.Write(() =>
                 {

--- a/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
+++ b/Tests/Realm.Tests/Sync/SynchronizedInstanceTests.cs
@@ -728,7 +728,7 @@ namespace Realms.Tests.Sync
         {
             var logger = new Logger.InMemoryLogger();
             Logger.Default = logger;
-            Logger.LogLevel = LogLevel.Debug;
+            Logger.SetLogLevel(LogLevel.Debug);
 
             SyncTestHelpers.RunBaasTestAsync(async () =>
             {
@@ -811,7 +811,7 @@ namespace Realms.Tests.Sync
                 }
             });
 
-            Logger.LogLevel = LogLevel.Info;
+            Logger.SetLogLevel(LogLevel.Info);
             Logger.Default = logger;
 
             SyncTestHelpers.RunBaasTestAsync(async () =>
@@ -824,7 +824,7 @@ namespace Realms.Tests.Sync
                 Assert.That(initialInfoLogs, Is.GreaterThan(0));
                 Assert.That(logs[LogLevel.Debug].Count, Is.EqualTo(0));
 
-                Logger.LogLevel = LogLevel.Debug;
+                Logger.SetLogLevel(LogLevel.Debug);
 
                 realm.Write(() =>
                 {

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -28,15 +28,6 @@
 
 namespace realm::binding {
 
-/// Needed for MSVC when returning a `MarshaledVector` from CPP
-/// directly, as compared to when nested within another struct.
-/// Returned via `MarshaledVector::for_top_level_marshalling()`.
-struct AnyTopLevelMarshallable
-{
-    const void* items;
-    size_t count;
-};
-
 template <typename T>
 struct MarshaledVector
 {
@@ -96,9 +87,15 @@ struct MarshaledVector
     iterator begin() const noexcept { return {items}; }
     iterator end() const noexcept { return {items + count}; }
 
+    struct AnyMarshallable
+    {
+        const void* items;
+        size_t count;
+    };
+
     /// Needed for MSVC when returning a `MarshaledVector` from CPP
     /// directly, as compared to when nested within another struct.
-    AnyTopLevelMarshallable for_top_level_marshalling() const {
+    AnyMarshallable for_top_level_marshalling() const {
         return {items, count};
     }
 };

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -86,6 +86,18 @@ struct MarshaledVector
 
     iterator begin() const noexcept { return {items}; }
     iterator end() const noexcept { return {items + count}; }
+
+    struct TopLevelMarshallable
+    {
+        const T* items;
+        size_t count;
+    };
+
+    /// Needed for MSVC when returning a `MarshaledVector` from CPP
+    /// directly, as compared to when nested within another struct.
+    TopLevelMarshallable for_top_level_marshalling() const {
+        return {items, count};
+    }
 };
 
 enum class realm_value_type : uint8_t {

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -31,10 +31,15 @@ namespace realm::binding {
 /// A struct used when marshaling of `MarshaledVector` cannot be
 /// compiled, e.g. for MSVC when returning a `MarshaledVector` from
 /// CPP directly, as compared to when nested within another struct.
-struct AnyMarshaledVector
+struct TypeErasedMarshaledVector
 {
     const void* items;
     size_t count;
+
+    template <typename T>
+    static TypeErasedMarshaledVector for_marshalling(const std::vector<T>& vector) {
+        return {vector.data(), vector.size()};
+    }
 };
 
 template <typename T>
@@ -95,12 +100,6 @@ struct MarshaledVector
 
     iterator begin() const noexcept { return {items}; }
     iterator end() const noexcept { return {items + count}; }
-
-    /// Needed for MSVC when returning a `MarshaledVector` from CPP
-    /// directly, as compared to when nested within another struct.
-    AnyMarshaledVector for_any_type_marshalling() const {
-        return {items, count};
-    }
 };
 
 enum class realm_value_type : uint8_t {

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -28,6 +28,15 @@
 
 namespace realm::binding {
 
+/// Needed for MSVC when returning a `MarshaledVector` from CPP
+/// directly, as compared to when nested within another struct.
+/// Returned via `MarshaledVector::for_top_level_marshalling()`.
+struct AnyTopLevelMarshallable
+{
+    const void* items;
+    size_t count;
+};
+
 template <typename T>
 struct MarshaledVector
 {
@@ -87,15 +96,9 @@ struct MarshaledVector
     iterator begin() const noexcept { return {items}; }
     iterator end() const noexcept { return {items + count}; }
 
-    struct TopLevelMarshallable
-    {
-        const T* items;
-        size_t count;
-    };
-
     /// Needed for MSVC when returning a `MarshaledVector` from CPP
     /// directly, as compared to when nested within another struct.
-    TopLevelMarshallable for_top_level_marshalling() const {
+    AnyTopLevelMarshallable for_top_level_marshalling() const {
         return {items, count};
     }
 };

--- a/wrappers/src/marshalling.hpp
+++ b/wrappers/src/marshalling.hpp
@@ -28,6 +28,15 @@
 
 namespace realm::binding {
 
+/// A struct used when marshaling of `MarshaledVector` cannot be
+/// compiled, e.g. for MSVC when returning a `MarshaledVector` from
+/// CPP directly, as compared to when nested within another struct.
+struct AnyMarshaledVector
+{
+    const void* items;
+    size_t count;
+};
+
 template <typename T>
 struct MarshaledVector
 {
@@ -87,15 +96,9 @@ struct MarshaledVector
     iterator begin() const noexcept { return {items}; }
     iterator end() const noexcept { return {items + count}; }
 
-    struct AnyMarshallable
-    {
-        const void* items;
-        size_t count;
-    };
-
     /// Needed for MSVC when returning a `MarshaledVector` from CPP
     /// directly, as compared to when nested within another struct.
-    AnyMarshallable for_top_level_marshalling() const {
+    AnyMarshaledVector for_any_type_marshalling() const {
         return {items, count};
     }
 };

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -48,8 +48,7 @@ using namespace realm::util;
 using OpenRealmCallbackT = void(void* task_completion_source, ThreadSafeReference* ref, NativeException::Marshallable ex);
 using RealmChangedT = void(void* managed_state_handle);
 using ReleaseGCHandleT = void(void* managed_handle);
-// TODO(lj): Update arg order to be the same across the SDK.
-using LogMessageT = void(realm_string_t message, util::Logger::Level level, realm_string_t category_name);
+using LogMessageT = void(util::Logger::Level level, realm_string_t category_name, realm_string_t message);
 using MigrationCallbackT = void*(realm::SharedRealm* old_realm, realm::SharedRealm* new_realm, Schema* migration_schema, MarshaledVector<SchemaObject>, uint64_t schema_version, void* managed_migration_handle);
 using HandleTaskCompletionCallbackT = void(void* tcs_ptr, bool invoke_async, NativeException::Marshallable ex);
 using SharedSyncSession = std::shared_ptr<SyncSession>;
@@ -100,7 +99,7 @@ namespace binding {
     protected:
         void do_log(const LogCategory& category, Level level, const std::string& message) override final
         {
-            s_log_message(to_capi(message), level, to_capi(category.get_name()));
+            s_log_message(level, to_capi(category.get_name()), to_capi(message));
         }
     };
 }

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -296,6 +296,16 @@ REALM_EXPORT void shared_realm_install_callbacks(
     LogCategory::realm.set_default_level_threshold(Logger::Level::info);
 }
 
+REALM_EXPORT Logger::Level shared_realm_get_log_level(uint16_t* category_name_buf, size_t category_name_len) {
+    Utf16StringAccessor category_name(category_name_buf, category_name_len);
+    // TODO(lj): Usage in Core:
+    auto& category = LogCategory::get_category(category_name);
+    return Logger::get_default_logger()->get_level_threshold(category);
+
+    // TODO(lj): But this seems to work as well:
+    // return LogCategory::get_category(category_name).get_default_level_threshold();
+}
+
 REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* category_name_buf, size_t category_name_len) {
     Utf16StringAccessor category_name(category_name_buf, category_name_len);
     LogCategory::get_category(category_name).set_default_level_threshold(level);

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -311,6 +311,20 @@ REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* cate
     LogCategory::get_category(category_name).set_default_level_threshold(level);
 }
 
+REALM_EXPORT MarshaledVector<realm_string_t> shared_realm_get_log_category_names() {
+    const auto names = LogCategory::get_category_names();
+    // Use heap allocation in order to keep the vector alive beyond this call.
+    // This will cause a memory leak 😢; however, this is only used for the tests.
+    const auto result = new std::vector<realm_string_t>();
+    result->reserve(names.size());
+
+    for (const auto name : names) {
+        result->push_back(to_capi(name));
+    }
+
+    return *result;
+}
+
 REALM_EXPORT SharedRealm* shared_realm_open(Configuration configuration, NativeException::Marshallable& ex)
 {
     return handle_errors(ex, [&]() {

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -320,7 +320,7 @@ REALM_EXPORT MarshaledVector<realm_string_t> shared_realm_get_log_category_names
         }
     }
 
-    return result;
+    return {result};
 }
 
 REALM_EXPORT SharedRealm* shared_realm_open(Configuration configuration, NativeException::Marshallable& ex)

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -306,7 +306,7 @@ REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* cate
     LogCategory::get_category(category_name).set_default_level_threshold(level);
 }
 
-REALM_EXPORT MarshaledVector<realm_string_t>::TopLevelMarshallable shared_realm_get_log_category_names() {
+REALM_EXPORT AnyTopLevelMarshallable shared_realm_get_log_category_names() {
     const auto names = LogCategory::get_category_names();
     // Declare the vector as static in order to make it a globally allocated
     // and keep the vector alive beyond this call.

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -306,7 +306,7 @@ REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* cate
     LogCategory::get_category(category_name).set_default_level_threshold(level);
 }
 
-REALM_EXPORT AnyMarshaledVector shared_realm_get_log_category_names() {
+REALM_EXPORT TypeErasedMarshaledVector shared_realm_get_log_category_names() {
     const auto names = LogCategory::get_category_names();
     // Declare the vector as static in order to make it a globally allocated
     // and keep the vector alive beyond this call.
@@ -320,7 +320,7 @@ REALM_EXPORT AnyMarshaledVector shared_realm_get_log_category_names() {
         }
     }
 
-    return MarshaledVector(result).for_any_type_marshalling();
+    return TypeErasedMarshaledVector::for_marshalling(result);
 }
 
 REALM_EXPORT SharedRealm* shared_realm_open(Configuration configuration, NativeException::Marshallable& ex)

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -306,7 +306,7 @@ REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* cate
     LogCategory::get_category(category_name).set_default_level_threshold(level);
 }
 
-REALM_EXPORT AnyTopLevelMarshallable shared_realm_get_log_category_names() {
+REALM_EXPORT MarshaledVector<realm_string_t>::AnyMarshallable shared_realm_get_log_category_names() {
     const auto names = LogCategory::get_category_names();
     // Declare the vector as static in order to make it a globally allocated
     // and keep the vector alive beyond this call.

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -306,7 +306,7 @@ REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* cate
     LogCategory::get_category(category_name).set_default_level_threshold(level);
 }
 
-REALM_EXPORT MarshaledVector<realm_string_t> shared_realm_get_log_category_names() {
+REALM_EXPORT MarshaledVector<realm_string_t>::TopLevelMarshallable shared_realm_get_log_category_names() {
     const auto names = LogCategory::get_category_names();
     // Declare the vector as static in order to make it a globally allocated
     // and keep the vector alive beyond this call.
@@ -320,7 +320,7 @@ REALM_EXPORT MarshaledVector<realm_string_t> shared_realm_get_log_category_names
         }
     }
 
-    return {result};
+    return MarshaledVector(result).for_top_level_marshalling();
 }
 
 REALM_EXPORT SharedRealm* shared_realm_open(Configuration configuration, NativeException::Marshallable& ex)

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -306,7 +306,7 @@ REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* cate
     LogCategory::get_category(category_name).set_default_level_threshold(level);
 }
 
-REALM_EXPORT MarshaledVector<realm_string_t>::AnyMarshallable shared_realm_get_log_category_names() {
+REALM_EXPORT AnyMarshaledVector shared_realm_get_log_category_names() {
     const auto names = LogCategory::get_category_names();
     // Declare the vector as static in order to make it a globally allocated
     // and keep the vector alive beyond this call.
@@ -320,7 +320,7 @@ REALM_EXPORT MarshaledVector<realm_string_t>::AnyMarshallable shared_realm_get_l
         }
     }
 
-    return MarshaledVector(result).for_top_level_marshalling();
+    return MarshaledVector(result).for_any_type_marshalling();
 }
 
 REALM_EXPORT SharedRealm* shared_realm_open(Configuration configuration, NativeException::Marshallable& ex)

--- a/wrappers/src/shared_realm_cs.cpp
+++ b/wrappers/src/shared_realm_cs.cpp
@@ -298,12 +298,7 @@ REALM_EXPORT void shared_realm_install_callbacks(
 
 REALM_EXPORT Logger::Level shared_realm_get_log_level(uint16_t* category_name_buf, size_t category_name_len) {
     Utf16StringAccessor category_name(category_name_buf, category_name_len);
-    // TODO(lj): Usage in Core:
-    auto& category = LogCategory::get_category(category_name);
-    return Logger::get_default_logger()->get_level_threshold(category);
-
-    // TODO(lj): But this seems to work as well:
-    // return LogCategory::get_category(category_name).get_default_level_threshold();
+    return LogCategory::get_category(category_name).get_default_level_threshold();
 }
 
 REALM_EXPORT void shared_realm_set_log_level(Logger::Level level, uint16_t* category_name_buf, size_t category_name_len) {


### PR DESCRIPTION
## Description

Deprecates `Logger` in favor of its new base class `RealmLogger` (see notes below on avoiding breaking changes).

Primarily, enables more control over which category of messages should be logged and at which criticality level, by setting and getting a `LogLevel` for a given `LogCategory`. The hierarchy of categories starts at `LogCategory.Realm`.

```csharp
RealmLogger.SetLogLevel(LogLevel.Warn, LogCategory.Realm.Sync);
RealmLogger.GetLogLevel(LogCategory.Realm.Sync.Client.Session); // LogLevel.Warn
```

Adds a function logger that accepts a callback that will receive the `LogLevel`, `LogCategory`, and the message when invoked.

```csharp
RealmLogger.Default = RealmLogger.Function((level, category, message) => /* custom implementation */);
```

Adds a `RealmLogger.Log()` overload taking a category.
```csharp
RealmLogger.Default.Log(LogLevel.Warn, LogCategory.Realm, "A warning message");
```

## Notes on avoiding breaking changes

### Would-be breaking changes

Users have been able to provide their own `Logger` subclass via the `Logger.Default` `set` accessor. Custom loggers need to override and implement `Logger.LogImpl()`, and with the addition of log categories in this PR, the `LogImpl()` signature would require breaking changes.

### Solution

Essentially, the previous `Logger` class has been renamed `RealmLogger`, and another class called `Logger` now derives from `RealmLogger`, with the only own member being the `LogImpl()` with an abstract method identical to before to avoid the breaking change.

```csharp
public abstract class Logger : RealmLogger
{
    protected abstract void LogImpl(LogLevel level, string message);

    protected override void LogImpl(LogLevel level, LogCategory category, string message)
    {
        LogImpl(level, message);
    }
}
```

Fixes #3633

@realm/devdocs 

##  TODO

* [x] Changelog entry
* [x] Tests
* [x] API docs
