### PR TITLE
fix/iOS: Load realm-wrapper DLL using DllImportSearchPath.ApplicationDirectory

### DIFF
--- a/Realm/Realm/Native/NativeCommon.cs
+++ b/Realm/Realm/Native/NativeCommon.cs
@@ -51,6 +51,14 @@ namespace Realms
                         if (libraryName == InteropConfig.DLL_NAME)
                         {
                             libraryName = "@rpath/realm-wrappers.framework/realm-wrappers";
+
+                            var runtimeVersion = Environment.Version;
+                            if (runtimeVersion.Major >= 10)
+                            {
+                                // .NET 10 breaking change: Application directory is no longer used when searching for DLLs
+                                // We need to explicitly add it to the search path
+                                searchPath |= DllImportSearchPath.ApplicationDirectory;
+                            }
                         }
 
                         return NativeLibrary.Load(libraryName, assembly, searchPath);


### PR DESCRIPTION
Explicitely changing the `searchPath` to include an application directory search.
Description

Fixes https://github.com/realm/realm-dotnet/issues/3711
Allows Realm to work in net10-ios apps.

This change is minimal.
Based on these comments:
* https://github.com/realm/realm-dotnet/issues/3711#issuecomment-3691192652
* https://github.com/realm/realm-dotnet/pull/3718#issuecomment-3662383635


Replaces https://github.com/realm/realm-dotnet/pull/3718