### PR TITLE
fix/iOS: Load realm-wrapper DLL using MainBundle.PrivateFrameworksPath

### DIFF
--- a/Realm/Realm/Native/NativeCommon.cs
+++ b/Realm/Realm/Native/NativeCommon.cs
@@ -23,7 +23,9 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Realms.Helpers;
 using Realms.Logging;
-#if !NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
+using System.Reflection;
+#else
 using System.IO;
 #endif
 
@@ -50,7 +52,26 @@ namespace Realms
                     {
                         if (libraryName == InteropConfig.DLL_NAME)
                         {
-                            libraryName = "@rpath/realm-wrappers.framework/realm-wrappers";
+                            var rpath = "@rpath";
+
+                            var runtimeVersion = Environment.Version;
+                            if (runtimeVersion.Major >= 10)
+                            {
+                                // .NET 10 breaking change: Realm can't use @rpath for runtime library location.
+                                // Solution: Use NSBundle.MainBundle.PrivateFrameworksPath
+                                // Currently it is evaluated through reflection, but could be replaced when platform code evaluation/injection improves in future versions.
+                                var nsBundleType = Assembly.Load("Microsoft.iOS").GetType("Foundation.NSBundle");
+                                var mainBundleProperty = nsBundleType?.GetProperty("MainBundle", BindingFlags.Public | BindingFlags.Static);
+                                var mainBundle = mainBundleProperty?.GetValue(null);
+                                var privateFrameworksPathProperty = nsBundleType?.GetProperty("PrivateFrameworksPath", BindingFlags.Public | BindingFlags.Instance);
+
+                                if (privateFrameworksPathProperty?.GetValue(mainBundle) is string privateFrameworksPath)
+                                {
+                                    rpath = privateFrameworksPath;
+                                }
+                            }
+
+                            libraryName = $"{rpath}/realm-wrappers.framework/realm-wrappers";
                         }
 
                         return NativeLibrary.Load(libraryName, assembly, searchPath);


### PR DESCRIPTION
Using Reflection to evaluate `MainBundle.PrivateFrameworksPath` on iOS

## Description

Fixes #3711
Allows Realm to work in net10-ios apps.

This change is minimal.
It is based on https://github.com/realm/realm-dotnet/pull/3714#issuecomment-3655212725

Replaces #3714

##  TODO

* [ ] Changelog entry
* [ ] Tests
