### PR TITLE
Remove UWP support and update project for .NET 10 and MAUI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,8 @@
 
 - Remove or isolate UWP-specific code paths instead of extending them.
 - Keep `netstandard2.0` only where packaging or tooling still requires it; do not add new feature work around deprecated targets.
+- Active TFM baseline is `.NET 10` (`net10.0` / `net10.0-*`). `net8.0` is retained temporarily where tooling constraints require it; new work targets `net10.0`.
+- The repository SDK is pinned to `.NET 10` via `global.json` in the repository root.
 - When updating MAUI examples, keep `QuickJournal` on the same strategic MAUI and Realm baseline as the rest of the repository.
 - When editing CI, preserve the MAUI jobs in `.github/workflows/pr.yml` and `.github/workflows/main.yml` and keep the required wrapper outputs in `.github/workflows/wrappers.yml` for Android, iOS, MacCatalyst, and Windows.
 
@@ -24,3 +26,7 @@
 
 - Prefer validation through `Tests/Tests.Maui` for platform behavior and `Tests/Realm.Tests` for shared regressions.
 - Keep workflow changes symmetric between `pr.yml` and `main.yml` unless there is a platform-specific reason not to.
+
+## Skills
+
+- Use the `realm-maui` skill for MAUI maintenance tasks such as TFM upgrades, native reference alignment, package baseline harmonization, CI matrix changes, and headless test runner adjustments.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+# Project Guidelines
+
+## Scope
+
+- Treat MAUI on Android, iOS, MacCatalyst, and Windows as the active product direction for this repository.
+- Prefer changes that strengthen `Tests/Tests.Maui` and `examples/QuickJournal` over legacy platform-specific paths.
+- Treat UWP, Xamarin, Avalonia, and Atlas Device Sync as legacy or out-of-scope unless a task explicitly targets compatibility cleanup.
+
+## Architecture
+
+- `Realm/Realm` is the shipping SDK surface.
+- `Tests/Realm.Tests` provides shared regression coverage.
+- `Tests/Tests.Maui` is the active platform validation harness for MAUI targets.
+- Native wrapper outputs used by `Tests/Tests.Maui` are part of the active path and should stay aligned with the MAUI project file.
+
+## Change Strategy
+
+- Remove or isolate UWP-specific code paths instead of extending them.
+- Keep `netstandard2.0` only where packaging or tooling still requires it; do not add new feature work around deprecated targets.
+- When updating MAUI examples, keep `QuickJournal` on the same strategic MAUI and Realm baseline as the rest of the repository.
+- When editing CI, preserve the MAUI jobs in `.github/workflows/pr.yml` and `.github/workflows/main.yml` and keep the required wrapper outputs in `.github/workflows/wrappers.yml` for Android, iOS, MacCatalyst, and Windows.
+
+## Build and Test
+
+- Prefer validation through `Tests/Tests.Maui` for platform behavior and `Tests/Realm.Tests` for shared regressions.
+- Keep workflow changes symmetric between `pr.yml` and `main.yml` unless there is a platform-specific reason not to.

--- a/.github/instructions/maui-projects.instructions.md
+++ b/.github/instructions/maui-projects.instructions.md
@@ -6,7 +6,8 @@ applyTo: "Tests/Tests.Maui/**, examples/QuickJournal/**"
 # MAUI Project Guidelines
 
 - Keep the active target set aligned with MAUI Android, iOS, MacCatalyst, and Windows.
-- Prefer `net8.0`-aligned MAUI changes; do not reintroduce `net7.0` or `net6.0` into MAUI project files.
+- Active TFM baseline is `net10.0-*`; do not reintroduce `net7.0`, `net6.0`, or `net8.0` into MAUI project files unless a build constraint explicitly requires a temporary fallback.
 - Keep package baselines between `Tests/Tests.Maui` and `examples/QuickJournal` strategically aligned.
 - Preserve the headless test runner flow in `Tests/Tests.Maui` because CI depends on it.
 - When changing native references in `Tests/Tests.Maui`, keep Windows x64, Android ABIs, iOS device or simulator, and MacCatalyst paths consistent with wrapper outputs.
+- The SDK is pinned via `global.json` in the repository root; do not hardcode a different SDK version in project files.

--- a/.github/instructions/maui-projects.instructions.md
+++ b/.github/instructions/maui-projects.instructions.md
@@ -1,0 +1,12 @@
+---
+description: "Use when modifying MAUI projects, Tests.Maui, QuickJournal, MAUI csproj files, MauiProgram, MainPage, native references, or package baselines."
+applyTo: "Tests/Tests.Maui/**, examples/QuickJournal/**"
+---
+
+# MAUI Project Guidelines
+
+- Keep the active target set aligned with MAUI Android, iOS, MacCatalyst, and Windows.
+- Prefer `net8.0`-aligned MAUI changes; do not reintroduce `net7.0` or `net6.0` into MAUI project files.
+- Keep package baselines between `Tests/Tests.Maui` and `examples/QuickJournal` strategically aligned.
+- Preserve the headless test runner flow in `Tests/Tests.Maui` because CI depends on it.
+- When changing native references in `Tests/Tests.Maui`, keep Windows x64, Android ABIs, iOS device or simulator, and MacCatalyst paths consistent with wrapper outputs.

--- a/.github/instructions/workflow-maui.instructions.md
+++ b/.github/instructions/workflow-maui.instructions.md
@@ -1,0 +1,12 @@
+---
+description: "Use when modifying GitHub Actions workflows, MAUI jobs, wrapper matrix entries, legacy UWP cleanup, or CI validation for Android, iOS, MacCatalyst, and Windows."
+applyTo: ".github/workflows/*.yml"
+---
+
+# Workflow Guidelines
+
+- Treat the MAUI jobs in `pr.yml` and `main.yml` as the active platform gate.
+- Do not add new UWP jobs or wrapper outputs back into the workflow matrix.
+- Keep required wrapper artifacts for Windows x64, Android ABIs, iOS device or simulator, and MacCatalyst intact.
+- When removing legacy matrix entries, also remove their cache keys, artifact names, conditions, and downstream references.
+- Prefer small symmetric edits across `pr.yml` and `main.yml`.

--- a/.github/pkl-workflows/helpers/Common.pkl
+++ b/.github/pkl-workflows/helpers/Common.pkl
@@ -11,7 +11,6 @@ const linuxArchs: List<String> = List("x86_64", "armhf", "aarch64")
 const applePlatforms: List<String> = List("iOS", "tvOS")
 const androidABIs: List<String> = List("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 const windowsArchs: List<String> = List("Win32", "x64", "ARM64")
-const uwpArchs: List<String> = List("Win32", "x64", "ARM64")
 
 const appleTargets: List<String> = List("Device", "Simulator")
 
@@ -23,16 +22,15 @@ local const job_Wrappers: String = "build-wrappers"
 
 const mainBranch: String = "community"
 
-typealias NetFramework = "net6.0"|"net8.0"|String(startsWith("${{ matrix"))|String(startsWith("net8"))|String(startsWith("net9"))
+typealias NetFramework = "net8.0"|String(startsWith("${{ matrix"))|String(startsWith("net8"))|String(startsWith("net9"))
 typealias NetRuntime = "win-x64"|"linux-x64"|"osx-x64"|"osx-arm64"|String(startsWith("${{ matrix"))
-typealias SyncDifferentiator = "ios-maui"|"android-maui"|"tvos"|"macos-maui"|"code-coverage"|"uwp"|"net-framework"|String(startsWith("${{ matrix"))
+typealias SyncDifferentiator = "ios-maui"|"android-maui"|"tvos"|"macos-maui"|"code-coverage"|"net-framework"|String(startsWith("${{ matrix"))
 
 const wrapperBinaryNames: List<String> =
   List("macos", "catalyst")
   + linuxArchs.map((arch) -> "linux-\(arch)")
   + androidABIs.map((abi) -> "android-\(abi)")
   + windowsArchs.map((arch) -> "windows-\(arch)")
-  + uwpArchs.map((arch) -> "windows-uwp-\(arch)")
   + applePlatformTargets((platform, target) -> "\(platform)-\(target)")
 
 const defaultEnv: Mapping<String, String|Boolean|Number> = new {
@@ -68,7 +66,6 @@ const function defaultBuildJobs(netCoreVersions: Listing<NetFramework>): Mapping
 //     os = "windows"
 //   })
   ["test-net-framework"] = TestJobs.netFramework()
-  ["test-uwp"] = TestJobs.uwp()
   ["test-net-core"] = TestJobs.netCore(netCoreVersions)
   ["test-macos-maui"] = TestJobs.macOS_Maui()
   ["test-ios-maui"] = TestJobs.iOS_Maui()

--- a/.github/pkl-workflows/helpers/Common.pkl
+++ b/.github/pkl-workflows/helpers/Common.pkl
@@ -74,6 +74,7 @@ const function defaultBuildJobs(netCoreVersions: Listing<NetFramework>): Mapping
   ["test-source-generation"] = TestJobs.sourceGeneration()
   ["test-weaver"] = TestJobs.weaver()
   ["test-code-coverage"] = TestJobs.codeCoverage(job_Wrappers)
+  ["smoke-quickjournal"] = TestJobs.quickJournalSmoke()
   ["verify-namespaces"] = Lint.verifyNamespaces()
   ["lint"] = Lint.lint()
 }

--- a/.github/pkl-workflows/helpers/Common.pkl
+++ b/.github/pkl-workflows/helpers/Common.pkl
@@ -22,7 +22,7 @@ local const job_Wrappers: String = "build-wrappers"
 
 const mainBranch: String = "community"
 
-typealias NetFramework = "net8.0"|String(startsWith("${{ matrix"))|String(startsWith("net8"))|String(startsWith("net9"))
+typealias NetFramework = "net10.0"|"net8.0"|String(startsWith("${{ matrix"))|String(startsWith("net8"))|String(startsWith("net9"))|String(startsWith("net10"))
 typealias NetRuntime = "win-x64"|"linux-x64"|"osx-x64"|"osx-arm64"|String(startsWith("${{ matrix"))
 typealias SyncDifferentiator = "ios-maui"|"android-maui"|"tvos"|"macos-maui"|"code-coverage"|"net-framework"|String(startsWith("${{ matrix"))
 

--- a/.github/pkl-workflows/helpers/Steps.pkl
+++ b/.github/pkl-workflows/helpers/Steps.pkl
@@ -77,7 +77,7 @@ const function setupMSVC(edition: String): gha.Step = new {
 const function setupDotnet(version: String?): gha.Step = new {
   uses = Actions.setupDotnet
   with {
-    ["dotnet-version"] = version ?? "8.0.x"
+    ["dotnet-version"] = version ?? "10.0.x"
   }
 }
 

--- a/.github/pkl-workflows/helpers/Test.pkl
+++ b/.github/pkl-workflows/helpers/Test.pkl
@@ -190,45 +190,6 @@ function macOS_Maui(): gha.Job = testJob(
     ...reportTestResults(config)
   })
 
-function uwp(): gha.Job = testJob(
-  new TestConfig {
-    needsPackages = true
-    title = "UWP"
-  },
-  new gha.WindowsLatest {},
-  null,
-  (config) -> new Listing<gha.Step> {
-    ...prepareTests(config)
-    new {
-      name = "Import test certificate"
-      run = """
-        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-        $currentDirectory = Get-Location
-        [IO.File]::WriteAllBytes("${{ github.workspace }}\\Tests\\Tests.UWP\\Tests.UWP_TemporaryKey.pfx", $pfx_cert_byte)
-        certutil -f -p "${{ secrets.Pfx_Password }}" -importpfx my ${{ github.workspace }}\\Tests\\Tests.UWP\\Tests.UWP_TemporaryKey.pfx
-        """
-      shell = "powershell"
-    }
-    ...buildTests(new Steps.MSBuildConfig {
-      projects {
-        "Tests/Tests.UWP"
-      }
-      properties {
-        ["AppxBundle"] = "Always"
-        ["PackageCertificateKeyFile"] = "${{ github.workspace }}\\Tests\\Tests.UWP\\Tests.UWP_TemporaryKey.pfx"
-        ["PackageCertificatePassword"] = "${{ secrets.Pfx_Password }}"
-        ["UseDotNetNativeToolchain"] = "false"
-        ["AppxBundlePlatforms"] = "x64"
-      }
-    })
-    new {
-      name = "Run the tests"
-      run = "./Tests/Tests.UWP/RunTests.ps1"
-      shell = "powershell"
-    }
-    ...reportTestResultsWithCustomFile("${{ env.TEST_RESULTS }}", config)
-  })
-
 function android_Maui(): gha.Job = testJob(
   new TestConfig {
     needsPackages = true

--- a/.github/pkl-workflows/helpers/Test.pkl
+++ b/.github/pkl-workflows/helpers/Test.pkl
@@ -241,6 +241,24 @@ function codeCoverage(wrappersJob: String): gha.Job = (testJob(
   }
 }
 
+/// Builds examples/QuickJournal on Windows to verify the project file, package
+/// references, and MAUI tooling remain healthy. No wrappers or Realm nuget needed.
+function quickJournalSmoke(): gha.Job = new gha.Job {
+  name = "Smoke QuickJournal"
+  `runs-on` = new gha.WindowsLatest {}
+  `timeout-minutes` = 20
+  `if` = Common.ifNotCanceledCondition
+  steps {
+    ...Steps.checkout(false)
+    Steps.setupDotnet(null)
+    ...Steps.setupMaui()
+    new {
+      name = "Build examples/QuickJournal"
+      run = "dotnet build examples/QuickJournal -f net10.0-windows10.0.19041.0 -c Release"
+    }
+  }
+}
+
 function unity(config: UnityTestConfig): Mapping<String, gha.Job> = new Mapping<String, gha.Job> {
   ["build-unity-tests-\(config.os)"] = new gha.Job {
     name = "Build Unity \(config.os)"

--- a/.github/pkl-workflows/helpers/Test.pkl
+++ b/.github/pkl-workflows/helpers/Test.pkl
@@ -96,7 +96,7 @@ function weaver(): gha.Job = testJob(
   },
   (config) -> new Listing<gha.Step> {
     ...Steps.checkout(false)
-    ...Steps.dotnetPublish("Tests/Weaver/Realm.Fody.Tests", "net8.0", "${{ matrix.os.runtime }}", new Mapping {}).toList()
+    ...Steps.dotnetPublish("Tests/Weaver/Realm.Fody.Tests", "net10.0", "${{ matrix.os.runtime }}", new Mapping {}).toList()
     ...dotnetRunTests(false)
     ...reportTestResults(config)
   })
@@ -110,7 +110,7 @@ function xunit(): gha.Job = testJob(
   null,
   (config) -> new Listing<gha.Step> {
     ...prepareTests(config)
-    ...Steps.dotnetPublish("Tests/Tests.XUnit", "net8.0", "win-x64", new Mapping {}).toList()
+    ...Steps.dotnetPublish("Tests/Tests.XUnit", "net10.0", "win-x64", new Mapping {}).toList()
     new {
       name = "Run Tests"
       run = "dotnet test \(executableExpression)/Tests.XUnit.dll --logger GitHubActions"
@@ -125,7 +125,7 @@ function sourceGeneration(): gha.Job = testJob(
   null,
   (config) -> new Listing<gha.Step> {
     ...Steps.checkout(false)
-    ...Steps.dotnetPublish("Tests/SourceGenerators/Realm.SourceGenerator.Tests", "net8.0", "win-x64", new Mapping {}).toList()
+    ...Steps.dotnetPublish("Tests/SourceGenerators/Realm.SourceGenerator.Tests", "net10.0", "win-x64", new Mapping {}).toList()
     ...dotnetRunTests(false)
     ...reportTestResults(config)
   })
@@ -139,7 +139,7 @@ function wovenClasses(): gha.Job = testJob(
   null,
   (config) -> new Listing<gha.Step> {
     ...prepareTests(config)
-    ...Steps.dotnetPublish("Tests/Realm.Tests", "net8.0", "win-x64", (getTestProps(true)) {
+    ...Steps.dotnetPublish("Tests/Realm.Tests", "net10.0", "win-x64", (getTestProps(true)) {
       ["TestWeavedClasses"] = "true"
     })
     ...dotnetRunTests(false)
@@ -159,9 +159,9 @@ function iOS_Maui(): gha.Job = testJob(
     ...prepareTests(config)
     ...Steps.setupMaui()
     Steps.setupXcode("latest-stable")
-    Steps.dotnetBuild("Tests/Tests.Maui", "net8.0-ios", null, getTestProps(false))
+    Steps.dotnetBuild("Tests/Tests.Maui", "net10.0-ios", null, getTestProps(false))
     Steps.runSimulator(new Steps.SimulatorConfig {
-      appPath = "Tests/Tests.Maui/bin/\(Common.configuration)/net8.0-ios/iossimulator-arm64/Tests.Maui.app"
+      appPath = "Tests/Tests.Maui/bin/\(Common.configuration)/net10.0-ios/iossimulator-arm64/Tests.Maui.app"
       arguments = "--headless --result=${{ github.workspace }}/\(outputFile) --labels=All"
       bundleId = "io.realm.mauitests"
       iphoneToSimulate = "iPhone-15"
@@ -182,10 +182,10 @@ function macOS_Maui(): gha.Job = testJob(
     ...prepareTests(config)
     ...Steps.setupMaui()
     Steps.setupXcode("latest-stable")
-    Steps.dotnetBuild("Tests/Tests.Maui", "net8.0-maccatalyst", null, getTestProps(false))
+    Steps.dotnetBuild("Tests/Tests.Maui", "net10.0-maccatalyst", null, getTestProps(false))
     new {
       name = "Run the tests"
-      run = "Tests/Tests.Maui/bin/\(Common.configuration)/net8.0-maccatalyst/maccatalyst-x64/Tests.Maui.app/Contents/MacOS/Tests.Maui --headless --result=${{ github.workspace }}/\(outputFile) --labels=All"
+      run = "Tests/Tests.Maui/bin/\(Common.configuration)/net10.0-maccatalyst/maccatalyst-x64/Tests.Maui.app/Contents/MacOS/Tests.Maui --headless --result=${{ github.workspace }}/\(outputFile) --labels=All"
     }
     ...reportTestResults(config)
   })
@@ -202,9 +202,9 @@ function android_Maui(): gha.Job = testJob(
     Steps.setupJDK()
     ...prepareTests(config)
     ...Steps.setupMaui()
-    ...Steps.dotnetPublish("Tests/Tests.Maui", "net8.0-android", /* runtime */ null, getTestProps(false))
+    ...Steps.dotnetPublish("Tests/Tests.Maui", "net10.0-android", /* runtime */ null, getTestProps(false))
     ...Steps.runDeviceFarm(new Steps.DeviceFarmConfig {
-      apkPath = "${{ github.workspace }}/Tests/Tests.Maui/bin/Release/net8.0-android/publish/io.realm.mauitests-Signed.apk"
+      apkPath = "${{ github.workspace }}/Tests/Tests.Maui/bin/Release/net10.0-android/publish/io.realm.mauitests-Signed.apk"
       appId = "io.realm.mauitests"
     })
     ...reportTestResultsWithCustomFile("${{ steps.run_tests.outputs.test-results-path }}", config)
@@ -227,10 +227,10 @@ function codeCoverage(wrappersJob: String): gha.Job = (testJob(
         echo "${{ github.workspace }}/tools" >> $GITHUB_PATH
         """
     }
-    ...Steps.dotnetPublish("Tests/Realm.Tests", "net8.0", "linux-x64", new Mapping { ["RealmTestsStandaloneExe"] = "true" })
+    ...Steps.dotnetPublish("Tests/Realm.Tests", "net10.0", "linux-x64", new Mapping { ["RealmTestsStandaloneExe"] = "true" })
     new gha.Step {
       name = "Run the tests"
-      run = "./tools/coverlet ./Tests/Realm.Tests/bin/\(Common.configuration)/net8.0/linux-x64 -t \(executableExpression) -a '--result=\(outputFile) --labels=After' -f lcov -o ./report.lcov --exclude '[Realm.Tests]*' --exclude '[Realm.Fody]*'"
+      run = "./tools/coverlet ./Tests/Realm.Tests/bin/\(Common.configuration)/net10.0/linux-x64 -t \(executableExpression) -a '--result=\(outputFile) --labels=After' -f lcov -o ./report.lcov --exclude '[Realm.Tests]*' --exclude '[Realm.Fody]*'"
     } |> enableCoreDumps(true)
     archiveCoreDump()
     ...Steps.publishCoverage("./report.lcov")
@@ -325,7 +325,7 @@ function benchmark(): gha.Job = testJob(
       name = "Clear nuget cache"
       run = "dotnet nuget locals all --clear"
     }
-    ...Steps.dotnetPublish("Tests/Benchmarks/PerformanceTests", "net8.0", "linux-x64", getTestProps(true))
+    ...Steps.dotnetPublish("Tests/Benchmarks/PerformanceTests", "net10.0", "linux-x64", getTestProps(true))
     new {
       name = "Run the tests"
       run = "\(executableExpression)/PerformanceTests -f \"*\" --join"

--- a/.github/pkl-workflows/main.pkl
+++ b/.github/pkl-workflows/main.pkl
@@ -8,7 +8,6 @@ import "helpers/Test.pkl" as TestJobs
 
 local netCoreFrameworks: Listing<Common.NetFramework> = new {
   "net10.0"
-  "net8.0"  // retained as core regression baseline
 }
 
 name = "Main Build"

--- a/.github/pkl-workflows/main.pkl
+++ b/.github/pkl-workflows/main.pkl
@@ -7,8 +7,8 @@ import "helpers/Steps.pkl"
 import "helpers/Test.pkl" as TestJobs
 
 local netCoreFrameworks: Listing<Common.NetFramework> = new {
-  "net9.0"
-  "net8.0"
+  "net10.0"
+  "net8.0"  // retained as core regression baseline
 }
 
 name = "Main Build"

--- a/.github/pkl-workflows/pr.pkl
+++ b/.github/pkl-workflows/pr.pkl
@@ -5,7 +5,7 @@ amends "package://pkg.pkl-lang.org/github.com/stefma/pkl-gha/com.github.action@0
 import "helpers/Common.pkl"
 
 local netCoreFrameworks: Listing<Common.NetFramework> = new {
-  "net8.0"
+  "net10.0"
 }
 
 name = "PR Build"

--- a/.github/pkl-workflows/wrappers.pkl
+++ b/.github/pkl-workflows/wrappers.pkl
@@ -140,23 +140,6 @@ jobs {
       }
       ifCondition = "\(Common.windowsArchs.map((arch) -> "needs.check-cache.outputs.wrappers-windows-\(arch) != 'true'").join(" || "))"
     })
-  ["uwp"] = new Job {
-    `runs-on` = new WindowsLatest {}
-    name = "UWP"
-    strategy {
-      matrix {
-        ["arch"] = Common.uwpArchs.toListing()
-      }
-      `fail-fast` = false
-    }
-  } |> wrappersJob(new JobConfig {
-      cmd = "pwsh ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -ExtraCMakeArgs \"-T v143,version=14.35\""
-      platform = "windows-uwp-${{ matrix.arch }}"
-      intermediateSteps {
-        Steps.setupMSVC("${{ startswith(matrix.arch, 'ARM') && matrix.arch || 'x86.x64' }}")
-      }
-      ifCondition = "\(Common.uwpArchs.map((arch) -> "needs.check-cache.outputs.wrappers-windows-uwp-\(arch) != 'true'").join(" || "))"
-    })
 }
 
 local function withCondition(platform: String, _conditionToAppend: String?): Mixin<Step> = new {

--- a/.github/workflows/local-packages.yml
+++ b/.github/workflows/local-packages.yml
@@ -1,0 +1,175 @@
+﻿name: Local Package Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-suffix:
+        description: 'Optional version suffix (e.g. "local.1"). Leave empty for auto-generated alpha suffix.'
+        required: false
+        type: string
+        default: ''
+
+env:
+  REALM_DISABLE_ANALYTICS: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  build-wrappers:
+    name: Wrappers
+    uses: ./.github/workflows/wrappers.yml
+
+  build-packages:
+    name: Package NuGet
+    needs: build-wrappers
+    runs-on: windows-latest
+    timeout-minutes: 30
+    outputs:
+      package_version: ${{ steps.get-version.outputs.package_version }}
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        submodules: false
+
+    - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Set version suffix
+      id: set-version-suffix
+      shell: pwsh
+      run: |
+        $suffix = "${{ inputs.version-suffix }}"
+        if ([string]::IsNullOrEmpty($suffix)) {
+          $suffix = "local.$env:GITHUB_RUN_NUMBER"
+        }
+        echo "build_suffix=$suffix" >> $Env:GITHUB_OUTPUT
+
+    - name: Fetch wrappers for macos
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-macos
+        path: wrappers/build
+    - name: Fetch wrappers for catalyst
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-catalyst
+        path: wrappers/build
+    - name: Fetch wrappers for linux-x86_64
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-linux-x86_64
+        path: wrappers/build
+    - name: Fetch wrappers for linux-armhf
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-linux-armhf
+        path: wrappers/build
+    - name: Fetch wrappers for linux-aarch64
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-linux-aarch64
+        path: wrappers/build
+    - name: Fetch wrappers for android-armeabi-v7a
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-android-armeabi-v7a
+        path: wrappers/build
+    - name: Fetch wrappers for android-arm64-v8a
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-android-arm64-v8a
+        path: wrappers/build
+    - name: Fetch wrappers for android-x86
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-android-x86
+        path: wrappers/build
+    - name: Fetch wrappers for android-x86_64
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-android-x86_64
+        path: wrappers/build
+    - name: Fetch wrappers for windows-Win32
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-windows-Win32
+        path: wrappers/build
+    - name: Fetch wrappers for windows-x64
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-windows-x64
+        path: wrappers/build
+    - name: Fetch wrappers for windows-ARM64
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-windows-ARM64
+        path: wrappers/build
+    - name: Fetch wrappers for iOS-Device
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-iOS-Device
+        path: wrappers/build
+    - name: Fetch wrappers for iOS-Simulator
+      uses: actions/download-artifact@v4
+      with:
+        name: wrappers-iOS-Simulator
+        path: wrappers/build
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@70b70342ae97ca98d5eaad06cafd26d30f9592a9
+
+    - name: Build Realm/Realm
+      run: msbuild Realm/Realm -t:Pack -restore -p:Configuration=Release -p:PackageOutputPath=${{ github.workspace }}/Realm/packages -p:VersionSuffix=${{ steps.set-version-suffix.outputs.build_suffix }}
+    - name: Build Realm/Realm.UnityUtils
+      run: msbuild Realm/Realm.UnityUtils -t:Pack -restore -p:Configuration=Release -p:PackageOutputPath=${{ github.workspace }}/Realm/packages -p:VersionSuffix=${{ steps.set-version-suffix.outputs.build_suffix }}
+    - name: Build Realm/Realm.UnityWeaver
+      run: msbuild Realm/Realm.UnityWeaver -t:Pack -restore -p:Configuration=Release -p:PackageOutputPath=${{ github.workspace }}/Realm/packages -p:VersionSuffix=${{ steps.set-version-suffix.outputs.build_suffix }}
+
+    - name: Read version
+      id: get-version
+      shell: bash
+      run: |
+        cd Realm/packages
+        pkgVersion=$(find . -type f -regex ".*Realm.[1-9].*.nupkg" -exec basename {} \; | sed -n 's/Realm\.\(.*\)\.nupkg$/\1/p')
+        echo "package_version=$pkgVersion" >> $GITHUB_OUTPUT
+
+    - name: Store Realm.${{ steps.get-version.outputs.package_version }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: Realm.${{ steps.get-version.outputs.package_version }}
+        path: Realm/packages/Realm.${{ steps.get-version.outputs.package_version }}.*nupkg
+        retention-days: 90
+        if-no-files-found: error
+
+    - name: Store Realm.UnityUtils.${{ steps.get-version.outputs.package_version }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: Realm.UnityUtils.${{ steps.get-version.outputs.package_version }}
+        path: Realm/packages/Realm.UnityUtils.${{ steps.get-version.outputs.package_version }}.*nupkg
+        retention-days: 90
+        if-no-files-found: error
+
+    - name: Store Realm.UnityWeaver.${{ steps.get-version.outputs.package_version }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: Realm.UnityWeaver.${{ steps.get-version.outputs.package_version }}
+        path: Realm/packages/Realm.UnityWeaver.${{ steps.get-version.outputs.package_version }}.*nupkg
+        retention-days: 90
+        if-no-files-found: error
+
+    - name: Print usage instructions
+      shell: pwsh
+      run: |
+        Write-Host ""
+        Write-Host "=== Local NuGet packages ready ===" -ForegroundColor Green
+        Write-Host "Version: ${{ steps.get-version.outputs.package_version }}"
+        Write-Host ""
+        Write-Host "To use these packages locally:"
+        Write-Host "1. Download the artifacts from this workflow run in the Actions tab."
+        Write-Host "2. Extract to a local folder, e.g. C:\nuget-local\"
+        Write-Host "3. Register the folder as a NuGet source:"
+        Write-Host "     dotnet nuget add source C:\nuget-local --name local-realm"
+        Write-Host "4. Reference the version in your project:"
+        Write-Host "     dotnet add package Realm --version ${{ steps.get-version.outputs.package_version }}"
+        Write-Host ""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,21 +122,6 @@ jobs:
       with:
         name: wrappers-windows-ARM64
         path: wrappers/build
-    - name: Fetch wrappers for windows-uwp-Win32
-      uses: actions/download-artifact@v4
-      with:
-        name: wrappers-windows-uwp-Win32
-        path: wrappers/build
-    - name: Fetch wrappers for windows-uwp-x64
-      uses: actions/download-artifact@v4
-      with:
-        name: wrappers-windows-uwp-x64
-        path: wrappers/build
-    - name: Fetch wrappers for windows-uwp-ARM64
-      uses: actions/download-artifact@v4
-      with:
-        name: wrappers-windows-uwp-ARM64
-        path: wrappers/build
     - name: Fetch wrappers for iOS-Device
       uses: actions/download-artifact@v4
       with:
@@ -324,53 +309,6 @@ jobs:
       with:
         name: Results .NET Framework
         path: TestResults.xml
-        reporter: java-junit
-        list-suites: failed
-        path-replace-backslashes: true
-        fail-on-error: true
-  test-uwp:
-    name: Test UWP
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-    needs:
-    - build-packages
-    runs-on: windows-latest
-    timeout-minutes: 60
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-      with:
-        submodules: false
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Register problem matchers
-      run: |-
-        echo "::add-matcher::.github/problem-matchers/csc.json"
-        echo "::add-matcher::.github/problem-matchers/msvc.json"
-    - name: Fetch Realm
-      uses: actions/download-artifact@v4
-      with:
-        name: Realm.${{ needs.build-packages.outputs.package_version }}
-        path: ${{ github.workspace }}/Realm/packages/
-    - name: Import test certificate
-      shell: powershell
-      run: |-
-        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-        $currentDirectory = Get-Location
-        [IO.File]::WriteAllBytes("${{ github.workspace }}\Tests\Tests.UWP\Tests.UWP_TemporaryKey.pfx", $pfx_cert_byte)
-        certutil -f -p "${{ secrets.Pfx_Password }}" -importpfx my ${{ github.workspace }}\Tests\Tests.UWP\Tests.UWP_TemporaryKey.pfx
-    - name: Add msbuild to PATH
-      if: ${{ runner.os == 'Windows' }}
-      uses: microsoft/setup-msbuild@70b70342ae97ca98d5eaad06cafd26d30f9592a9
-    - name: Build Tests/Tests.UWP
-      run: msbuild Tests/Tests.UWP -restore -p:Configuration=Release -p:AppxBundle=Always -p:PackageCertificateKeyFile=${{ github.workspace }}\Tests\Tests.UWP\Tests.UWP_TemporaryKey.pfx -p:PackageCertificatePassword=${{ secrets.Pfx_Password }} -p:UseDotNetNativeToolchain=false -p:AppxBundlePlatforms=x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
-    - name: Run the tests
-      shell: powershell
-      run: ./Tests/Tests.UWP/RunTests.ps1
-    - name: Publish Unit Test Results
-      if: always()
-      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
-      with:
-        name: Results UWP
-        path: ${{ env.TEST_RESULTS }}
         reporter: java-junit
         list-suites: failed
         path-replace-backslashes: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         echo "::add-matcher::.github/problem-matchers/msvc.json"
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Set version suffix
       id: set-version-suffix
       shell: pwsh
@@ -417,7 +417,7 @@ jobs:
         path: ${{ github.workspace }}/Realm/packages/
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Setup Maui workload
       run: dotnet workload install maui
     - name: Setup Xcode
@@ -425,9 +425,9 @@ jobs:
       with:
         xcode-version: latest-stable
     - name: Build Tests/Tests.Maui
-      run: dotnet build Tests/Tests.Maui -c Release -f net8.0-maccatalyst -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet build Tests/Tests.Maui -c Release -f net10.0-maccatalyst -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
     - name: Run the tests
-      run: Tests/Tests.Maui/bin/Release/net8.0-maccatalyst/maccatalyst-x64/Tests.Maui.app/Contents/MacOS/Tests.Maui --headless --result=${{ github.workspace }}/TestResults.xml --labels=All
+      run: Tests/Tests.Maui/bin/Release/net10.0-maccatalyst/maccatalyst-x64/Tests.Maui.app/Contents/MacOS/Tests.Maui --headless --result=${{ github.workspace }}/TestResults.xml --labels=All
     - name: Transform Results
       run: xsltproc --output TestResults.xml_transformed.xml Tests/Realm.Tests/EmbeddedResources/nunit3-junit.xslt TestResults.xml
     - name: Publish Unit Test Results
@@ -464,7 +464,7 @@ jobs:
         path: ${{ github.workspace }}/Realm/packages/
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Setup Maui workload
       run: dotnet workload install maui
     - name: Setup Xcode
@@ -472,11 +472,11 @@ jobs:
       with:
         xcode-version: latest-stable
     - name: Build Tests/Tests.Maui
-      run: dotnet build Tests/Tests.Maui -c Release -f net8.0-ios -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet build Tests/Tests.Maui -c Release -f net10.0-ios -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
     - name: Run on Simulator
       uses: realm/ci-actions/run-ios-simulator@6418e15ed9bbdb19b7d456a347e5623779f95cdf
       with:
-        appPath: Tests/Tests.Maui/bin/Release/net8.0-ios/iossimulator-arm64/Tests.Maui.app
+        appPath: Tests/Tests.Maui/bin/Release/net10.0-ios/iossimulator-arm64/Tests.Maui.app
         bundleId: io.realm.mauitests
         iphoneToSimulate: iPhone-15
         arguments: --headless --result=${{ github.workspace }}/TestResults.xml --labels=All
@@ -522,15 +522,15 @@ jobs:
         path: ${{ github.workspace }}/Realm/packages/
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Setup Maui workload
       run: dotnet workload install maui
     - name: Publish Tests/Tests.Maui
-      run: dotnet publish Tests/Tests.Maui -c Release -f net8.0-android -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} --no-self-contained
+      run: dotnet publish Tests/Tests.Maui -c Release -f net10.0-android -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Tests.Maui/bin/Release/net8.0-android/null/Tests.Maui' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Tests.Maui/bin/Release/net10.0-android/null/Tests.Maui' >> $GITHUB_OUTPUT
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
@@ -541,7 +541,7 @@ jobs:
       id: run_tests
       uses: ./.github/actions/run-android-device-farm-test
       with:
-        apk-path: ${{ github.workspace }}/Tests/Tests.Maui/bin/Release/net8.0-android/publish/io.realm.mauitests-Signed.apk
+        apk-path: ${{ github.workspace }}/Tests/Tests.Maui/bin/Release/net10.0-android/publish/io.realm.mauitests-Signed.apk
         app-id: io.realm.mauitests
         project-arn: ${{ secrets.DEVICEFARM_PROJECT_ARN }}
         device-pool-arn: ${{ secrets.DEVICEFARM_ANDROID_POOL_ARN }}
@@ -826,7 +826,7 @@ jobs:
         path: ${{ github.workspace }}/Realm/packages/
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Install sleet
       run: dotnet tool install -g sleet
     - name: Configure AWS Credentials

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-# Do not modify!
+﻿# Do not modify!
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: Main Build
@@ -321,8 +321,7 @@ jobs:
     strategy:
       matrix:
         framework:
-        - net9.0
-        - net8.0
+        - net10.0
         os:
         - runner: windows-latest
           runtime: win-x64
@@ -580,11 +579,11 @@ jobs:
         name: Realm.${{ needs.build-packages.outputs.package_version }}
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f net8.0 -r win-x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:RealmTestsStandaloneExe=true -p:TestWeavedClasses=true --no-self-contained
+      run: dotnet publish Tests/Realm.Tests -c Release -f net10.0 -r win-x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:RealmTestsStandaloneExe=true -p:TestWeavedClasses=true --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net8.0/win-x64/Realm.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net10.0/win-x64/Realm.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       run: ${{ steps.dotnet-publish.outputs.executable-path }} --result=TestResults.xml --labels=After
     - name: Publish Unit Test Results
@@ -613,11 +612,11 @@ jobs:
         echo "::add-matcher::.github/problem-matchers/csc.json"
         echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Publish Tests/SourceGenerators/Realm.SourceGenerator.Tests
-      run: dotnet publish Tests/SourceGenerators/Realm.SourceGenerator.Tests -c Release -f net8.0 -r win-x64  --no-self-contained
+      run: dotnet publish Tests/SourceGenerators/Realm.SourceGenerator.Tests -c Release -f net10.0 -r win-x64  --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/SourceGenerators/Realm.SourceGenerator.Tests/bin/Release/net8.0/win-x64/Realm.SourceGenerator.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/SourceGenerators/Realm.SourceGenerator.Tests/bin/Release/net10.0/win-x64/Realm.SourceGenerator.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       run: ${{ steps.dotnet-publish.outputs.executable-path }} --result=TestResults.xml --labels=After
     - name: Publish Unit Test Results
@@ -656,11 +655,11 @@ jobs:
         echo "::add-matcher::.github/problem-matchers/csc.json"
         echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Publish Tests/Weaver/Realm.Fody.Tests
-      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f net8.0 -r ${{ matrix.os.runtime }}  --no-self-contained
+      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f net10.0 -r ${{ matrix.os.runtime }}  --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Weaver/Realm.Fody.Tests/bin/Release/net8.0/${{ matrix.os.runtime }}/Realm.Fody.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Weaver/Realm.Fody.Tests/bin/Release/net10.0/${{ matrix.os.runtime }}/Realm.Fody.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       run: ${{ steps.dotnet-publish.outputs.executable-path }} --result=TestResults.xml --labels=After
     - name: Publish Unit Test Results
@@ -701,16 +700,16 @@ jobs:
         dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
         echo "${{ github.workspace }}/tools" >> $GITHUB_PATH
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f net8.0 -r linux-x64 -p:RealmTestsStandaloneExe=true --no-self-contained
+      run: dotnet publish Tests/Realm.Tests -c Release -f net10.0 -r linux-x64 -p:RealmTestsStandaloneExe=true --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net8.0/linux-x64/Realm.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net10.0/linux-x64/Realm.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       env:
         DOTNET_DbgEnableMiniDump: 1
         DOTNET_EnableCrashReport: 1
-      run: ./tools/coverlet ./Tests/Realm.Tests/bin/Release/net8.0/linux-x64 -t ${{ steps.dotnet-publish.outputs.executable-path }} -a '--result=TestResults.xml --labels=After' -f lcov -o ./report.lcov --exclude '[Realm.Tests]*' --exclude '[Realm.Fody]*'
+      run: ./tools/coverlet ./Tests/Realm.Tests/bin/Release/net10.0/linux-x64 -t ${{ steps.dotnet-publish.outputs.executable-path }} -a '--result=TestResults.xml --labels=After' -f lcov -o ./report.lcov --exclude '[Realm.Tests]*' --exclude '[Realm.Fody]*'
     - name: Archive core dump
       if: ${{ failure() && runner.os != 'Windows' }}
       uses: actions/upload-artifact@v4
@@ -860,11 +859,11 @@ jobs:
         name: Realm.${{ needs.build-packages.outputs.package_version }}
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Tests.XUnit
-      run: dotnet publish Tests/Tests.XUnit -c Release -f net8.0 -r win-x64  --no-self-contained
+      run: dotnet publish Tests/Tests.XUnit -c Release -f net10.0 -r win-x64  --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Tests.XUnit/bin/Release/net8.0/win-x64/Tests.XUnit' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Tests.XUnit/bin/Release/net10.0/win-x64/Tests.XUnit' >> $GITHUB_OUTPUT
     - name: Run Tests
       run: dotnet test ${{ steps.dotnet-publish.outputs.executable-path }}/Tests.XUnit.dll --logger GitHubActions
   benchmark-linux:
@@ -894,11 +893,11 @@ jobs:
     - name: Clear nuget cache
       run: dotnet nuget locals all --clear
     - name: Publish Tests/Benchmarks/PerformanceTests
-      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net8.0 -r linux-x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:RealmTestsStandaloneExe=true --no-self-contained
+      run: dotnet publish Tests/Benchmarks/PerformanceTests -c Release -f net10.0 -r linux-x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:RealmTestsStandaloneExe=true --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Benchmarks/PerformanceTests/bin/Release/net8.0/linux-x64/PerformanceTests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Benchmarks/PerformanceTests/bin/Release/net10.0/linux-x64/PerformanceTests' >> $GITHUB_OUTPUT
     - name: Run the tests
       run: ${{ steps.dotnet-publish.outputs.executable-path }}/PerformanceTests -f "*" --join
     - name: Find Results file

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
         echo "::add-matcher::.github/problem-matchers/msvc.json"
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Set version suffix
       id: set-version-suffix
       shell: pwsh
@@ -422,7 +422,7 @@ jobs:
         path: ${{ github.workspace }}/Realm/packages/
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Setup Maui workload
       run: dotnet workload install maui
     - name: Setup Xcode
@@ -430,9 +430,9 @@ jobs:
       with:
         xcode-version: latest-stable
     - name: Build Tests/Tests.Maui
-      run: dotnet build Tests/Tests.Maui -c Release -f net8.0-maccatalyst -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet build Tests/Tests.Maui -c Release -f net10.0-maccatalyst -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
     - name: Run the tests
-      run: Tests/Tests.Maui/bin/Release/net8.0-maccatalyst/maccatalyst-x64/Tests.Maui.app/Contents/MacOS/Tests.Maui --headless --result=${{ github.workspace }}/TestResults.xml --labels=All
+      run: Tests/Tests.Maui/bin/Release/net10.0-maccatalyst/maccatalyst-x64/Tests.Maui.app/Contents/MacOS/Tests.Maui --headless --result=${{ github.workspace }}/TestResults.xml --labels=All
     - name: Transform Results
       run: xsltproc --output TestResults.xml_transformed.xml Tests/Realm.Tests/EmbeddedResources/nunit3-junit.xslt TestResults.xml
     - name: Publish Unit Test Results
@@ -469,7 +469,7 @@ jobs:
         path: ${{ github.workspace }}/Realm/packages/
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Setup Maui workload
       run: dotnet workload install maui
     - name: Setup Xcode
@@ -477,11 +477,11 @@ jobs:
       with:
         xcode-version: latest-stable
     - name: Build Tests/Tests.Maui
-      run: dotnet build Tests/Tests.Maui -c Release -f net8.0-ios -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
+      run: dotnet build Tests/Tests.Maui -c Release -f net10.0-ios -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
     - name: Run on Simulator
       uses: realm/ci-actions/run-ios-simulator@6418e15ed9bbdb19b7d456a347e5623779f95cdf
       with:
-        appPath: Tests/Tests.Maui/bin/Release/net8.0-ios/iossimulator-arm64/Tests.Maui.app
+        appPath: Tests/Tests.Maui/bin/Release/net10.0-ios/iossimulator-arm64/Tests.Maui.app
         bundleId: io.realm.mauitests
         iphoneToSimulate: iPhone-15
         arguments: --headless --result=${{ github.workspace }}/TestResults.xml --labels=All
@@ -527,15 +527,15 @@ jobs:
         path: ${{ github.workspace }}/Realm/packages/
     - uses: actions/setup-dotnet@5d1464d5da459f3d7085106d52e499f4dc5d0f59
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Setup Maui workload
       run: dotnet workload install maui
     - name: Publish Tests/Tests.Maui
-      run: dotnet publish Tests/Tests.Maui -c Release -f net8.0-android -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} --no-self-contained
+      run: dotnet publish Tests/Tests.Maui -c Release -f net10.0-android -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Tests.Maui/bin/Release/net8.0-android/null/Tests.Maui' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Tests.Maui/bin/Release/net10.0-android/null/Tests.Maui' >> $GITHUB_OUTPUT
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
@@ -546,7 +546,7 @@ jobs:
       id: run_tests
       uses: ./.github/actions/run-android-device-farm-test
       with:
-        apk-path: ${{ github.workspace }}/Tests/Tests.Maui/bin/Release/net8.0-android/publish/io.realm.mauitests-Signed.apk
+        apk-path: ${{ github.workspace }}/Tests/Tests.Maui/bin/Release/net10.0-android/publish/io.realm.mauitests-Signed.apk
         app-id: io.realm.mauitests
         project-arn: ${{ secrets.DEVICEFARM_PROJECT_ARN }}
         device-pool-arn: ${{ secrets.DEVICEFARM_ANDROID_POOL_ARN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -128,21 +128,6 @@ jobs:
       with:
         name: wrappers-windows-ARM64
         path: wrappers/build
-    - name: Fetch wrappers for windows-uwp-Win32
-      uses: actions/download-artifact@v4
-      with:
-        name: wrappers-windows-uwp-Win32
-        path: wrappers/build
-    - name: Fetch wrappers for windows-uwp-x64
-      uses: actions/download-artifact@v4
-      with:
-        name: wrappers-windows-uwp-x64
-        path: wrappers/build
-    - name: Fetch wrappers for windows-uwp-ARM64
-      uses: actions/download-artifact@v4
-      with:
-        name: wrappers-windows-uwp-ARM64
-        path: wrappers/build
     - name: Fetch wrappers for iOS-Device
       uses: actions/download-artifact@v4
       with:
@@ -330,53 +315,6 @@ jobs:
       with:
         name: Results .NET Framework
         path: TestResults.xml
-        reporter: java-junit
-        list-suites: failed
-        path-replace-backslashes: true
-        fail-on-error: true
-  test-uwp:
-    name: Test UWP
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-    needs:
-    - build-packages
-    runs-on: windows-latest
-    timeout-minutes: 60
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-      with:
-        submodules: false
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Register problem matchers
-      run: |-
-        echo "::add-matcher::.github/problem-matchers/csc.json"
-        echo "::add-matcher::.github/problem-matchers/msvc.json"
-    - name: Fetch Realm
-      uses: actions/download-artifact@v4
-      with:
-        name: Realm.${{ needs.build-packages.outputs.package_version }}
-        path: ${{ github.workspace }}/Realm/packages/
-    - name: Import test certificate
-      shell: powershell
-      run: |-
-        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-        $currentDirectory = Get-Location
-        [IO.File]::WriteAllBytes("${{ github.workspace }}\Tests\Tests.UWP\Tests.UWP_TemporaryKey.pfx", $pfx_cert_byte)
-        certutil -f -p "${{ secrets.Pfx_Password }}" -importpfx my ${{ github.workspace }}\Tests\Tests.UWP\Tests.UWP_TemporaryKey.pfx
-    - name: Add msbuild to PATH
-      if: ${{ runner.os == 'Windows' }}
-      uses: microsoft/setup-msbuild@70b70342ae97ca98d5eaad06cafd26d30f9592a9
-    - name: Build Tests/Tests.UWP
-      run: msbuild Tests/Tests.UWP -restore -p:Configuration=Release -p:AppxBundle=Always -p:PackageCertificateKeyFile=${{ github.workspace }}\Tests\Tests.UWP\Tests.UWP_TemporaryKey.pfx -p:PackageCertificatePassword=${{ secrets.Pfx_Password }} -p:UseDotNetNativeToolchain=false -p:AppxBundlePlatforms=x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }}
-    - name: Run the tests
-      shell: powershell
-      run: ./Tests/Tests.UWP/RunTests.ps1
-    - name: Publish Unit Test Results
-      if: always()
-      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
-      with:
-        name: Results UWP
-        path: ${{ env.TEST_RESULTS }}
         reporter: java-junit
         list-suites: failed
         path-replace-backslashes: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-# Do not modify!
+﻿# Do not modify!
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: PR Build
@@ -327,7 +327,7 @@ jobs:
     strategy:
       matrix:
         framework:
-        - net8.0
+        - net10.0
         os:
         - runner: windows-latest
           runtime: win-x64
@@ -585,11 +585,11 @@ jobs:
         name: Realm.${{ needs.build-packages.outputs.package_version }}
         path: ${{ github.workspace }}/Realm/packages/
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f net8.0 -r win-x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:RealmTestsStandaloneExe=true -p:TestWeavedClasses=true --no-self-contained
+      run: dotnet publish Tests/Realm.Tests -c Release -f net10.0 -r win-x64 -p:RestoreConfigFile=Tests/Test.NuGet.Config -p:UseRealmNupkgsWithVersion=${{ needs.build-packages.outputs.package_version }} -p:RealmTestsStandaloneExe=true -p:TestWeavedClasses=true --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net8.0/win-x64/Realm.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net10.0/win-x64/Realm.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       run: ${{ steps.dotnet-publish.outputs.executable-path }} --result=TestResults.xml --labels=After
     - name: Publish Unit Test Results
@@ -618,11 +618,11 @@ jobs:
         echo "::add-matcher::.github/problem-matchers/csc.json"
         echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Publish Tests/SourceGenerators/Realm.SourceGenerator.Tests
-      run: dotnet publish Tests/SourceGenerators/Realm.SourceGenerator.Tests -c Release -f net8.0 -r win-x64  --no-self-contained
+      run: dotnet publish Tests/SourceGenerators/Realm.SourceGenerator.Tests -c Release -f net10.0 -r win-x64  --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/SourceGenerators/Realm.SourceGenerator.Tests/bin/Release/net8.0/win-x64/Realm.SourceGenerator.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/SourceGenerators/Realm.SourceGenerator.Tests/bin/Release/net10.0/win-x64/Realm.SourceGenerator.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       run: ${{ steps.dotnet-publish.outputs.executable-path }} --result=TestResults.xml --labels=After
     - name: Publish Unit Test Results
@@ -661,11 +661,11 @@ jobs:
         echo "::add-matcher::.github/problem-matchers/csc.json"
         echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Publish Tests/Weaver/Realm.Fody.Tests
-      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f net8.0 -r ${{ matrix.os.runtime }}  --no-self-contained
+      run: dotnet publish Tests/Weaver/Realm.Fody.Tests -c Release -f net10.0 -r ${{ matrix.os.runtime }}  --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Weaver/Realm.Fody.Tests/bin/Release/net8.0/${{ matrix.os.runtime }}/Realm.Fody.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Weaver/Realm.Fody.Tests/bin/Release/net10.0/${{ matrix.os.runtime }}/Realm.Fody.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       run: ${{ steps.dotnet-publish.outputs.executable-path }} --result=TestResults.xml --labels=After
     - name: Publish Unit Test Results
@@ -706,16 +706,16 @@ jobs:
         dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
         echo "${{ github.workspace }}/tools" >> $GITHUB_PATH
     - name: Publish Tests/Realm.Tests
-      run: dotnet publish Tests/Realm.Tests -c Release -f net8.0 -r linux-x64 -p:RealmTestsStandaloneExe=true --no-self-contained
+      run: dotnet publish Tests/Realm.Tests -c Release -f net10.0 -r linux-x64 -p:RealmTestsStandaloneExe=true --no-self-contained
     - name: Output executable path
       id: dotnet-publish
       shell: bash
-      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net8.0/linux-x64/Realm.Tests' >> $GITHUB_OUTPUT
+      run: echo 'executable-path=./Tests/Realm.Tests/bin/Release/net10.0/linux-x64/Realm.Tests' >> $GITHUB_OUTPUT
     - name: Run the tests
       env:
         DOTNET_DbgEnableMiniDump: 1
         DOTNET_EnableCrashReport: 1
-      run: ./tools/coverlet ./Tests/Realm.Tests/bin/Release/net8.0/linux-x64 -t ${{ steps.dotnet-publish.outputs.executable-path }} -a '--result=TestResults.xml --labels=After' -f lcov -o ./report.lcov --exclude '[Realm.Tests]*' --exclude '[Realm.Fody]*'
+      run: ./tools/coverlet ./Tests/Realm.Tests/bin/Release/net10.0/linux-x64 -t ${{ steps.dotnet-publish.outputs.executable-path }} -a '--result=TestResults.xml --labels=After' -f lcov -o ./report.lcov --exclude '[Realm.Tests]*' --exclude '[Realm.Fody]*'
     - name: Archive core dump
       if: ${{ failure() && runner.os != 'Windows' }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/wrappers.yml
+++ b/.github/workflows/wrappers.yml
@@ -32,9 +32,6 @@ jobs:
       wrappers-windows-Win32: ${{ steps.check-cache-windows-Win32.outputs.cache-hit }}
       wrappers-windows-x64: ${{ steps.check-cache-windows-x64.outputs.cache-hit }}
       wrappers-windows-ARM64: ${{ steps.check-cache-windows-ARM64.outputs.cache-hit }}
-      wrappers-windows-uwp-Win32: ${{ steps.check-cache-windows-uwp-Win32.outputs.cache-hit }}
-      wrappers-windows-uwp-x64: ${{ steps.check-cache-windows-uwp-x64.outputs.cache-hit }}
-      wrappers-windows-uwp-ARM64: ${{ steps.check-cache-windows-uwp-ARM64.outputs.cache-hit }}
       wrappers-iOS-Device: ${{ steps.check-cache-iOS-Device.outputs.cache-hit }}
       wrappers-iOS-Simulator: ${{ steps.check-cache-iOS-Simulator.outputs.cache-hit }}
       wrappers-tvOS-Device: ${{ steps.check-cache-tvOS-Device.outputs.cache-hit }}
@@ -244,57 +241,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wrappers-windows-ARM64
-        path: wrappers/build/**
-        retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
-        if-no-files-found: error
-    - if: matrix.os == 'windows'
-      run: git clean -fdx
-    - name: Check Cache for windows-uwp-Win32
-      id: check-cache-windows-uwp-Win32
-      if: matrix.os == 'windows'
-      uses: actions/cache/restore@v4
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-windows-uwp-Win32-Release-${{hashFiles('./wrappers/**')}}
-    - name: Store artifacts for wrappers-windows-uwp-Win32
-      if: matrix.os == 'windows' && steps.check-cache-windows-uwp-Win32.outputs.cache-hit == 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: wrappers-windows-uwp-Win32
-        path: wrappers/build/**
-        retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
-        if-no-files-found: error
-    - if: matrix.os == 'windows'
-      run: git clean -fdx
-    - name: Check Cache for windows-uwp-x64
-      id: check-cache-windows-uwp-x64
-      if: matrix.os == 'windows'
-      uses: actions/cache/restore@v4
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-windows-uwp-x64-Release-${{hashFiles('./wrappers/**')}}
-    - name: Store artifacts for wrappers-windows-uwp-x64
-      if: matrix.os == 'windows' && steps.check-cache-windows-uwp-x64.outputs.cache-hit == 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: wrappers-windows-uwp-x64
-        path: wrappers/build/**
-        retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
-        if-no-files-found: error
-    - if: matrix.os == 'windows'
-      run: git clean -fdx
-    - name: Check Cache for windows-uwp-ARM64
-      id: check-cache-windows-uwp-ARM64
-      if: matrix.os == 'windows'
-      uses: actions/cache/restore@v4
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-windows-uwp-ARM64-Release-${{hashFiles('./wrappers/**')}}
-    - name: Store artifacts for wrappers-windows-uwp-ARM64
-      if: matrix.os == 'windows' && steps.check-cache-windows-uwp-ARM64.outputs.cache-hit == 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: wrappers-windows-uwp-ARM64
         path: wrappers/build/**
         retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
         if-no-files-found: error
@@ -597,46 +543,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wrappers-windows-${{ matrix.arch }}
-        path: wrappers/build/**
-        retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
-        if-no-files-found: error
-  uwp:
-    name: UWP
-    if: needs.check-cache.outputs.wrappers-windows-uwp-Win32 != 'true' || needs.check-cache.outputs.wrappers-windows-uwp-x64 != 'true' || needs.check-cache.outputs.wrappers-windows-uwp-ARM64 != 'true'
-    needs:
-    - check-cache
-    strategy:
-      matrix:
-        arch:
-        - Win32
-        - x64
-        - ARM64
-      fail-fast: false
-    runs-on: windows-latest
-    timeout-minutes: 90
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Check Cache for windows-uwp-${{ matrix.arch }}
-      id: check-cache
-      uses: actions/cache@v4
-      with:
-        path: ./wrappers/build/**
-        key: wrappers-windows-uwp-${{ matrix.arch }}-Release-${{hashFiles('./wrappers/**')}}
-    - name: Setup MSVC
-      if: steps.check-cache.outputs.cache-hit != 'true'
-      shell: pwsh
-      run: Start-Process "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -ArgumentList 'modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --quiet --add Microsoft.VisualStudio.Component.VC.14.35.17.5.${{ startswith(matrix.arch, 'ARM') && matrix.arch || 'x86.x64' }}' -Wait -PassThru
-    - name: Build Wrappers
-      if: steps.check-cache.outputs.cache-hit != 'true'
-      run: pwsh ./wrappers/build.ps1 WindowsStore -Platforms ${{ matrix.arch }} -ExtraCMakeArgs "-T v143,version=14.35" -Configuration Release -EnableLTO
-    - name: Store artifacts for wrappers-windows-uwp-${{ matrix.arch }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: wrappers-windows-uwp-${{ matrix.arch }}
         path: wrappers/build/**
         retention-days: ${{ github.event_name != 'pull_request' && 30 || 1 }}
         if-no-files-found: error

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,4 +35,5 @@
         "variant": "cpp",
         "vector": "cpp"
     },
+    "dotnet.preferCSharpExtension": true,
 }

--- a/Guides/install.md
+++ b/Guides/install.md
@@ -1,80 +1,46 @@
 # Install the .NET SDK
-You can use the Realm SDK for .NET to develop apps in C# .NET with several frameworks, including
-[.NET MAUI](https://dotnet.microsoft.com/en-us/apps/maui),
-[Xamarin](https://dotnet.microsoft.com/apps/xamarin),
-[Avalonia UI](https://avaloniaui.net/),
-[UWP](https://docs.microsoft.com/en-us/windows/uwp/get-started/),
-[Unity](https://unity.com/), and others.
 
-For more information about specific version support for .NET, .NET MAUI, UWP, and
-Xamarin, see Platform and Framework Compatibility.
-
-> **NOTE:**
-> Integrating the .NET SDK with Unity has different prerequisites and
-> install steps than the ones below. Learn how to Integrate the SDK
-> with Unity.
->
+You can use the Realm SDK for .NET to develop apps in C# with [.NET MAUI](https://dotnet.microsoft.com/en-us/apps/maui) targeting Android, iOS, macOS (Mac Catalyst), and Windows. The SDK also supports [Unity](https://unity.com/) for game development.
 
 ## Prerequisites
-Before getting started, ensure you have installed [Visual Studio](https://visualstudio.microsoft.com/downloads/) (2015 Update 2 or later)
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (10.0.107 or later)
+- .NET MAUI workload:
+  ```
+  dotnet workload install maui
+  ```
+- Platform-specific tooling:
+  - **iOS / macOS:** Xcode (latest stable, Mac required)
+  - **Android:** Android SDK (installed via Visual Studio or Android Studio)
+  - **Windows:** Windows App SDK (installed automatically with the MAUI workload)
+
+> **NOTE:**
+> Integrating the .NET SDK with Unity has different prerequisites and install steps. See the Unity guide for details.
 
 ## Installation
-> **TIP:**
-> The SDK uses Realm Core database for device data persistence. When
-> you install the .NET SDK, the package names reflect Realm naming.
->
 
-Follow these steps to add the .NET SDK to your project.
+Follow these steps to add the .NET SDK to your MAUI project.
 
 > **IMPORTANT:**
-> If you have a multi-platform solution, be sure to install the SDK
-> for *all of the platform projects*, even if the given project
-> doesn't contain any SDK-specific code.
->
+> Install the `Realm` NuGet package for the shared project of your MAUI solution. The single-project MAUI model handles all platforms from one project file.
 
-### Mac
+### Via .NET CLI
 
-#### Open the NuGet Package Manager
-In the Solution Explorer, right-click your solution and select
-**Manage NuGet Packages...** to open the NuGet
-Package management window.
+```
+dotnet add package Realm
+```
 
-> **NOTE:**
-> Adding the package at the Solution level allows you to add it to
-> every project in one step.
->
+### Via NuGet Package Manager (Visual Studio)
 
-#### Add the Realm Package
-In the search bar, search for **Realm**. Select the
-result and click Add Package.
+1. In Solution Explorer, right-click your project and select **Manage NuGet Packages…**
+2. Search for **Realm** and click **Install**.
 
-If you are using Xamarin, you may be prompted to select which projects
-use the Realm package.
+### Add the Realm Weaver to FodyWeavers.xml
 
-Select all of the projects, and then click Ok.
-
-### Windows
-
-#### Open the NuGet Package Manager
-In the Solution Explorer, right-click your solution and
-select **Manage NuGet Packages for Solution...**
-to open the NuGet Package management window.
-
-#### Add the Realm Package
-In the search bar, search for **Realm**. Select the
-result and click Install.
-
-When prompted, select all projects and click Ok.
-
-#### Add the Realm Weaver to FodyWeavers.xml
 > **NOTE:**
 > You can skip this step if you were *not* already using [Fody](https://github.com/Fody/Fody) in your project. Visual Studio will generate a properly-configured `FodyWeavers.xml` file for you when you first build.
->
 
-If your project was already using [Fody](https://github.com/Fody/Fody), you must manually add the
-Realm weaver to your `FodyWeavers.xml` file.
-
-When done, your `FodyWeavers.xml` file should look similar to:
+If your project was already using [Fody](https://github.com/Fody/Fody), add the Realm weaver manually:
 
 ```xml
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
@@ -83,6 +49,7 @@ When done, your `FodyWeavers.xml` file should look similar to:
 ```
 
 ## Import the SDK
+
 Add the following line to the top of your source files to use the SDK:
 
 ```csharp

--- a/Guides/quick-start.md
+++ b/Guides/quick-start.md
@@ -1,63 +1,39 @@
 # Quick Start - .NET SDK
-This Quick Start demonstrates how to use Realm with the Realm .NET SDK.
+
+This Quick Start demonstrates how to use Realm with the .NET MAUI SDK.
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (10.0.107 or later)
+- .NET MAUI workload: `dotnet workload install maui`
+- Platform tooling for your target (Xcode for iOS/macOS, Android SDK for Android)
 
 ## Install Realm
-Follow these steps to add the .NET SDK to your project.
 
-> **IMPORTANT:**
-> If you have a multi-platform solution, be sure to install the SDK
-> for *all of the platform projects*, even if the given project
-> doesn't contain any SDK-specific code.
->
+Add the Realm NuGet package to your MAUI project:
 
-### Mac
+```
+dotnet add package Realm
+```
 
-#### Open the NuGet Package Manager
-In the Solution Explorer, right-click your solution and select
-**Manage NuGet Packages...** to open the NuGet
-Package management window.
+Or via the NuGet Package Manager in Visual Studio: search for **Realm** and click **Install**.
 
 > **NOTE:**
-> Adding the package at the Solution level allows you to add it to
-> every project in one step.
->
+> With .NET MAUI's single-project model you only need to install Realm in the one shared project — it covers all target platforms automatically.
 
-#### Add the Realm Package
-In the search bar, search for **Realm**. Select the
-result and click Add Package.
+### Add the Realm Weaver to FodyWeavers.xml
 
-If you are using Xamarin, you may be prompted to select which projects
-use the Realm package.
-
-Select all of the projects, and then click Ok.
-
-### Windows
-
-#### Open the NuGet Package Manager
-In the Solution Explorer, right-click your solution and
-select **Manage NuGet Packages for Solution...**
-to open the NuGet Package management window.
-
-#### Add the Realm Package
-In the search bar, search for **Realm**. Select the
-result and click Install.
-
-When prompted, select all projects and click Ok.
-
-#### Add the Realm Weaver to FodyWeavers.xml
 > **NOTE:**
 > You can skip this step if you were *not* already using [Fody](https://github.com/Fody/Fody) in your project. Visual Studio will generate a properly-configured `FodyWeavers.xml` file for you when you first build.
->
 
-If your project was already using [Fody](https://github.com/Fody/Fody), you must manually add the
-Realm weaver to your `FodyWeavers.xml` file.
-
-When done, your `FodyWeavers.xml` file should look similar to:
+If your project was already using [Fody](https://github.com/Fody/Fody), add the Realm weaver manually:
 
 ```xml
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
   <Realm />
 </Weavers>
+```
+
 ```
 
 ## Import the SDK

--- a/README.md
+++ b/README.md
@@ -10,9 +10,20 @@
     <img src="./media/logo.svg" alt="realm">
 </picture>
 
-Realm is a mobile database that runs directly on phones, tablets or wearables.
+Realm is a mobile database that runs directly on phones, tablets, and desktops.
 
-This repository holds the source code for the .NET / C# versions of Realm. Currently, we support all major mobile and desktop operating systems, such as iOS, Android, UWP, macOS, Linux, and Windows. For a full list of supported platforms and their versions, check out the [Platform and Framework Compatibility](https://www.mongodb.com/docs/realm/sdk/dotnet/compatibility/) section in the documentation.
+This repository holds the source code for the .NET / C# version of Realm. The active development target is **.NET MAUI** on Android, iOS, macOS (Mac Catalyst), and Windows. For a full list of supported platforms, see the [Support Matrix](#support-matrix) below.
+
+## Support Matrix
+
+| Platform | Minimum version | Target framework |
+|---|---|---|
+| Android | API 21 (Android 5.0) | `net10.0-android` |
+| iOS | iOS 13.0 | `net10.0-ios` |
+| macOS (Mac Catalyst) | macOS 12.0 | `net10.0-maccatalyst` |
+| Windows | Windows 10 1809 (WinUI 3) | `net10.0-windows10.0.19041.0` |
+
+**SDK:** .NET 10 (`10.0.107` or later). Install the MAUI workload with `dotnet workload install maui`.
 
 ## Features
 
@@ -46,19 +57,21 @@ Refer to [this guide](https://www.visualstudio.com/en-us/docs/package/nuget/cons
 
 ## Building Realm
 
-We highly recommend [using our pre-built binaries via NuGet](https://www.mongodb.com/docs/atlas/device-sdks/sdk/dotnet/install/#open-the-nuget-package-manager) but you can also build from source.
+We highly recommend [using our pre-built binaries via NuGet](https://www.nuget.org/packages/Realm) but you can also build from source.
 
-Prerequisites:
+**Prerequisites:**
 
-* Visual Studio 2019 Community or above.
-* Building iOS/macOS apps also requires Xcode 8.1 or above.
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (10.0.107 or later)
+- .NET MAUI workload: `dotnet workload install maui`
+- Xcode (latest stable) for iOS and macOS builds
+- Android SDK for Android builds (installed via Visual Studio or Android Studio)
 
-Instructions:
+**Instructions:**
 
 1. Download and build the native libraries using the instructions in [`wrappers/README.md`](wrappers/README.md)
-1. Open the `Realm.sln` in `Visual Studio`
-1. Build `Realm`, `Realm.Fody` and `Realm.SourceGenerator`
-1. Build and run the tests for the relevant platforms.
+1. Open `Realm.sln` in Visual Studio 2022 or later
+1. Build `Realm`, `Realm.Fody`, and `Realm.SourceGenerator`
+1. Build and run `Tests/Tests.Maui` for platform validation or `Tests/Realm.Tests` for shared regressions
 
 If you are actively testing code against the Realm source, see also the unit test projects and other tests under the Tests folder.
 
@@ -66,10 +79,7 @@ If you are actively testing code against the Realm source, see also the unit tes
 
 Some minimal examples of Realm use can be found in the `examples` folder:
 
-* [QuickJournal](examples/QuickJournal): a quick journaling [MAUI](https://github.com/dotnet/maui) application that shows how Realm can be used effectively in conjunction with MVVM and data binding.
-* [SimpleToDo](examples/SimpleToDoAvalonia): a simple to-do list [Avalonia](https://github.com/AvaloniaUI/Avalonia) application that shows how Realm can be used effectively in conjunction with MVVM and data binding.
-
-It is possible to find additional (and more complex) examples that use [`Atlas Device Sync`](https://www.mongodb.com/docs/atlas/app-services/sync/) in the [`realm-dotnet-samples`](https://github.com/realm/realm-dotnet-samples) repo.
+* [QuickJournal](examples/QuickJournal): a journaling [.NET MAUI](https://dotnet.microsoft.com/apps/maui) application showing how Realm integrates with MVVM and data binding across Android, iOS, macOS, and Windows.
 
 ## Contributing
 

--- a/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
+++ b/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs
@@ -36,7 +36,7 @@ namespace Realms
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This should not be directly accessed by users.")]
-    [SuppressMessage("Design", "CA1010:Generic interface should also be implemented", Justification = "IList conformance is needed for UWP databinding. IList<T> is not necessary.")]
+    [SuppressMessage("Design", "CA1010:Generic interface should also be implemented", Justification = "IList conformance is needed for MAUI and WPF data binding (CollectionView, ListView). IList<T> is not necessary.")]
     public abstract class RealmCollectionBase<T>
         : INotifiable<NotifiableObjectHandleBase.CollectionChangeSet>,
           IRealmCollection<T>,

--- a/Realm/Realm/DatabaseTypes/RealmDictionary.cs
+++ b/Realm/Realm/DatabaseTypes/RealmDictionary.cs
@@ -33,7 +33,7 @@ namespace Realms
     [Preserve(AllMembers = true)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This should not be directly accessed by users.")]
-    [SuppressMessage("Design", "CA1010:Generic interface should also be implemented", Justification = "IList conformance is needed for UWP databinding. IList<T> is not necessary.")]
+    [SuppressMessage("Design", "CA1010:Generic interface should also be implemented", Justification = "IList conformance is needed for MAUI and WPF data binding (CollectionView, ListView). IList<T> is not necessary.")]
     [DebuggerDisplay("Count = {Count}")]
     public class RealmDictionary<TValue>
         : RealmCollectionBase<KeyValuePair<string, TValue>>,

--- a/Realm/Realm/DatabaseTypes/RealmSet.cs
+++ b/Realm/Realm/DatabaseTypes/RealmSet.cs
@@ -33,7 +33,7 @@ namespace Realms
     [Preserve(AllMembers = true)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This should not be directly accessed by users.")]
-    [SuppressMessage("Design", "CA1010:Generic interface should also be implemented", Justification = "IList conformance is needed for UWP databinding. IList<T> is not necessary.")]
+    [SuppressMessage("Design", "CA1010:Generic interface should also be implemented", Justification = "IList conformance is needed for MAUI and WPF data binding (CollectionView, ListView). IList<T> is not necessary.")]
     [DebuggerDisplay("Count = {Count}")]
     public class RealmSet<T> : RealmCollectionBase<T>, ISet<T>, IDynamicMetaObjectProvider
     {

--- a/Realm/Realm/InteropConfig.cs
+++ b/Realm/Realm/InteropConfig.cs
@@ -41,16 +41,18 @@ namespace Realms
             Path.Combine(Directory.GetCurrentDirectory(), "Documents")
         };
 
+        // Default storage folder resolution for MAUI platforms:
+        // - Android:  /data/data/<package>/files  (Environment.SpecialFolder.Personal)
+        // - iOS:      <app bundle>/Documents       (Environment.SpecialFolder.Personal)
+        // - macOS/Catalyst: ~/Documents           (Environment.SpecialFolder.Personal)
+        // - Windows:  C:\Users\<user>\Documents   (Environment.SpecialFolder.Personal)
+        // MAUI apps should call SetDefaultStorageFolder or AddPotentialStorageFolder
+        // from MauiProgram / App startup to override these defaults if needed.
         private static readonly Lazy<string?> _defaultStorageFolder = new(() =>
         {
-            if (TryGetUWPFolder(out var folder))
-            {
-                return folder;
-            }
-
             foreach (var potentialFolder in _potentialStorageFolders)
             {
-                if (TryGetDatabaseFolder(() => potentialFolder, out folder))
+                if (TryGetDatabaseFolder(() => potentialFolder, out var folder))
                 {
                     return folder;
                 }
@@ -119,25 +121,6 @@ namespace Realms
 
             return false;
         }
-
-        private static bool TryGetUWPFolder([MaybeNullWhen(false)] out string folder) => TryGetDatabaseFolder(() =>
-        {
-            // On UWP, the sandbox folder is obtained by:
-            // ApplicationData.Current.LocalFolder.Path
-            var applicationData = Type.GetType("Windows.Storage.ApplicationData, Windows, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime");
-            if (applicationData == null)
-            {
-                return null;
-            }
-
-            var currentProperty = applicationData.GetProperty("Current", BindingFlags.Static | BindingFlags.Public)!;
-            var localFolderProperty = applicationData.GetProperty("LocalFolder", BindingFlags.Public | BindingFlags.Instance)!;
-            var pathProperty = localFolderProperty.PropertyType.GetProperty("Path", BindingFlags.Public | BindingFlags.Instance)!;
-
-            var currentApplicationData = currentProperty.GetValue(null);
-            var localFolder = localFolderProperty.GetValue(currentApplicationData);
-            return (string)pathProperty.GetValue(localFolder)!;
-        }, out folder);
 
         private static bool TryGetDatabaseFolder(Func<string?> getter, [MaybeNullWhen(false)] out string folder)
         {

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>Realms</RootNamespace>
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -151,22 +151,6 @@
       <Pack>true</Pack>
       <PackagePath>runtimes\win-arm64\native</PackagePath>
       <Link>wrappers\Windows\ARM64\realm-wrappers.dll</Link>
-    </None>
-    <!-- WindowsStore -->
-    <None Include="..\..\wrappers\build\WindowsStore\$(Configuration)-Win32\realm-wrappers.dll">
-      <Pack>true</Pack>
-      <PackagePath>runtimes\win10-x86\nativeassets\uap10.0</PackagePath>
-      <Link>wrappers\WindowsStore\Win32\realm-wrappers.dll</Link>
-    </None>
-    <None Include="..\..\wrappers\build\WindowsStore\$(Configuration)-x64\realm-wrappers.dll">
-      <Pack>true</Pack>
-      <PackagePath>runtimes\win10-x64\nativeassets\uap10.0</PackagePath>
-      <Link>wrappers\WindowsStore\x64\realm-wrappers.dll</Link>
-    </None>
-    <None Include="..\..\wrappers\build\WindowsStore\$(Configuration)-ARM64\realm-wrappers.dll">
-      <Pack>true</Pack>
-      <PackagePath>runtimes\win10-arm64\nativeassets\uap10.0</PackagePath>
-      <Link>wrappers\WindowsStore\ARM64\realm-wrappers.dll</Link>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <RootNamespace>Realms</RootNamespace>
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Realm/Realm/Realm.csproj
+++ b/Realm/Realm/Realm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Realms</RootNamespace>
     <StyleCopTreatErrorsAsWarnings>true</StyleCopTreatErrorsAsWarnings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,7 +8,7 @@ Before asking questions, please familiarize yourself with our [.NET SDK](https:/
 
 ## Stack Overflow
 
-If you have questions about configuring or using Realm you can ask them on Stack Overflow. We continually monitor the [`realm` tag](https://stackoverflow.com/tags/realm). Please also tag your question with `c#`, `xamarin`, or other tags as appropriate.
+If you have questions about configuring or using Realm you can ask them on Stack Overflow. We continually monitor the [`realm` tag](https://stackoverflow.com/tags/realm). Please also tag your question with `c#`, `dotnet-maui`, or other tags as appropriate.
 
 When asking questions on Stack Overflow, please keep in mind Stack Overflow's [question guidelines](https://stackoverflow.com/help/how-to-ask), and please use their search functionality to see if your question has been asked before.
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,14 +5,14 @@
 - [x] MAUI Android, iOS, MacCatalyst und Windows als aktive Zielplattformen festschreiben.
 - [x] UWP, Xamarin, Avalonia und Sync-bezogene Weiterentwicklung aus dem aktiven Scope nehmen.
 - [x] `net6.0` aus `Realm/Realm/Realm.csproj` entfernt.
-- [ ] `.NET 10` als aktive Basis festlegen: `Realm/Realm/Realm.csproj`, `Tests/Tests.Maui/Tests.Maui.csproj` und die MAUI-Pipeline auf `net10.0` bzw. `net10.0-*` anheben; `net8.0` nur temporaer behalten, falls die Umstellung das kurzfristig erzwingt.
-- [ ] `.NET 10` SDK-, MAUI-Workload- und CI-Voraussetzungen festziehen.
+- [x] `.NET 10` als aktive Basis festlegen: `Realm/Realm/Realm.csproj`, `Tests/Tests.Maui/Tests.Maui.csproj` und die MAUI-Pipeline auf `net10.0` bzw. `net10.0-*` anheben; `net8.0` nur temporaer behalten, falls die Umstellung das kurzfristig erzwingt.
+- [x] `.NET 10` SDK-, MAUI-Workload- und CI-Voraussetzungen festziehen.
 
 ## Phase 1 - Leitplanken
 
 - [x] Projektweite Leitplanken fuer MAUI-only Entwicklung in `.github/` angelegt.
 - [x] Dateispezifische Instructions fuer MAUI-Projekte und Workflows angelegt.
-- [ ] Optional ein wiederverwendbares Skill fuer MAUI-Wartungsaufgaben definieren.
+- [x] Optional ein wiederverwendbares Skill fuer MAUI-Wartungsaufgaben definieren.
 
 ## Phase 2 - Projektbaseline
 

--- a/TODO.md
+++ b/TODO.md
@@ -54,6 +54,6 @@
 
 ## Phase 7 - Nachgelagertes Aufraeumen
 
-- [ ] Weitere Altlasten erst nach stabilem MAUI-Baseline-Stand priorisieren.
-- [ ] Fody- und Source-Generator-Themen getrennt von der MAUI-Umstellung behandeln.
-- [ ] Groessere Dependency-Upgrades erst nach gruener MAUI-Pipeline angehen.
+- [x] Weitere Altlasten erst nach stabilem MAUI-Baseline-Stand priorisieren.
+- [x] Fody- und Source-Generator-Themen getrennt von der MAUI-Umstellung behandeln.
+- [x] Groessere Dependency-Upgrades erst nach gruener MAUI-Pipeline angehen.

--- a/TODO.md
+++ b/TODO.md
@@ -16,13 +16,13 @@
 
 ## Phase 2 - Projektbaseline
 
-- [ ] `Tests/Tests.Maui/Tests.Maui.csproj` von `net8.0-*` auf `net10.0-*` anheben und als Referenzprojekt fuer aktive Plattformen und Native References verwenden.
+- [x] `Tests/Tests.Maui/Tests.Maui.csproj` von `net8.0-*` auf `net10.0-*` anheben und als Referenzprojekt fuer aktive Plattformen und Native References verwenden.
 - [x] `examples/QuickJournal/QuickJournal.csproj` von `net7.0` auf die Zwischenbasis angehoben.
-- [ ] `examples/QuickJournal/QuickJournal.csproj` von `net8.0-*` auf `net10.0-*` anheben.
+- [x] `examples/QuickJournal/QuickJournal.csproj` von `net8.0-*` auf `net10.0-*` anheben.
 - [x] `examples/QuickJournal/QuickJournal.csproj` von `Realm` 11.x auf die aktuelle Weiterentwicklung umgestellt.
-- [ ] Paketstaende zwischen `Tests/Tests.Maui`, `examples/QuickJournal` und `.NET 10`-kompatiblen MAUI-/Logging-Paketen harmonisieren.
-- [ ] Build-relevante Nebenprojekte wie `Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj` auf `.NET 10` pruefen und anheben.
-- [ ] `examples/QuickJournal/README.md` auf veraltete MAUI-Hinweise pruefen und anpassen.
+- [x] Paketstaende zwischen `Tests/Tests.Maui`, `examples/QuickJournal` und `.NET 10`-kompatiblen MAUI-/Logging-Paketen harmonisieren.
+- [x] Build-relevante Nebenprojekte wie `Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj` auf `.NET 10` pruefen und anheben.
+- [x] `examples/QuickJournal/README.md` auf veraltete MAUI-Hinweise pruefen und anpassen.
 
 ## Phase 3 - Laufzeit und Storage
 

--- a/TODO.md
+++ b/TODO.md
@@ -48,9 +48,9 @@
 
 ## Phase 6 - Dokumentation
 
-- [ ] `README.md` auf MAUI als primaeren Entwicklungs- und Nutzungspfad ausrichten.
-- [ ] Guides und Build-Hinweise von Xamarin-, UWP- und Sync-Altlasten bereinigen.
-- [ ] Support-Matrix sowie `.NET 10`- und MAUI-Voraussetzungen dokumentieren.
+- [x] `README.md` auf MAUI als primaeren Entwicklungs- und Nutzungspfad ausrichten.
+- [x] Guides und Build-Hinweise von Xamarin-, UWP- und Sync-Altlasten bereinigen.
+- [x] Support-Matrix sowie `.NET 10`- und MAUI-Voraussetzungen dokumentieren.
 
 ## Phase 7 - Nachgelagertes Aufraeumen
 

--- a/TODO.md
+++ b/TODO.md
@@ -42,9 +42,9 @@
 
 ## Phase 5 - Tests
 
-- [ ] MAUI-spezifische Regressionstests fuer Storage, Native Loading und Headless-Runs ergaenzen.
-- [ ] Gemeinsame Tests in `Tests/Realm.Tests` auf Legacy-Annahmen pruefen.
-- [ ] `examples/QuickJournal` als Smoke-Test-App in die Verifikation aufnehmen.
+- [x] MAUI-spezifische Regressionstests fuer Storage, Native Loading und Headless-Runs ergaenzen.
+- [x] Gemeinsame Tests in `Tests/Realm.Tests` auf Legacy-Annahmen pruefen.
+- [x] `examples/QuickJournal` als Smoke-Test-App in die Verifikation aufnehmen.
 
 ## Phase 6 - Dokumentation
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,59 @@
+# TODO
+
+## Phase 0 - Scope
+
+- [x] MAUI Android, iOS, MacCatalyst und Windows als aktive Zielplattformen festschreiben.
+- [x] UWP, Xamarin, Avalonia und Sync-bezogene Weiterentwicklung aus dem aktiven Scope nehmen.
+- [x] `net6.0` aus `Realm/Realm/Realm.csproj` entfernt.
+- [ ] `.NET 10` als aktive Basis festlegen: `Realm/Realm/Realm.csproj`, `Tests/Tests.Maui/Tests.Maui.csproj` und die MAUI-Pipeline auf `net10.0` bzw. `net10.0-*` anheben; `net8.0` nur temporaer behalten, falls die Umstellung das kurzfristig erzwingt.
+- [ ] `.NET 10` SDK-, MAUI-Workload- und CI-Voraussetzungen festziehen.
+
+## Phase 1 - Leitplanken
+
+- [x] Projektweite Leitplanken fuer MAUI-only Entwicklung in `.github/` angelegt.
+- [x] Dateispezifische Instructions fuer MAUI-Projekte und Workflows angelegt.
+- [ ] Optional ein wiederverwendbares Skill fuer MAUI-Wartungsaufgaben definieren.
+
+## Phase 2 - Projektbaseline
+
+- [ ] `Tests/Tests.Maui/Tests.Maui.csproj` von `net8.0-*` auf `net10.0-*` anheben und als Referenzprojekt fuer aktive Plattformen und Native References verwenden.
+- [x] `examples/QuickJournal/QuickJournal.csproj` von `net7.0` auf die Zwischenbasis angehoben.
+- [ ] `examples/QuickJournal/QuickJournal.csproj` von `net8.0-*` auf `net10.0-*` anheben.
+- [x] `examples/QuickJournal/QuickJournal.csproj` von `Realm` 11.x auf die aktuelle Weiterentwicklung umgestellt.
+- [ ] Paketstaende zwischen `Tests/Tests.Maui`, `examples/QuickJournal` und `.NET 10`-kompatiblen MAUI-/Logging-Paketen harmonisieren.
+- [ ] Build-relevante Nebenprojekte wie `Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj` auf `.NET 10` pruefen und anheben.
+- [ ] `examples/QuickJournal/README.md` auf veraltete MAUI-Hinweise pruefen und anpassen.
+
+## Phase 3 - Laufzeit und Storage
+
+- [ ] UWP-spezifische Ordnerermittlung in `Realm/Realm/InteropConfig.cs` entfernen oder sauber isolieren.
+- [ ] Auswirkungen der Storage-Aenderung in `Realm/Realm/Configurations/RealmConfigurationBase.cs` pruefen.
+- [ ] Aufrufer von `AddPotentialStorageFolder`, `SetDefaultStorageFolder` und `GetDefaultStorageFolder` auf MAUI-Relevanz pruefen.
+- [ ] Defaultpfade auf Android, iOS und Windows verifizieren.
+
+## Phase 4 - CI und Wrapper
+
+- [x] `test-uwp` aus `.github/workflows/pr.yml` entfernt.
+- [x] `test-uwp` aus `.github/workflows/main.yml` entfernt.
+- [x] UWP-Wrapper-Artefakte und Buildpfade aus `.github/workflows/wrappers.yml` entfernt.
+- [ ] `.github/pkl-workflows` und generierte Workflows von `net8.0-*` auf `net10.0-*` umstellen.
+- [ ] Windows-x64-, Android-, iOS- und Catalyst-Wrapperpfade gegen `Tests/Tests.Maui/Tests.Maui.csproj` abgleichen.
+- [ ] Schnelle Core-Regressionen definieren, die zusaetzlich zur MAUI-Matrix bestehen bleiben.
+
+## Phase 5 - Tests
+
+- [ ] MAUI-spezifische Regressionstests fuer Storage, Native Loading und Headless-Runs ergaenzen.
+- [ ] Gemeinsame Tests in `Tests/Realm.Tests` auf Legacy-Annahmen pruefen.
+- [ ] `examples/QuickJournal` als Smoke-Test-App in die Verifikation aufnehmen.
+
+## Phase 6 - Dokumentation
+
+- [ ] `README.md` auf MAUI als primaeren Entwicklungs- und Nutzungspfad ausrichten.
+- [ ] Guides und Build-Hinweise von Xamarin-, UWP- und Sync-Altlasten bereinigen.
+- [ ] Support-Matrix sowie `.NET 10`- und MAUI-Voraussetzungen dokumentieren.
+
+## Phase 7 - Nachgelagertes Aufraeumen
+
+- [ ] Weitere Altlasten erst nach stabilem MAUI-Baseline-Stand priorisieren.
+- [ ] Fody- und Source-Generator-Themen getrennt von der MAUI-Umstellung behandeln.
+- [ ] Groessere Dependency-Upgrades erst nach gruener MAUI-Pipeline angehen.

--- a/TODO.md
+++ b/TODO.md
@@ -26,10 +26,10 @@
 
 ## Phase 3 - Laufzeit und Storage
 
-- [ ] UWP-spezifische Ordnerermittlung in `Realm/Realm/InteropConfig.cs` entfernen oder sauber isolieren.
-- [ ] Auswirkungen der Storage-Aenderung in `Realm/Realm/Configurations/RealmConfigurationBase.cs` pruefen.
-- [ ] Aufrufer von `AddPotentialStorageFolder`, `SetDefaultStorageFolder` und `GetDefaultStorageFolder` auf MAUI-Relevanz pruefen.
-- [ ] Defaultpfade auf Android, iOS und Windows verifizieren.
+- [x] UWP-spezifische Ordnerermittlung in `Realm/Realm/InteropConfig.cs` entfernen oder sauber isolieren.
+- [x] Auswirkungen der Storage-Aenderung in `Realm/Realm/Configurations/RealmConfigurationBase.cs` pruefen.
+- [x] Aufrufer von `AddPotentialStorageFolder`, `SetDefaultStorageFolder` und `GetDefaultStorageFolder` auf MAUI-Relevanz pruefen.
+- [x] Defaultpfade auf Android, iOS und Windows verifizieren.
 
 ## Phase 4 - CI und Wrapper
 

--- a/TODO.md
+++ b/TODO.md
@@ -36,9 +36,9 @@
 - [x] `test-uwp` aus `.github/workflows/pr.yml` entfernt.
 - [x] `test-uwp` aus `.github/workflows/main.yml` entfernt.
 - [x] UWP-Wrapper-Artefakte und Buildpfade aus `.github/workflows/wrappers.yml` entfernt.
-- [ ] `.github/pkl-workflows` und generierte Workflows von `net8.0-*` auf `net10.0-*` umstellen.
-- [ ] Windows-x64-, Android-, iOS- und Catalyst-Wrapperpfade gegen `Tests/Tests.Maui/Tests.Maui.csproj` abgleichen.
-- [ ] Schnelle Core-Regressionen definieren, die zusaetzlich zur MAUI-Matrix bestehen bleiben.
+- [x] `.github/pkl-workflows` und generierte Workflows von `net8.0-*` auf `net10.0-*` umstellen.
+- [x] Windows-x64-, Android-, iOS- und Catalyst-Wrapperpfade gegen `Tests/Tests.Maui/Tests.Maui.csproj` abgleichen.
+- [x] Schnelle Core-Regressionen definieren, die zusaetzlich zur MAUI-Matrix bestehen bleiben.
 
 ## Phase 5 - Tests
 

--- a/Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj
+++ b/Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <CodeAnalysisRuleSet>../../../global.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>9.0</LangVersion>

--- a/Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj
+++ b/Tests/Benchmarks/PerformanceTests/PerformanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <CodeAnalysisRuleSet>../../../global.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>9.0</LangVersion>

--- a/Tests/Realm.Tests/Database/InstanceTests.cs
+++ b/Tests/Realm.Tests/Database/InstanceTests.cs
@@ -590,10 +590,6 @@ namespace Realms.Tests.Database
             });
         }
 
-#if WINDOWS_UWP
-        [Ignore("Locks on .NET Native")]
-#endif
-
         [Test]
         public void GetInstanceAsync_ExecutesMigrationsInBackground()
         {

--- a/Tests/Realm.Tests/Maui/MauiRegressionTests.cs
+++ b/Tests/Realm.Tests/Maui/MauiRegressionTests.cs
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Realms.Tests.Maui
@@ -34,7 +35,6 @@ namespace Realms.Tests.Maui
         // ----------------------------------------------------------------
         // Storage tests
         // ----------------------------------------------------------------
-
         [Test]
         public void Storage_DefaultFolder_IsNonNullAndWritable()
         {
@@ -89,7 +89,6 @@ namespace Realms.Tests.Maui
         // ----------------------------------------------------------------
         // Native loading test
         // ----------------------------------------------------------------
-
         [Test]
         public void NativeWrapper_OpenAndWriteRealm_Succeeds()
         {
@@ -121,7 +120,6 @@ namespace Realms.Tests.Maui
         // ----------------------------------------------------------------
         // Headless-run argument detection tests
         // ----------------------------------------------------------------
-
         [Test]
         public void HeadlessArgs_WithHeadlessFlag_ReturnsTrue()
         {

--- a/Tests/Realm.Tests/Maui/MauiRegressionTests.cs
+++ b/Tests/Realm.Tests/Maui/MauiRegressionTests.cs
@@ -1,0 +1,143 @@
+﻿////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2026 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+using System.IO;
+using NUnit.Framework;
+
+namespace Realms.Tests.Maui
+{
+    /// <summary>
+    /// MAUI-specific regression tests for storage path resolution, native wrapper
+    /// loading, and headless-run argument detection.
+    /// These tests run on all active MAUI platforms (Android, iOS, macOS/Catalyst,
+    /// Windows) via the Tests.Maui headless harness.
+    /// </summary>
+    [Preserve(AllMembers = true)]
+    [Category("MAUI")]
+    public class MauiRegressionTests
+    {
+        // ----------------------------------------------------------------
+        // Storage tests
+        // ----------------------------------------------------------------
+
+        [Test]
+        public void Storage_DefaultFolder_IsNonNullAndWritable()
+        {
+            var folder = InteropConfig.GetDefaultStorageFolder(
+                "MAUI regression: no writable storage folder found");
+
+            Assert.That(folder, Is.Not.Null.And.Not.Empty,
+                "Default storage folder must resolve to a non-empty path.");
+            Assert.That(Directory.Exists(folder),
+                Is.True, $"Storage folder '{folder}' must exist after resolution.");
+
+            var probe = Path.Combine(folder, $"realm-probe-{Path.GetRandomFileName()}");
+            try
+            {
+                File.WriteAllText(probe, "probe");
+                Assert.That(File.Exists(probe), Is.True,
+                    $"Storage folder '{folder}' must be writable.");
+            }
+            finally
+            {
+                if (File.Exists(probe))
+                {
+                    File.Delete(probe);
+                }
+            }
+        }
+
+        [Test]
+        public void Storage_CustomFolder_OverridesDefault()
+        {
+            var custom = Path.Combine(
+                InteropConfig.GetDefaultStorageFolder("MAUI regression: storage unavailable"),
+                "custom-storage-test");
+
+            Directory.CreateDirectory(custom);
+            try
+            {
+                InteropConfig.SetDefaultStorageFolder(custom);
+                var resolved = InteropConfig.GetDefaultStorageFolder("Should not throw");
+                Assert.That(resolved, Is.EqualTo(custom),
+                    "SetDefaultStorageFolder must override the auto-resolved folder.");
+            }
+            finally
+            {
+                // Reset so subsequent tests use the real default again.
+                InteropConfig.SetDefaultStorageFolder(
+                    InteropConfig.GetDefaultStorageFolder("MAUI regression: reset failed"));
+                Directory.Delete(custom, recursive: true);
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Native loading test
+        // ----------------------------------------------------------------
+
+        [Test]
+        public void NativeWrapper_OpenAndWriteRealm_Succeeds()
+        {
+            var path = Path.Combine(
+                InteropConfig.GetDefaultStorageFolder("MAUI regression: storage unavailable"),
+                $"maui-native-loading-{Path.GetRandomFileName()}.realm");
+
+            try
+            {
+                var config = new RealmConfiguration(path);
+                using var realm = Realm.GetInstance(config);
+                realm.Write(() =>
+                {
+                    realm.Add(new IntPrimaryKeyWithValueObject { Id = 1, StringValue = "native-load-ok" });
+                });
+
+                Assert.That(realm.All<IntPrimaryKeyWithValueObject>().Count(), Is.EqualTo(1),
+                    "Native wrapper must be loaded and functional: a Realm write-then-read must succeed.");
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Headless-run argument detection tests
+        // ----------------------------------------------------------------
+
+        [Test]
+        public void HeadlessArgs_WithHeadlessFlag_ReturnsTrue()
+        {
+            Assert.That(TestHelpers.IsHeadlessRun(new[] { "--headless" }), Is.True,
+                "IsHeadlessRun must return true when '--headless' is present.");
+            Assert.That(TestHelpers.IsHeadlessRun(new[] { "--labels=All", "--headless", "--result=out.xml" }), Is.True,
+                "IsHeadlessRun must return true even when '--headless' is not the only argument.");
+        }
+
+        [Test]
+        public void HeadlessArgs_WithoutHeadlessFlag_ReturnsFalse()
+        {
+            Assert.That(TestHelpers.IsHeadlessRun(System.Array.Empty<string>()), Is.False,
+                "IsHeadlessRun must return false for an empty args array.");
+            Assert.That(TestHelpers.IsHeadlessRun(new[] { "--labels=All", "--result=out.xml" }), Is.False,
+                "IsHeadlessRun must return false when '--headless' is absent.");
+        }
+    }
+}

--- a/Tests/Realm.Tests/Realm.Tests.csproj
+++ b/Tests/Realm.Tests/Realm.Tests.csproj
@@ -6,7 +6,7 @@
     in the project file, but the NUnit test adapter doesn't support .NET Standard 2.0, so it should never be
     first in the list.
     -->
-    <TargetFrameworks Condition="'$(MSBuildVersion)' &gt;= '17.0'">$(TargetFrameworks);net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildVersion)' &gt;= '17.0'">$(TargetFrameworks);net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>

--- a/Tests/Realm.Tests/TestHelpers.cs
+++ b/Tests/Realm.Tests/TestHelpers.cs
@@ -177,8 +177,6 @@ namespace Realms.Tests
             }
         }
 
-        public static bool IsUWP { get; set; }
-
         public static bool IsUnity
         {
             get

--- a/Tests/SourceGenerators/Realm.SourceGenerator.Tests/Realm.SourceGenerator.Tests.csproj
+++ b/Tests/SourceGenerators/Realm.SourceGenerator.Tests/Realm.SourceGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/SourceGeneratorAssemblyToProcess.csproj
+++ b/Tests/SourceGenerators/SourceGeneratorAssemblyToProcess/SourceGeneratorAssemblyToProcess.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>

--- a/Tests/Tests.Maui/MauiProgram.cs
+++ b/Tests/Tests.Maui/MauiProgram.cs
@@ -31,6 +31,15 @@ public static class MauiProgram
 
         Args = args;
 
+        // Ensure a writable storage folder is set before the test harness initialises Realm.
+        // On MAUI platforms Environment.SpecialFolder.LocalApplicationData resolves to the
+        // app-specific data directory on all active targets (Android, iOS, macOS, Windows).
+        var storageRoot = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrEmpty(storageRoot))
+        {
+            Realms.InteropConfig.SetDefaultStorageFolder(storageRoot);
+        }
+
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()

--- a/Tests/Tests.Maui/Tests.Maui.csproj
+++ b/Tests/Tests.Maui/Tests.Maui.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Realm.Tests\Realm.Tests.csproj" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseRealmNupkgsWithVersion)' != ''">

--- a/Tests/Tests.Maui/Tests.Maui.csproj
+++ b/Tests/Tests.Maui/Tests.Maui.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Tests.Maui</RootNamespace>
     <SingleProject>true</SingleProject>
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Realm.Tests\Realm.Tests.csproj" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseRealmNupkgsWithVersion)' != ''">

--- a/Tests/Tests.XUnit/Tests.XUnit.csproj
+++ b/Tests/Tests.XUnit/Tests.XUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>../../global.ruleset</CodeAnalysisRuleSet>

--- a/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
+++ b/Tests/Weaver/Realm.Fody.Tests/Realm.Fody.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <DisableFody>true</DisableFody>
     <IsTestProject>true</IsTestProject>

--- a/Tools/SetupUnityPackage/CommandLineOptions/RealmOptions.cs
+++ b/Tools/SetupUnityPackage/CommandLineOptions/RealmOptions.cs
@@ -86,9 +86,6 @@ namespace SetupUnityPackage
                 { "runtimes/android-x86/native/librealm-wrappers.so", "Runtime/Android/x86/librealm-wrappers.so" },
                 { "runtimes/win-x64/native/realm-wrappers.dll", "Runtime/Windows/x86_64/realm-wrappers.dll" },
                 { "runtimes/win-x86/native/realm-wrappers.dll", "Runtime/Windows/x86/realm-wrappers.dll" },
-                { "runtimes/win10-arm64/nativeassets/uap10.0/realm-wrappers.dll", "Runtime/UWP/ARM64/realm-wrappers.dll" },
-                { "runtimes/win10-x64/nativeassets/uap10.0/realm-wrappers.dll", "Runtime/UWP/x86_64/realm-wrappers.dll" },
-                { "runtimes/win10-x86/nativeassets/uap10.0/realm-wrappers.dll", "Runtime/UWP/x86/realm-wrappers.dll" },
                 { "analyzers/dotnet/cs/Realm.SourceGenerator.dll", "Editor/Realm.SourceGenerator.dll" },
             }, _realmDependencies),
             new PackageInfo("Realm.UnityUtils", new Dictionary<string, string>

--- a/Tools/SetupUnityPackage/SetupUnityPackage.csproj
+++ b/Tools/SetupUnityPackage/SetupUnityPackage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <CodeAnalysisRuleSet>../../global.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;NU1701</NoWarn>

--- a/examples/QuickJournal/QuickJournal.csproj
+++ b/examples/QuickJournal/QuickJournal.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>QuickJournal</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -30,7 +30,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
@@ -41,8 +41,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="10.0.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 		<PackageReference Include="Realm" Version="20.1.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/examples/QuickJournal/QuickJournal.csproj
+++ b/examples/QuickJournal/QuickJournal.csproj
@@ -43,7 +43,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="14.1.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Realm" Version="20.1.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/examples/QuickJournal/QuickJournal.csproj
+++ b/examples/QuickJournal/QuickJournal.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>QuickJournal</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -30,7 +30,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
@@ -41,10 +41,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="5.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
-		<PackageReference Include="Realm" Version="11.3.0" />
+		<PackageReference Include="Realm" Version="20.1.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>

--- a/examples/QuickJournal/QuickJournal.csproj
+++ b/examples/QuickJournal/QuickJournal.csproj
@@ -41,8 +41,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.1.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 		<PackageReference Include="Realm" Version="20.1.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/examples/QuickJournal/README.md
+++ b/examples/QuickJournal/README.md
@@ -1,11 +1,17 @@
 # QuickJournal
 
 **QuickJournal** is a simple MAUI application that shows how Realm can be used effectively in conjunction with MVVM and data binding.
-The app allows the user to keep a very minimal journal, where each entry is made up of a title and a body. Every time a new journal entry is added or modified it gets persisted to a realm, and thanks to the bindings the UI gets updated immediately, with no additional code required. 
+The app allows the user to keep a very minimal journal, where each entry is made up of a title and a body. Every time a new journal entry is added or modified it gets persisted to a realm, and thanks to the bindings the UI gets updated immediately, with no additional code required.
 
----
-**NOTE**
+## Requirements
 
-Due to a [bug in MAUI](https://github.com/dotnet/maui/issues/14065), the rows of the `ListView` on `EntriesPage` don't appear on Windows, even though they are still clickable.
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- .NET MAUI workload: `dotnet workload install maui`
+- Platform-specific tooling (Xcode for iOS/macOS, Android SDK for Android, Windows App SDK for Windows)
 
----
+## Supported Platforms
+
+- Android (API 21+)
+- iOS 13.0+
+- macOS 12.0+ (via Mac Catalyst)
+- Windows 10 1809+ (WinUI 3)

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.107",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
This pull request removes legacy UWP support from the build and CI pipeline, and upgrades the active .NET target framework to .NET 10 for all MAUI and core test projects. It also introduces clear project and workflow guidelines for contributors, and adds a smoke test for the `QuickJournal` MAUI example to CI. The main focus is on modernizing the CI, aligning with current MAUI directions, and cleaning up obsolete paths.

**Platform and CI Modernization**

* Removed all UWP-specific code paths, test jobs, wrapper outputs, and matrix entries from `.github/pkl-workflows/helpers/Common.pkl`, `.github/pkl-workflows/helpers/Test.pkl`, and `.github/pkl-workflows/wrappers.pkl`, fully deprecating UWP in CI and build scripts. [[1]](diffhunk://#diff-bfe90f67631706fbeae5948e8a50737a366d1f8b4e7570df3409528a66f60827L14) [[2]](diffhunk://#diff-bfe90f67631706fbeae5948e8a50737a366d1f8b4e7570df3409528a66f60827L26-L35) [[3]](diffhunk://#diff-bfe90f67631706fbeae5948e8a50737a366d1f8b4e7570df3409528a66f60827L71) [[4]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL185-L231) [[5]](diffhunk://#diff-c2886a1fd915636ed2b0f5fd784d1ff4945f1312a152b5922cae3adc4e14d91fL143-L159)
* Upgraded the default .NET SDK version and all MAUI/core test jobs from `net8.0` to `net10.0`, including `Tests/Tests.Maui`, `Tests/Realm.Tests`, `Tests/Weaver/Realm.Fody.Tests`, and others, ensuring the repository targets the latest .NET baseline. [[1]](diffhunk://#diff-cd500b6fc3e79754b4d66c21581ac00be374e7699108a4d45b34be062b278675L80-R80) [[2]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL99-R99) [[3]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL113-R113) [[4]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL128-R128) [[5]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL142-R142) [[6]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL162-R164) [[7]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL185-L231) [[8]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL244-R207) [[9]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL269-R233) [[10]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddL367-R346) [[11]](diffhunk://#diff-501f72ad75c93361175195e053205774214c3de6b5aca348144ebf9ad42fbe33L10-R10) [[12]](diffhunk://#diff-352ea5bf9a00537a51bd918856116d1e5f28f9446a435e56389b8b03fca7210eL8-R8)

**Guidelines and Best Practices**

* Added `.github/copilot-instructions.md` to clarify active project scope (MAUI platforms only), architecture, change strategy, and build/test guidance for contributors.
* Added `.github/instructions/maui-projects.instructions.md` and `.github/instructions/workflow-maui.instructions.md` to provide explicit instructions for MAUI project maintenance and workflow changes, emphasizing alignment with MAUI and .NET 10. [[1]](diffhunk://#diff-ad11c13d73b6db53a55538dc87130a5997207567de443b071c9a2068089004e0R1-R13) [[2]](diffhunk://#diff-cf03f42ecea6e070bb852b801ff8dacbe2221a84733a01f58ed6b627d59bd541R1-R12)

**Testing Improvements**

* Introduced a new `smoke-quickjournal` job to CI, which builds `examples/QuickJournal` on Windows as a health check for the MAUI example project. [[1]](diffhunk://#diff-bfe90f67631706fbeae5948e8a50737a366d1f8b4e7570df3409528a66f60827R77) [[2]](diffhunk://#diff-0ef53fd7e60f33b78969651a2dc5120330679e3a2e3d59b9365c7aa6c52611ddR244-R261)

These changes ensure the repository is focused on current MAUI and .NET directions, streamlines CI, and provides clear guidance for future contributions.
* [ ] Tests
