### PR TITLE
RNET-1175 Fix potential outgoing message corruption in managed websockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * None
 
 ### Fixed
-* None
+* Fixed a possible disruption of sync traffic under heavy load when using managed web sockets where malformed binary messages cause the server to drop the connection and force the client to reconnect and upload again. (Issue [#3671](https://github.com/realm/realm-dotnet/issues/3671)).
 
 ### Compatibility
 * Realm Studio: 15.0.0 or later.

--- a/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
+++ b/Realm/Realm/Native/SyncSocketProvider.WebSocket.cs
@@ -124,7 +124,7 @@ internal partial class SyncSocketProvider
 
             try
             {
-                await _webSocket.SendAsync(new(buffer), WebSocketMessageType.Binary, true, _cancellationToken);
+                await _webSocket.SendAsync(new(buffer, 0, (int)data.size), WebSocketMessageType.Binary, true, _cancellationToken);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Description
When managed websockets are enabled we use array pooling to cut down on constant managed heap allocations for the byte arrays that store the sync messages Core wants us to send. However there is a chance that if a rented array is bigger than the buffer we need to store we will attempt to send the entire array, including stale data it contained previously. This is avoided by using the `ArraySegment<T>` constructor that accepts the explicit offset and length parameters.

Fixes #3671 

##  TODO

* [x] Changelog entry
* [ ] Tests
