### PR TITLE
fix/iOS: Load realm-wrapper DLL using MainBundle.PrivateFrameworksPath

### DIFF
--- a/Realm/Realm.PlatformHelpers/Apple/InteropInfo.ios.mac.cs
+++ b/Realm/Realm.PlatformHelpers/Apple/InteropInfo.ios.mac.cs
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Realms.PlatformHelpers
+{
+    internal class InteropInfo
+    {
+        /// <summary>
+        /// Runtime library search path embedded in the binary (Unix/Linux/macOS/iOS).
+        /// Specifies where the dynamic linker should look for shared libraries at runtime.
+        /// </summary>
+        public static string RPath
+        {
+            get
+            {
+                var runtimeVersion = System.Environment.Version;
+
+                if (runtimeVersion.Major >= 10)
+                {
+                    // .NET 10 or greater
+                    return Foundation.NSBundle.MainBundle.PrivateFrameworksPath;
+                }
+                
+                return "@rpath";
+            }
+        }
+    }
+}

--- a/Realm/Realm.PlatformHelpers/fallback/InteropInfo.netstandard.cs
+++ b/Realm/Realm.PlatformHelpers/fallback/InteropInfo.netstandard.cs
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace Realms.PlatformHelpers
+{
+    internal class InteropInfo
+    {
+        /// <summary>
+        /// Runtime library search path embedded in the binary (Unix/Linux/macOS/iOS).
+        /// Specifies where the dynamic linker should look for shared libraries at runtime.
+        /// </summary>
+        public static string RPath => string.Empty;
+    }
+}

--- a/Realm/Realm/Native/NativeCommon.cs
+++ b/Realm/Realm/Native/NativeCommon.cs
@@ -52,7 +52,7 @@ namespace Realms
                     {
                         if (libraryName == InteropConfig.DLL_NAME)
                         {
-                            libraryName = "@rpath/realm-wrappers.framework/realm-wrappers";
+                            libraryName = $"{PlatformHelpers.InteropInfo.RPath}/realm-wrappers.framework/realm-wrappers";
                         }
 
                         return NativeLibrary.Load(libraryName, assembly, searchPath);


### PR DESCRIPTION
## Description

Fixes #3711.
Allows Realm to work in net10-ios apps.

This change is minimal.
It is based on [this comment](https://github.com/realm/realm-dotnet/issues/3711#issuecomment-3541020237).
Ideally I think it would have been better to delegate the wrappers initialization to the platform level (Windows & iOS).
But as the platform level code is not part of the main assembly, changing the resolver of another assembly [is not recommended](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.nativelibrary.setdllimportresolver?view=net-9.0#remarks).

As I am developing on a Mac, I encountered a lot of hiccups when trying to build the various projects. 
Based on my testings it should work fine on net8-ios and net10-ios, but if it is possible to generate nuget packages from my PR, I would like to test them in a standalone app to make sure everything works well once packaged up.

##  TODO

* [ ] Changelog entry
* [ ] Tests
