### PR TITLE
Unity 6 xcframework fix

### DIFF
--- a/Realm/Realm.UnityWeaver/UnityWeaver.cs
+++ b/Realm/Realm.UnityWeaver/UnityWeaver.cs
@@ -342,6 +342,7 @@ namespace RealmWeaver
 
         public void OnPostprocessBuild(BuildReport? report)
         {
+            if (UnityMajorVersion >= 6000) return;
             switch (report?.summary.platform)
             {
                 case BuildTarget.iOS:
@@ -351,7 +352,7 @@ namespace RealmWeaver
             }
         }
 
-        public void OnPreprocessBuild(BuildReport? report)
+        public void OnPreprocessBuild(BuildReport report)
         {
             bool enableForDevice;
             bool enableForSimulator;

--- a/Realm/Realm.UnityWeaver/UnityWeaver.cs
+++ b/Realm/Realm.UnityWeaver/UnityWeaver.cs
@@ -352,7 +352,7 @@ namespace RealmWeaver
             }
         }
 
-        public void OnPreprocessBuild(BuildReport report)
+        public void OnPreprocessBuild(BuildReport? report)
         {
             bool enableForDevice;
             bool enableForSimulator;


### PR DESCRIPTION
## Description
I believe this change would disable the hacky workaround for the lack of xcframework support in Unity, but don't understand why it was working for me in Unity 2021.3 because Unity claims that .xcframeworks are supported in Unity 2021.3, 2022.3 and Unity 6: https://discussions.unity.com/t/does-unity-support-xcframeworks/240687/5

xcframework generation and the workaround was introduced in Realm.NET 10.3: https://github.com/realm/realm-dotnet/pull/2475/files
but it was also mentioned since that xcframework is no longer generated and we are just dealing with a .framework in 10.19 and 20.1:
https://github.com/realm/realm-dotnet/pull/2906#discussion_r865077969

So it seems that the workaround itself shouldn't be causing the issue, it's possible that this is just a Unity 6 compatibility issue.

I have no way to test this change without a packaged up tarball file of Realm for Unity because the suggested method had dependency issues I wasn't able to fix (Cecil.pdb, Cecil.Rocky etc)

I'd like to test this change in either Realm 10.19 or 20.1 in Unity 6 - could you provide a tarball with this change? Or provide instructions on how I can generate this myself?

Fixes #3693 

##  TODO

* [ ] Changelog entry
* [ ] Tests
