### PR TITLE
Load realm-wrappers from application directory in Initialize method

### DIFF
--- a/Realm/Realm/Native/NativeCommon.cs
+++ b/Realm/Realm/Native/NativeCommon.cs
@@ -51,6 +51,7 @@ namespace Realms
                         if (libraryName == InteropConfig.DLL_NAME)
                         {
                             libraryName = "@rpath/realm-wrappers.framework/realm-wrappers";
+                            return NativeLibrary.Load(libraryName, assembly, DllImportSearchPath.ApplicationDirectory);
                         }
 
                         return NativeLibrary.Load(libraryName, assembly, searchPath);


### PR DESCRIPTION
## Description

.NET 10 [removed the application directory](https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/10.0/native-library-search) from the default native library search paths. It needs to explicitly specify ApplicationDirectory to find realm-wrappers.

Similar to https://github.com/realm/realm-dotnet/pull/3721

Fixes https://github.com/realm/realm-dotnet/issues/3711
